### PR TITLE
fix: load all agents on agents page

### DIFF
--- a/frontend/src/routes/agents/+page.server.ts
+++ b/frontend/src/routes/agents/+page.server.ts
@@ -14,7 +14,7 @@ export async function load({ fetch }) {
 	// This matches the tools page pattern (no pagination).
 	const [definitions, usage] = await Promise.all([
 		fetchWithFallback<AgentDefinition[]>(fetch, `${API_BASE}/agents`, []),
-		fetchWithFallback<AgentUsageListResponse>(fetch, `${API_BASE}/agents/usage`, {
+		fetchWithFallback<AgentUsageListResponse>(fetch, `${API_BASE}/agents/usage?per_page=100`, {
 			agents: [],
 			total: 0,
 			page: 1,


### PR DESCRIPTION
## Summary
- The agents page only fetched the first 20 agents (API default `per_page=20`), but there are 52 total agents
- Custom agents have lower run counts, so they fell on pages 2-3 and never appeared in the listing
- Added `per_page=100` (API max) to load all agents in a single request
- All 12 custom agents now appear in the "Custom Agents" group with their actual usage stats

## Test plan
- [ ] Navigate to `/agents` page
- [ ] Verify all 52 agents appear (not just 20)
- [ ] Expand "Custom Agents" group — all 12 custom agents should be visible with usage data
- [ ] Switch to "All Agents" table view — custom agents should appear in the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)