### PR TITLE
feat: cross-platform desktop session linking

### DIFF
--- a/api/services/desktop_sessions.py
+++ b/api/services/desktop_sessions.py
@@ -7,24 +7,55 @@ This service detects worktree projects and maps them back to real projects.
 
 Two detection strategies:
 - Strategy A: Worktree filesystem scan (fallback, cross-platform)
-- Strategy B: Desktop metadata ingestion (primary, macOS)
+- Strategy B: Desktop metadata ingestion (primary, cross-platform)
 """
 
 import json
 import logging
+import os
+import platform
 import time
 from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-# Worktree base directory
-WORKTREE_BASE = Path.home() / ".claude-worktrees"
 
-# Desktop metadata location (macOS)
-DESKTOP_SESSIONS_DIR = (
-    Path.home() / "Library" / "Application Support" / "Claude" / "claude-code-sessions"
-)
+def _get_worktree_base() -> Path:
+    """Get worktree base directory, configurable via env var."""
+    custom = os.environ.get("CLAUDE_KARMA_WORKTREE_BASE")
+    if custom:
+        return Path(custom)
+    return Path.home() / ".claude-worktrees"
+
+
+def _get_desktop_sessions_dir() -> Path:
+    """Get platform-specific Claude Desktop sessions directory."""
+    system = platform.system()
+    if system == "Darwin":
+        return (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "Claude"
+            / "claude-code-sessions"
+        )
+    elif system == "Windows":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            return Path(appdata) / "Claude" / "claude-code-sessions"
+        return (
+            Path.home() / "AppData" / "Roaming" / "Claude" / "claude-code-sessions"
+        )
+    else:  # Linux and other Unix
+        xdg_config = os.environ.get(
+            "XDG_CONFIG_HOME", str(Path.home() / ".config")
+        )
+        return Path(xdg_config) / "Claude" / "claude-code-sessions"
+
+
+WORKTREE_BASE = _get_worktree_base()
+DESKTOP_SESSIONS_DIR = _get_desktop_sessions_dir()
 
 # Cache for desktop metadata: (timestamp, data)
 # Note: in-memory cache assumes single-process uvicorn (no workers)
@@ -92,7 +123,7 @@ def extract_worktree_info(encoded_name: str) -> Optional[dict]:
 
 
 # =============================================================================
-# Strategy B: Desktop Metadata Ingestion (Primary, macOS)
+# Strategy B: Desktop Metadata Ingestion (Primary, cross-platform)
 # =============================================================================
 
 

--- a/api/tests/test_desktop_sessions.py
+++ b/api/tests/test_desktop_sessions.py
@@ -1,0 +1,465 @@
+"""
+Tests for desktop session detection and worktree merging service.
+
+Tests platform-aware path detection, worktree identification,
+and desktop metadata lookup.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# =============================================================================
+# Platform Detection: _get_desktop_sessions_dir
+# =============================================================================
+
+
+class TestGetDesktopSessionsDir:
+    """Tests for _get_desktop_sessions_dir platform detection."""
+
+    def test_macos_path(self):
+        with patch("services.desktop_sessions.platform.system", return_value="Darwin"):
+            from services.desktop_sessions import _get_desktop_sessions_dir
+
+            result = _get_desktop_sessions_dir()
+            assert result == (
+                Path.home()
+                / "Library"
+                / "Application Support"
+                / "Claude"
+                / "claude-code-sessions"
+            )
+
+    def test_windows_path_with_appdata(self):
+        with (
+            patch("services.desktop_sessions.platform.system", return_value="Windows"),
+            patch.dict(
+                "os.environ", {"APPDATA": "C:\\Users\\test\\AppData\\Roaming"}
+            ),
+        ):
+            from services.desktop_sessions import _get_desktop_sessions_dir
+
+            result = _get_desktop_sessions_dir()
+            assert result == Path(
+                "C:\\Users\\test\\AppData\\Roaming"
+            ) / "Claude" / "claude-code-sessions"
+
+    def test_windows_path_without_appdata(self):
+        with (
+            patch("services.desktop_sessions.platform.system", return_value="Windows"),
+            patch.dict("os.environ", {}, clear=True),
+            patch("services.desktop_sessions.os.environ.get", return_value=None),
+        ):
+            from services.desktop_sessions import _get_desktop_sessions_dir
+
+            result = _get_desktop_sessions_dir()
+            assert result == (
+                Path.home()
+                / "AppData"
+                / "Roaming"
+                / "Claude"
+                / "claude-code-sessions"
+            )
+
+    def test_linux_path_default(self):
+        with (
+            patch("services.desktop_sessions.platform.system", return_value="Linux"),
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "services.desktop_sessions.os.environ.get",
+                side_effect=lambda k, d=None: d,
+            ),
+        ):
+            from services.desktop_sessions import _get_desktop_sessions_dir
+
+            result = _get_desktop_sessions_dir()
+            assert result == (
+                Path.home() / ".config" / "Claude" / "claude-code-sessions"
+            )
+
+    def test_linux_path_with_xdg(self):
+        with (
+            patch("services.desktop_sessions.platform.system", return_value="Linux"),
+            patch(
+                "services.desktop_sessions.os.environ.get",
+                side_effect=lambda k, d=None: "/custom/config"
+                if k == "XDG_CONFIG_HOME"
+                else d,
+            ),
+        ):
+            from services.desktop_sessions import _get_desktop_sessions_dir
+
+            result = _get_desktop_sessions_dir()
+            assert result == Path(
+                "/custom/config/Claude/claude-code-sessions"
+            )
+
+
+# =============================================================================
+# Worktree Base: _get_worktree_base
+# =============================================================================
+
+
+class TestGetWorktreeBase:
+    """Tests for _get_worktree_base with env var override."""
+
+    def test_default_path(self):
+        with patch.dict("os.environ", {}, clear=True):
+            # Need to re-read since os.environ.get is called at function time
+            with patch(
+                "services.desktop_sessions.os.environ.get",
+                side_effect=lambda k, d=None: None
+                if k == "CLAUDE_KARMA_WORKTREE_BASE"
+                else d,
+            ):
+                from services.desktop_sessions import _get_worktree_base
+
+                result = _get_worktree_base()
+                assert result == Path.home() / ".claude-worktrees"
+
+    def test_custom_path_via_env(self):
+        with patch(
+            "services.desktop_sessions.os.environ.get",
+            side_effect=lambda k, d=None: "/custom/worktrees"
+            if k == "CLAUDE_KARMA_WORKTREE_BASE"
+            else d,
+        ):
+            from services.desktop_sessions import _get_worktree_base
+
+            result = _get_worktree_base()
+            assert result == Path("/custom/worktrees")
+
+
+# =============================================================================
+# is_worktree_project
+# =============================================================================
+
+
+class TestIsWorktreeProject:
+    """Tests for is_worktree_project encoded name detection."""
+
+    def test_worktree_with_dot_encoding(self):
+        from services.desktop_sessions import is_worktree_project
+
+        # Our encode_path preserves dots: -.claude-worktrees- does NOT
+        # contain -claude-worktrees- (dot != dash), so this is False
+        assert not is_worktree_project(
+            "-Users-test-.claude-worktrees-myproject-focused-jepsen"
+        )
+
+    def test_worktree_with_dash_encoding(self):
+        from services.desktop_sessions import is_worktree_project
+
+        # Claude Code's encoding replaces dots with dashes
+        assert is_worktree_project(
+            "-Users-test--claude-worktrees-myproject-focused-jepsen"
+        )
+
+    def test_regular_project(self):
+        from services.desktop_sessions import is_worktree_project
+
+        assert not is_worktree_project("-Users-test-Documents-myproject")
+
+    def test_empty_string(self):
+        from services.desktop_sessions import is_worktree_project
+
+        assert not is_worktree_project("")
+
+    def test_partial_match(self):
+        from services.desktop_sessions import is_worktree_project
+
+        # Must contain the full marker
+        assert not is_worktree_project("-Users-test-claude-worktrees")
+        assert is_worktree_project("-Users-test-claude-worktrees-proj-wt")
+
+
+# =============================================================================
+# extract_worktree_info
+# =============================================================================
+
+
+class TestExtractWorktreeInfo:
+    """Tests for extract_worktree_info filesystem scan."""
+
+    def test_non_worktree_returns_none(self):
+        from services.desktop_sessions import extract_worktree_info
+
+        assert extract_worktree_info("-Users-test-myproject") is None
+
+    def test_missing_worktree_base_returns_none(self, tmp_path):
+        from services.desktop_sessions import extract_worktree_info
+
+        with patch(
+            "services.desktop_sessions.WORKTREE_BASE",
+            tmp_path / "nonexistent",
+        ):
+            result = extract_worktree_info(
+                "-Users-test-.claude-worktrees-proj-wt"
+            )
+            assert result is None
+
+    def test_matching_worktree_found(self, tmp_path):
+        # Use a dir name without leading dot so the encoded form
+        # contains -claude-worktrees- (passing is_worktree_project check)
+        wt_base = tmp_path / "claude-worktrees"
+        project_dir = wt_base / "myproject"
+        worktree_dir = project_dir / "focused-jepsen"
+        worktree_dir.mkdir(parents=True)
+
+        from models.project import Project
+
+        encoded = Project.encode_path(str(worktree_dir))
+        # Verify the encoded name passes the worktree check
+        assert "-claude-worktrees-" in encoded
+
+        with patch("services.desktop_sessions.WORKTREE_BASE", wt_base):
+            from services.desktop_sessions import extract_worktree_info
+
+            result = extract_worktree_info(encoded)
+            assert result is not None
+            assert result["project_name"] == "myproject"
+            assert result["worktree_name"] == "focused-jepsen"
+
+    def test_dot_dash_encoding_variant(self, tmp_path):
+        """Test that dots-replaced-by-dashes encoding also matches."""
+        wt_base = tmp_path / ".claude-worktrees"
+        project_dir = wt_base / "myproject"
+        worktree_dir = project_dir / "focused-jepsen"
+        worktree_dir.mkdir(parents=True)
+
+        from models.project import Project
+
+        encoded = Project.encode_path(str(worktree_dir))
+        # Simulate Claude Code's dot->dash encoding
+        encoded_dots = encoded.replace(".", "-")
+
+        with patch("services.desktop_sessions.WORKTREE_BASE", wt_base):
+            from services.desktop_sessions import extract_worktree_info
+
+            result = extract_worktree_info(encoded_dots)
+            assert result is not None
+            assert result["project_name"] == "myproject"
+            assert result["worktree_name"] == "focused-jepsen"
+
+
+# =============================================================================
+# get_session_source
+# =============================================================================
+
+
+class TestGetSessionSource:
+    """Tests for get_session_source desktop metadata lookup."""
+
+    def test_session_in_desktop_metadata(self):
+        mock_meta = {
+            "session-uuid-123": {
+                "originCwd": "/Users/test/project",
+                "worktreeName": "focused-jepsen",
+            }
+        }
+        with patch(
+            "services.desktop_sessions.load_desktop_metadata",
+            return_value=mock_meta,
+        ):
+            from services.desktop_sessions import get_session_source
+
+            assert get_session_source("session-uuid-123") == "desktop"
+
+    def test_session_not_in_desktop_metadata(self):
+        with patch(
+            "services.desktop_sessions.load_desktop_metadata",
+            return_value={},
+        ):
+            from services.desktop_sessions import get_session_source
+
+            assert get_session_source("unknown-uuid") is None
+
+
+# =============================================================================
+# _load_desktop_metadata_impl
+# =============================================================================
+
+
+class TestLoadDesktopMetadataImpl:
+    """Tests for _load_desktop_metadata_impl file parsing."""
+
+    def test_nonexistent_dir_returns_empty(self, tmp_path):
+        with patch(
+            "services.desktop_sessions.DESKTOP_SESSIONS_DIR",
+            tmp_path / "nonexistent",
+        ):
+            from services.desktop_sessions import _load_desktop_metadata_impl
+
+            assert _load_desktop_metadata_impl() == {}
+
+    def test_parses_session_files(self, tmp_path):
+        # Create Desktop sessions structure
+        account_dir = tmp_path / "account-uuid"
+        project_dir = account_dir / "project-uuid"
+        project_dir.mkdir(parents=True)
+
+        session_data = {
+            "cliSessionId": "cli-session-abc",
+            "originCwd": "/Users/test/myproject",
+            "worktreeName": "focused-jepsen",
+            "title": "Test Session",
+            "model": "claude-opus-4-5-20251101",
+            "isArchived": False,
+            "cwd": "/Users/test/.claude-worktrees/myproject/focused-jepsen",
+        }
+        session_file = project_dir / "local_session-uuid.json"
+        session_file.write_text(json.dumps(session_data))
+
+        with patch(
+            "services.desktop_sessions.DESKTOP_SESSIONS_DIR", tmp_path
+        ):
+            from services.desktop_sessions import _load_desktop_metadata_impl
+
+            result = _load_desktop_metadata_impl()
+
+        assert "cli-session-abc" in result
+        meta = result["cli-session-abc"]
+        assert meta["originCwd"] == "/Users/test/myproject"
+        assert meta["worktreeName"] == "focused-jepsen"
+        assert meta["title"] == "Test Session"
+        assert meta["model"] == "claude-opus-4-5-20251101"
+        assert meta["isArchived"] is False
+
+    def test_skips_invalid_json(self, tmp_path):
+        account_dir = tmp_path / "account-uuid"
+        project_dir = account_dir / "project-uuid"
+        project_dir.mkdir(parents=True)
+
+        # Write invalid JSON
+        (project_dir / "local_bad.json").write_text("not json{{{")
+
+        # Write valid JSON without cliSessionId
+        (project_dir / "local_nocli.json").write_text(json.dumps({"title": "no cli id"}))
+
+        # Write valid session
+        valid_data = {
+            "cliSessionId": "valid-session",
+            "originCwd": "/Users/test/proj",
+        }
+        (project_dir / "local_good.json").write_text(json.dumps(valid_data))
+
+        with patch(
+            "services.desktop_sessions.DESKTOP_SESSIONS_DIR", tmp_path
+        ):
+            from services.desktop_sessions import _load_desktop_metadata_impl
+
+            result = _load_desktop_metadata_impl()
+
+        # Only the valid session with cliSessionId should be present
+        assert len(result) == 1
+        assert "valid-session" in result
+
+    def test_skips_non_local_files(self, tmp_path):
+        account_dir = tmp_path / "account-uuid"
+        project_dir = account_dir / "project-uuid"
+        project_dir.mkdir(parents=True)
+
+        # File that doesn't match local_*.json pattern
+        data = {"cliSessionId": "should-not-appear"}
+        (project_dir / "remote_session.json").write_text(json.dumps(data))
+
+        with patch(
+            "services.desktop_sessions.DESKTOP_SESSIONS_DIR", tmp_path
+        ):
+            from services.desktop_sessions import _load_desktop_metadata_impl
+
+            result = _load_desktop_metadata_impl()
+
+        assert len(result) == 0
+
+
+# =============================================================================
+# get_real_project_encoded_name
+# =============================================================================
+
+
+class TestGetRealProjectEncodedName:
+    """Tests for get_real_project_encoded_name resolution strategies."""
+
+    def test_strategy_b_desktop_metadata(self, tmp_path):
+        """Strategy B: resolve via Desktop metadata originCwd."""
+        projects_dir = tmp_path / "projects"
+        real_project = projects_dir / "-Users-test-myproject"
+        real_project.mkdir(parents=True)
+
+        mock_meta = {
+            "session-uuid-1": {
+                "originCwd": "/Users/test/myproject",
+            }
+        }
+
+        with (
+            patch(
+                "services.desktop_sessions.load_desktop_metadata",
+                return_value=mock_meta,
+            ),
+            patch("config.settings") as mock_settings,
+        ):
+            mock_settings.projects_dir = projects_dir
+
+            from services.desktop_sessions import get_real_project_encoded_name
+
+            result = get_real_project_encoded_name(
+                "-Users-test--claude-worktrees-myproject-wt",
+                ["session-uuid-1"],
+            )
+            assert result == "-Users-test-myproject"
+
+    def test_strategy_a_filesystem_fallback(self, tmp_path):
+        """Strategy A: resolve via worktree filesystem scan."""
+        projects_dir = tmp_path / "projects"
+        real_project = projects_dir / "-Users-test-myproject"
+        real_project.mkdir(parents=True)
+
+        # Use dir name without dot so encoded form passes is_worktree_project
+        wt_base = tmp_path / "claude-worktrees"
+        wt_dir = wt_base / "myproject" / "focused-jepsen"
+        wt_dir.mkdir(parents=True)
+
+        from models.project import Project
+
+        encoded_wt = Project.encode_path(str(wt_dir))
+
+        with (
+            patch(
+                "services.desktop_sessions.load_desktop_metadata",
+                return_value={},
+            ),
+            patch("services.desktop_sessions.WORKTREE_BASE", wt_base),
+            patch("config.settings") as mock_settings,
+        ):
+            mock_settings.projects_dir = projects_dir
+
+            from services.desktop_sessions import get_real_project_encoded_name
+
+            result = get_real_project_encoded_name(
+                encoded_wt, ["no-match-uuid"]
+            )
+            assert result == "-Users-test-myproject"
+
+    def test_no_match_returns_none(self):
+        with (
+            patch(
+                "services.desktop_sessions.load_desktop_metadata",
+                return_value={},
+            ),
+            patch(
+                "services.desktop_sessions.extract_worktree_info",
+                return_value=None,
+            ),
+        ):
+            from services.desktop_sessions import get_real_project_encoded_name
+
+            result = get_real_project_encoded_name(
+                "-Users-test-unknown", ["no-match"]
+            )
+            assert result is None


### PR DESCRIPTION
## Summary

- Replace hardcoded macOS paths in `desktop_sessions.py` with platform-aware detection for Desktop metadata and worktree base directories
- Windows users now get worktree merging (phantom project resolution) instead of seeing duplicate project entries
- Linux support added via XDG conventions for unofficial Claude Desktop builds

## Changes

**`api/services/desktop_sessions.py`** — Platform detection logic:
- `_get_desktop_sessions_dir()`: Darwin → `~/Library/Application Support/Claude/...`, Windows → `%APPDATA%/Claude/...`, Linux → `$XDG_CONFIG_HOME/Claude/...`
- `_get_worktree_base()`: Supports `CLAUDE_KARMA_WORKTREE_BASE` env var override
- Module-level `WORKTREE_BASE` and `DESKTOP_SESSIONS_DIR` preserved for backward compat

**`api/tests/test_desktop_sessions.py`** — 25 new tests:
- Platform detection for macOS, Windows (with/without APPDATA), Linux (default/XDG)
- Worktree base env var override
- `is_worktree_project()`, `extract_worktree_info()`, `get_real_project_encoded_name()`
- `get_session_source()`, `_load_desktop_metadata_impl()` with mock filesystem

## Platform Path Matrix

| Platform | Desktop metadata path |
|----------|----------------------|
| macOS | `~/Library/Application Support/Claude/claude-code-sessions/` |
| Windows | `%APPDATA%/Claude/claude-code-sessions/` |
| Linux | `$XDG_CONFIG_HOME/Claude/claude-code-sessions/` (default: `~/.config/...`) |

## Test plan

- [x] `pytest tests/test_desktop_sessions.py -v` — 25/25 pass
- [x] `pytest` — 1248 passed, 2 skipped (full suite)
- [x] `ruff check` — Clean
- [ ] Manual: start API, hit `/projects` — existing macOS behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)