### PR TITLE
ci: add Windows CI runner for cross-platform path tests

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -80,6 +80,37 @@ jobs:
         run: |
           pytest tests/api/ -v
 
+  cross-platform-test:
+    name: Cross-Platform Path Tests
+    defaults:
+      run:
+        working-directory: api
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.11"]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: api/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run cross-platform path tests
+        run: |
+          pytest tests/test_project.py tests/test_cross_platform_paths.py -v
+
   lint:
     name: Python Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -105,7 +105,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e '.[dev]'
+          pip install -r requirements.txt
+          pip install httpx pytest-asyncio
 
       - name: Run cross-platform path tests
         run: |


### PR DESCRIPTION
## Summary
- Adds `cross-platform-test` job to `api-tests.yml` CI workflow
- Runs `test_project.py` and `test_cross_platform_paths.py` on both `ubuntu-latest` and `windows-latest` (Python 3.11)
- Validates real `pathlib` behavior with Windows paths on actual Windows runners

Companion to PR #50 which adds the cross-platform path test suite.

## Test plan
- [ ] CI passes on both ubuntu and windows runners
- [ ] 4 `TestWindowsNativePathlib` tests that are skipped on Mac should run and pass on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)