### PR TITLE
fix: correct settings page UX — permission labels, validation, descriptions

### DIFF
--- a/api/routers/settings.py
+++ b/api/routers/settings.py
@@ -1,7 +1,8 @@
 import json
 import logging
+from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, Field
@@ -28,11 +29,42 @@ def _write_settings_sync(settings_path: Path, data: dict) -> None:
         json.dump(data, f, indent=2)
 
 
+class PermissionModeEnum(str, Enum):
+    default = "default"
+    acceptEdits = "acceptEdits"
+    plan = "plan"
+    bypassPermissions = "bypassPermissions"
+    dontAsk = "dontAsk"
+
+
+class PermissionsUpdate(BaseModel):
+    allow: Optional[List[str]] = None
+    deny: Optional[List[str]] = None
+    defaultMode: Optional[PermissionModeEnum] = None
+
+    model_config = {"extra": "allow"}
+
+
+class StatusLineUpdate(BaseModel):
+    type: Optional[str] = Field(None, pattern=r"^(command|disabled)$")
+    command: Optional[str] = None
+    padding: Optional[int] = Field(None, ge=0)
+
+    model_config = {"extra": "allow"}
+
+
 class ClaudeSettingsUpdate(BaseModel):
     cleanupPeriodDays: Optional[int] = Field(
         None,
         description="Days to keep sessions before cleanup. Default is 30. Set to 99999 to disable.",
+        ge=1,
     )
+    permissions: Optional[PermissionsUpdate] = None
+    statusLine: Optional[StatusLineUpdate] = None
+    enabledPlugins: Optional[Dict[str, bool]] = None
+    alwaysThinkingEnabled: Optional[bool] = None
+    env: Optional[Dict[str, str]] = None
+    model: Optional[str] = None
 
     model_config = {"extra": "allow"}
 

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -421,17 +421,18 @@ export type PermissionMode =
 	| 'acceptEdits'
 	| 'plan'
 	| 'bypassPermissions'
-	| 'delegate'
 	| 'dontAsk';
 
 export interface PermissionsConfig {
 	allow?: string[];
+	deny?: string[];
 	defaultMode?: PermissionMode;
 }
 
 export interface StatusLineConfig {
-	type: 'command';
-	command: string;
+	type: 'command' | 'disabled';
+	command?: string;
+	padding?: number;
 }
 
 export interface ClaudeSettings {
@@ -440,7 +441,39 @@ export interface ClaudeSettings {
 	enabledPlugins?: Record<string, boolean>;
 	alwaysThinkingEnabled?: boolean;
 	cleanupPeriodDays?: number;
+	env?: Record<string, string>;
+	model?: string;
+	hooks?: Record<string, unknown>;
 }
+
+// Permission mode options with labels and descriptions for the settings UI
+export const PERMISSION_MODE_OPTIONS = [
+	{
+		label: 'Default',
+		value: 'default' as PermissionMode,
+		description: 'Prompts for permission on first use of each tool'
+	},
+	{
+		label: 'Auto-accept Edits',
+		value: 'acceptEdits' as PermissionMode,
+		description: 'Auto-approves file edits; other tools still prompt'
+	},
+	{
+		label: 'Plan Mode',
+		value: 'plan' as PermissionMode,
+		description: 'Read-only — Claude can analyze but not modify files or run commands'
+	},
+	{
+		label: 'Pre-approved Only',
+		value: 'dontAsk' as PermissionMode,
+		description: 'Auto-denies tools unless explicitly allowed in the list below'
+	},
+	{
+		label: 'Bypass All',
+		value: 'bypassPermissions' as PermissionMode,
+		description: 'Skips all permission checks. Only use in isolated environments'
+	}
+] as const;
 
 // Retention period options for the settings UI
 export const RETENTION_OPTIONS = [

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -4,14 +4,13 @@
 	import { onMount } from 'svelte';
 	import Switch from '$lib/components/ui/Switch.svelte';
 	import SelectDropdown from '$lib/components/ui/SelectDropdown.svelte';
-	import SegmentedControl from '$lib/components/ui/SegmentedControl.svelte';
 	import TextInput from '$lib/components/ui/TextInput.svelte';
 	import SettingsSection from '$lib/components/settings/SettingsSection.svelte';
 	import SettingItem from '$lib/components/settings/SettingItem.svelte';
 	import PermissionsList from '$lib/components/settings/PermissionsList.svelte';
 	import PageHeader from '$lib/components/layout/PageHeader.svelte';
 	import type { ClaudeSettings, PermissionMode } from '$lib/api-types';
-	import { RETENTION_OPTIONS } from '$lib/api-types';
+	import { RETENTION_OPTIONS, PERMISSION_MODE_OPTIONS } from '$lib/api-types';
 	import { API_BASE } from '$lib/config';
 
 	// State
@@ -28,6 +27,9 @@
 	let permissions = $derived(settings.permissions?.allow ?? []);
 	let plugins = $derived(Object.entries(settings.enabledPlugins ?? {}));
 	let statusLineCommand = $derived(settings.statusLine?.command ?? '');
+	let activePermissionDescription = $derived(
+		PERMISSION_MODE_OPTIONS.find((o) => o.value === permissionMode)?.description ?? ''
+	);
 
 	// Load settings on mount
 	onMount(async () => {
@@ -156,7 +158,7 @@
 			<SettingsSection title="General">
 				<SettingItem
 					title="Session Retention"
-					description="How long to keep session history before automatic cleanup."
+					description="Sessions inactive longer than this period are deleted when Claude Code starts. This removes JSONL transcripts from ~/.claude/projects/."
 					saving={savingField === 'cleanupPeriodDays'}
 					success={successField === 'cleanupPeriodDays' ? 'Saved' : null}
 				>
@@ -175,7 +177,7 @@
 
 				<SettingItem
 					title="Extended Thinking"
-					description="Enable 'always thinking' mode for deeper reasoning. Uses more tokens but produces more thorough responses."
+					description="Enable extended thinking by default for deeper reasoning. Increases latency and token cost but improves quality on complex tasks. Toggle per-session with Option+T."
 					saving={savingField === 'alwaysThinkingEnabled'}
 					success={successField === 'alwaysThinkingEnabled' ? 'Saved' : null}
 				>
@@ -193,23 +195,30 @@
 			<SettingsSection title="Permissions">
 				<SettingItem
 					title="Default Permission Mode"
-					description="How Claude handles permission requests for tools."
+					description="Controls how Claude handles tool permission requests at the start of each session."
 					saving={savingField === 'permissions'}
 					success={successField === 'permissions' ? 'Saved' : null}
 				>
 					{#snippet control()}
-						<SegmentedControl
-							options={[
-								{ label: 'Default', value: 'default' },
-								{ label: 'Ask Before Edits', value: 'acceptEdits' },
-								{ label: 'Bypass All', value: 'bypassPermissions' }
-							]}
+						<SelectDropdown
+							options={PERMISSION_MODE_OPTIONS.map((o) => ({
+								label: o.label,
+								value: o.value
+							}))}
 							value={permissionMode}
-							onchange={handlePermissionModeChange}
+							onchange={(v) => handlePermissionModeChange(String(v))}
 							disabled={savingField === 'permissions'}
 						/>
 					{/snippet}
 				</SettingItem>
+
+				{#if activePermissionDescription}
+					<div class="px-5 pb-3 -mt-2">
+						<p class="text-xs text-[var(--text-muted)] italic">
+							{activePermissionDescription}
+						</p>
+					</div>
+				{/if}
 
 				<div class="p-5">
 					<div class="space-y-1.5 mb-4">
@@ -217,7 +226,7 @@
 							Allowed Tools
 						</h3>
 						<p class="text-[13px] text-[var(--text-secondary)]">
-							MCP tools that are granted permission automatically.
+							Tools and commands that are granted permission automatically, without prompting.
 						</p>
 					</div>
 					<PermissionsList
@@ -230,8 +239,8 @@
 			</SettingsSection>
 
 			<!-- PLUGINS Section -->
-			{#if plugins.length > 0}
-				<SettingsSection title="Plugins">
+			<SettingsSection title="Plugins">
+				{#if plugins.length > 0}
 					{#each plugins as [pluginName, enabled]}
 						<SettingItem
 							title={pluginName}
@@ -248,15 +257,21 @@
 							{/snippet}
 						</SettingItem>
 					{/each}
-				</SettingsSection>
-			{/if}
+				{:else}
+					<div class="p-5">
+						<p class="text-sm text-[var(--text-muted)]">
+							No plugins installed. Install plugins with <code class="text-xs font-mono bg-[var(--bg-muted)] px-1.5 py-0.5 rounded">/install-plugin</code> in Claude Code.
+						</p>
+					</div>
+				{/if}
+			</SettingsSection>
 
 			<!-- ADVANCED Section -->
 			<SettingsSection title="Advanced">
 				<SettingItem
 					title="Status Line Command"
-					description="Custom script for status line display. Script must be executable and output a single line."
-					hint="Example: ~/.claude/statusline-command.sh"
+					description="Shell command that receives session JSON on stdin and prints a status line. Displayed at the bottom of Claude Code's terminal. Use /statusline in Claude Code to generate one automatically."
+					hint="Example: jq -r '.model.display_name' or path to a script"
 					saving={savingField === 'statusLine'}
 					success={successField === 'statusLine' ? 'Saved' : null}
 				>


### PR DESCRIPTION
## Summary

- **Fix misleading permission mode labels**: "Ask Before Edits" renamed to "Auto-accept Edits" — the old label implied Claude would *ask* before editing, but `acceptEdits` actually *auto-approves* edits without asking
- **Expose all 5 valid permission modes**: Previously only showed 3 (Default, Ask Before Edits, Bypass All). Now shows all 5 with descriptions: Default, Auto-accept Edits, Plan Mode, Pre-approved Only, Bypass All
- **Add backend validation**: Permission modes, statusLine config, cleanupPeriodDays (≥1 to prevent known bug where 0 breaks transcript persistence), enabledPlugins (must be bool values)
- **Improve setting descriptions**: Session retention explains *what* gets deleted and *when*; Extended Thinking mentions Option+T toggle; Status Line explains stdin JSON format and `/statusline` command
- **Show plugins section always**: Previously hidden when empty — users didn't know the feature existed. Now shows empty state with install instructions
- **Remove invalid `delegate` mode** from TypeScript types (not a real Claude Code permission mode)

## Files Changed

| File | Change |
|------|--------|
| `api/routers/settings.py` | Added `PermissionModeEnum`, `PermissionsUpdate`, `StatusLineUpdate` Pydantic models with validation |
| `frontend/src/lib/api-types.ts` | Fixed `PermissionMode` type, added `PERMISSION_MODE_OPTIONS` with descriptions, updated `StatusLineConfig` |
| `frontend/src/routes/settings/+page.svelte` | Switched to SelectDropdown for permissions, improved all descriptions, added plugins empty state |

## Test plan

- [ ] Open `/settings` page — verify all 5 permission modes appear in dropdown
- [ ] Select each mode — verify description text updates below the dropdown
- [ ] Verify "Auto-accept Edits" is the label for `acceptEdits` (not "Ask Before Edits")
- [ ] Try sending invalid permission mode via API — should return 422
- [ ] Try `cleanupPeriodDays: 0` via API — should return 422 (validation rejects < 1)
- [ ] Verify plugins section shows empty state when no plugins installed
- [ ] Check session retention, extended thinking, status line descriptions are informative

🤖 Generated with [Claude Code](https://claude.com/claude-code)