### PR TITLE
fix: correct agent route path for unused definitions

### DIFF
--- a/frontend/src/routes/agents/+page.svelte
+++ b/frontend/src/routes/agents/+page.svelte
@@ -439,7 +439,7 @@
 					{#each unusedDefinitions as def (def.name)}
 						{@const colorVars = getSubagentColorVars(def.name)}
 						<a
-							href="/agents/info/{encodeURIComponent(def.name)}"
+							href="/agents/{encodeURIComponent(def.name)}"
 							class="
 								group block
 								bg-[var(--bg-base)]


### PR DESCRIPTION
## Summary
- Fixed incorrect route path in the "Available Agents" section on `/agents` page
- Links were pointing to `/agents/info/{name}` (the API endpoint path) instead of `/agents/{name}` (the actual SvelteKit route)
- `AgentUsageCard` and `AgentUsageTable` already had the correct path — only the unused definitions section was wrong

## Test plan
- [ ] Navigate to `/agents`, expand "Available Agents" group
- [ ] Click on any custom agent definition — should route to `/agents/{name}` (not `/agents/info/{name}`)
- [ ] Verify the agent detail page loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)