### PR TITLE
fix: consolidate project name parsing for history tab pills

### DIFF
--- a/frontend/src/routes/skills/[skill_name]/+page.svelte
+++ b/frontend/src/routes/skills/[skill_name]/+page.svelte
@@ -32,7 +32,7 @@
 	import FiltersDropdown from '$lib/components/FiltersDropdown.svelte';
 	import FiltersBottomSheet from '$lib/components/FiltersBottomSheet.svelte';
 	import ActiveFilterChips from '$lib/components/ActiveFilterChips.svelte';
-	import { renderMarkdownEffect, cleanSkillName, getPluginColorVars, getPluginChartHex } from '$lib/utils';
+	import { renderMarkdownEffect, cleanSkillName, getPluginColorVars, getPluginChartHex, getProjectNameFromEncoded } from '$lib/utils';
 	import SkeletonBox from '$lib/components/skeleton/SkeletonBox.svelte';
 	import SkeletonText from '$lib/components/skeleton/SkeletonText.svelte';
 	import { SkeletonGlobalSessionCard } from '$lib/components/skeleton';
@@ -170,7 +170,7 @@
 			session_titles: s.session_titles,
 			project_encoded_name: s.project_encoded_name ?? undefined,
 			project_path: s.project_encoded_name ?? '',
-			project_name: s.project_encoded_name?.split('-').pop() ?? ''
+			project_name: getProjectNameFromEncoded(s.project_encoded_name ?? '')
 		};
 	}
 

--- a/frontend/src/routes/tools/[server_name]/+page.svelte
+++ b/frontend/src/routes/tools/[server_name]/+page.svelte
@@ -35,6 +35,7 @@
 	import FiltersBottomSheet from '$lib/components/FiltersBottomSheet.svelte';
 	import ActiveFilterChips from '$lib/components/ActiveFilterChips.svelte';
 	import { getServerColorVars, getServerChartHex } from '$lib/utils/mcp';
+	import { getProjectNameFromEncoded } from '$lib/utils';
 	import {
 		DEFAULT_FILTERS,
 		DEFAULT_SCOPE_SELECTION,
@@ -241,7 +242,7 @@
 			session_titles: s.session_titles,
 			project_encoded_name: s.project_encoded_name ?? undefined,
 			project_path: s.project_encoded_name ?? '',
-			project_name: s.project_encoded_name?.split('-').pop() ?? ''
+			project_name: getProjectNameFromEncoded(s.project_encoded_name ?? '')
 		};
 	}
 

--- a/frontend/src/routes/tools/[server_name]/[tool_name]/+page.svelte
+++ b/frontend/src/routes/tools/[server_name]/[tool_name]/+page.svelte
@@ -33,6 +33,7 @@
 	import FiltersBottomSheet from '$lib/components/FiltersBottomSheet.svelte';
 	import ActiveFilterChips from '$lib/components/ActiveFilterChips.svelte';
 	import { getServerColorVars, getServerChartHex } from '$lib/utils/mcp';
+	import { getProjectNameFromEncoded } from '$lib/utils';
 	import {
 		DEFAULT_FILTERS,
 		DEFAULT_SCOPE_SELECTION,
@@ -226,7 +227,7 @@
 			session_titles: s.session_titles,
 			project_encoded_name: s.project_encoded_name ?? undefined,
 			project_path: s.project_encoded_name ?? '',
-			project_name: s.project_encoded_name?.split('-').pop() ?? ''
+			project_name: getProjectNameFromEncoded(s.project_encoded_name ?? '')
 		};
 	}
 


### PR DESCRIPTION
## Summary
- Skills and tools history tabs were using naive `.split('-').pop()` to parse project names from encoded paths, breaking hyphenated names (e.g., `claude-karma` showed as `karma`)
- Replaced with the shared `getProjectNameFromEncoded()` utility that correctly strips path prefixes while preserving hyphens in project names
- Affects 3 files: skills detail page, tools server page, tools detail page

## Test plan
- [ ] Navigate to `/skills/{skill_name}` → History tab → verify project pills show full name (e.g., `claude-karma` not `karma`)
- [ ] Navigate to `/tools/{server}/{tool}` → History tab → verify project pills show full name
- [ ] Navigate to `/tools/{server}` → History tab → verify project pills show full name
- [ ] Verify `npm run check` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)