### PR TITLE
fix(session-title): persist titles locally when API is offline, retry on rate limits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,25 @@ ruff check models/ tests/ routers/
 ruff format models/ tests/ routers/
 ```
 
+### CLI (karma)
+
+```bash
+cd api
+pip install -e ".[dev]"    # Registers `karma` command globally
+
+# Search sessions
+karma search --branch 1610
+karma search --date 2026-03-15
+karma search --keyword "refactor"
+karma search --skill ralph-loop
+karma search --branch 1610 --for-claude    # Structured markdown for Claude Code
+
+# Get session details
+karma sessions get <uuid>                   # Metadata table
+karma sessions get <uuid> --for-claude      # Structured markdown
+karma sessions get <uuid> --content         # Include conversation content
+```
+
 ### Frontend (SvelteKit/Svelte 5)
 
 ```bash

--- a/api/cli/db.py
+++ b/api/cli/db.py
@@ -1,0 +1,26 @@
+"""Read-only SQLite connection for CLI queries."""
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path.home() / ".claude_karma" / "metadata.db"
+
+
+def get_read_connection(db_path: Path | None = None) -> sqlite3.Connection:
+    """Open a read-only connection to the Karma metadata database.
+
+    Raises FileNotFoundError if the database file does not exist.
+    """
+    path = db_path or DB_PATH
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Karma database not found at {path}. "
+            "Make sure the API has been started at least once to create the index."
+        )
+
+    conn = sqlite3.connect(
+        f"file:{path}?mode=ro",
+        uri=True,
+        timeout=5.0,
+    )
+    conn.row_factory = sqlite3.Row
+    return conn

--- a/api/cli/formatters.py
+++ b/api/cli/formatters.py
@@ -1,0 +1,80 @@
+"""Output formatters for karma CLI."""
+from tabulate import tabulate
+
+
+def _truncate(text: str, max_len: int = 50) -> str:
+    if not text:
+        return ""
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3] + "..."
+
+
+def _format_duration(seconds: float | None) -> str:
+    if not seconds:
+        return "-"
+    minutes = int(seconds // 60)
+    if minutes < 60:
+        return f"{minutes}min"
+    hours = minutes // 60
+    remaining = minutes % 60
+    return f"{hours}h{remaining:02d}m"
+
+
+def format_table(sessions: list[dict]) -> str:
+    """Format sessions as a human-readable table."""
+    if not sessions:
+        return "No sessions found."
+
+    rows = []
+    for s in sessions:
+        rows.append([
+            s["uuid"][:8],
+            s.get("git_branch") or "-",
+            (s.get("start_time") or "")[:10],
+            _format_duration(s.get("duration_seconds")),
+            s.get("message_count") or 0,
+            f"${s.get('total_cost', 0):.2f}",
+            _truncate(s.get("session_titles") or s.get("initial_prompt") or "", 40),
+        ])
+
+    headers = ["UUID", "BRANCH", "DATE", "DURATION", "MSGS", "COST", "TITLE/PROMPT"]
+    return tabulate(rows, headers=headers, tablefmt="plain")
+
+
+def format_for_claude(sessions: list[dict]) -> str:
+    """Format sessions as structured markdown for Claude Code consumption."""
+    if not sessions:
+        return "No sessions found."
+
+    parts = []
+    for s in sessions:
+        uuid = s["uuid"]
+        branch = s.get("git_branch") or "unknown"
+        date = (s.get("start_time") or "")[:10]
+        title = s.get("session_titles") or ""
+        prompt = s.get("initial_prompt") or ""
+        duration = _format_duration(s.get("duration_seconds"))
+        msgs = s.get("message_count", 0)
+        cost = s.get("total_cost", 0)
+        skills = s.get("skills") or ""
+        tools = s.get("tools") or ""
+        project = s.get("project_path") or ""
+
+        section = f"## Session {uuid[:12]} — {branch} — {date}\n"
+        if title:
+            section += f"**Title:** {title}\n"
+        if prompt:
+            section += f"**Initial prompt:** {_truncate(prompt, 200)}\n"
+        section += f"**Duration:** {duration} | **Messages:** {msgs} | **Cost:** ${cost:.2f}\n"
+        if skills:
+            section += f"**Skills used:** {skills}\n"
+        if tools:
+            section += f"**Tools used:** {tools}\n"
+        if project:
+            section += f"**Project:** {project}\n"
+        section += f"**Full UUID:** {uuid}\n"
+
+        parts.append(section)
+
+    return "\n---\n\n".join(parts)

--- a/api/cli/main.py
+++ b/api/cli/main.py
@@ -2,6 +2,7 @@
 import click
 
 from .search import search
+from .sessions import sessions
 
 
 @click.group()
@@ -11,3 +12,4 @@ def cli():
 
 
 cli.add_command(search)
+cli.add_command(sessions)

--- a/api/cli/main.py
+++ b/api/cli/main.py
@@ -1,0 +1,13 @@
+"""Karma CLI — search and retrieve Claude Code session context."""
+import click
+
+from .search import search
+
+
+@click.group()
+def cli():
+    """Karma — Claude Code session search and context retrieval."""
+    pass
+
+
+cli.add_command(search)

--- a/api/cli/search.py
+++ b/api/cli/search.py
@@ -1,0 +1,127 @@
+"""karma search — find sessions by branch, date, keyword, skill."""
+import sqlite3
+
+import click
+
+from . import db as _db
+from .formatters import format_for_claude, format_table
+
+
+def _query_sessions(
+    conn: sqlite3.Connection,
+    branch: str | None = None,
+    date: str | None = None,
+    keyword: str | None = None,
+    skill: str | None = None,
+    limit: int = 50,
+) -> list[dict]:
+    """Query sessions from SQLite with optional filters."""
+    conditions = []
+    params = {}
+
+    if branch:
+        conditions.append("s.git_branch LIKE :branch")
+        params["branch"] = f"%{branch}%"
+
+    if date:
+        conditions.append("s.start_time LIKE :date")
+        params["date"] = f"{date}%"
+
+    if keyword:
+        conditions.append(
+            "s.uuid IN ("
+            "SELECT uuid FROM sessions_fts WHERE sessions_fts MATCH :keyword"
+            ")"
+        )
+        params["keyword"] = keyword
+
+    if skill:
+        conditions.append(
+            "s.uuid IN ("
+            "SELECT session_uuid FROM session_skills WHERE skill_name LIKE :skill"
+            ")"
+        )
+        params["skill"] = f"%{skill}%"
+
+    where = "WHERE " + " AND ".join(conditions) if conditions else ""
+
+    query = f"""
+        SELECT s.uuid, s.slug, s.git_branch, s.project_encoded_name,
+               s.project_path, s.start_time, s.end_time,
+               s.duration_seconds, s.message_count, s.total_cost,
+               s.initial_prompt, s.session_titles, s.input_tokens,
+               s.output_tokens
+        FROM sessions s
+        {where}
+        ORDER BY s.start_time DESC
+        LIMIT :limit
+    """
+    params["limit"] = limit
+
+    rows = conn.execute(query, params).fetchall()
+    sessions = [dict(row) for row in rows]
+
+    uuids = [s["uuid"] for s in sessions]
+    if uuids:
+        _enrich_skills(conn, sessions)
+        _enrich_tools(conn, sessions)
+
+    return sessions
+
+
+def _enrich_skills(conn: sqlite3.Connection, sessions: list[dict]) -> None:
+    """Add aggregated skill names to each session dict."""
+    uuid_map = {s["uuid"]: s for s in sessions}
+    placeholders = ",".join("?" for _ in uuid_map)
+    rows = conn.execute(
+        f"SELECT session_uuid, skill_name, count FROM session_skills "
+        f"WHERE session_uuid IN ({placeholders})",
+        list(uuid_map.keys()),
+    ).fetchall()
+
+    skills_by_uuid: dict[str, list[str]] = {}
+    for row in rows:
+        skills_by_uuid.setdefault(row["session_uuid"], []).append(row["skill_name"])
+
+    for s in sessions:
+        s["skills"] = ", ".join(skills_by_uuid.get(s["uuid"], []))
+
+
+def _enrich_tools(conn: sqlite3.Connection, sessions: list[dict]) -> None:
+    """Add aggregated tool usage to each session dict."""
+    uuid_map = {s["uuid"]: s for s in sessions}
+    placeholders = ",".join("?" for _ in uuid_map)
+    rows = conn.execute(
+        f"SELECT session_uuid, tool_name, count FROM session_tools "
+        f"WHERE session_uuid IN ({placeholders})",
+        list(uuid_map.keys()),
+    ).fetchall()
+
+    tools_by_uuid: dict[str, list[str]] = {}
+    for row in rows:
+        tools_by_uuid.setdefault(row["session_uuid"], []).append(
+            f"{row['tool_name']}({row['count']})"
+        )
+
+    for s in sessions:
+        s["tools"] = ", ".join(tools_by_uuid.get(s["uuid"], []))
+
+
+@click.command()
+@click.option("--branch", "-b", help="Filter by git branch (partial match)")
+@click.option("--date", "-d", help="Filter by date (YYYY-MM-DD)")
+@click.option("--keyword", "-k", help="Full-text search in prompts and titles")
+@click.option("--skill", "-s", help="Filter by skill name (partial match)")
+@click.option("--limit", "-l", default=50, help="Max results (default: 50)")
+@click.option("--for-claude", is_flag=True, help="Output structured markdown for Claude Code")
+def search(branch, date, keyword, skill, limit, for_claude):
+    """Search Claude Code sessions by branch, date, keyword, or skill."""
+    conn = _db.get_read_connection(_db.DB_PATH)
+    try:
+        sessions = _query_sessions(conn, branch, date, keyword, skill, limit)
+        if for_claude:
+            click.echo(format_for_claude(sessions))
+        else:
+            click.echo(format_table(sessions))
+    finally:
+        conn.close()

--- a/api/cli/sessions.py
+++ b/api/cli/sessions.py
@@ -1,0 +1,113 @@
+"""karma sessions — get session details and content."""
+import subprocess
+import sys
+from pathlib import Path
+
+import click
+
+from . import db as _db
+from .formatters import format_for_claude, format_table
+
+
+CLEAN_SCRIPT = Path.home() / ".claude" / "skills" / "session-summary" / "add" / "scripts" / "clean-session.py"
+
+
+def _find_session(conn, uuid_prefix: str) -> dict | None:
+    """Find a session by exact or prefix UUID match."""
+    row = conn.execute(
+        "SELECT * FROM sessions WHERE uuid = ?", (uuid_prefix,)
+    ).fetchone()
+
+    if not row:
+        row = conn.execute(
+            "SELECT * FROM sessions WHERE uuid LIKE ?", (f"{uuid_prefix}%",)
+        ).fetchone()
+
+    if not row:
+        return None
+
+    session = dict(row)
+
+    skills = conn.execute(
+        "SELECT skill_name FROM session_skills WHERE session_uuid = ?",
+        (session["uuid"],),
+    ).fetchall()
+    session["skills"] = ", ".join(r["skill_name"] for r in skills)
+
+    tools = conn.execute(
+        "SELECT tool_name, count FROM session_tools WHERE session_uuid = ?",
+        (session["uuid"],),
+    ).fetchall()
+    session["tools"] = ", ".join(f"{r['tool_name']}({r['count']})" for r in tools)
+
+    return session
+
+
+def _get_clean_content(session: dict) -> str | None:
+    """Get cleaned session content using clean-session.py."""
+    if not CLEAN_SCRIPT.exists():
+        return None
+
+    projects_dir = Path.home() / ".claude" / "projects" / session["project_encoded_name"]
+    if not projects_dir.exists():
+        return None
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(CLEAN_SCRIPT),
+                "--session", session["uuid"],
+                "--projects-dir", str(projects_dir),
+                "--format", "md",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+
+    return None
+
+
+@click.group()
+def sessions():
+    """Session details and content retrieval."""
+    pass
+
+
+@sessions.command()
+@click.argument("uuid")
+@click.option("--content", is_flag=True, help="Include cleaned conversation content")
+@click.option("--for-claude", is_flag=True, help="Output structured markdown for Claude Code")
+def get(uuid, content, for_claude):
+    """Get details of a specific session by UUID (or prefix)."""
+    conn = _db.get_read_connection()
+    try:
+        session = _find_session(conn, uuid)
+        if not session:
+            click.echo(f"Session not found for UUID: {uuid}")
+            return
+
+        if for_claude:
+            output = format_for_claude([session])
+        else:
+            output = format_table([session])
+
+        click.echo(output)
+
+        if content:
+            click.echo("\n---\n")
+            clean = _get_clean_content(session)
+            if clean:
+                click.echo(clean)
+            else:
+                click.echo(
+                    "Could not retrieve session content. "
+                    "Make sure clean-session.py is available."
+                )
+    finally:
+        conn.close()

--- a/api/main.py
+++ b/api/main.py
@@ -93,6 +93,35 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.warning(f"SQLite indexing failed to start (non-critical): {e}")
 
+    # Process title-retry queue in background (non-blocking)
+    try:
+        import threading
+
+        def _process_title_retries():
+            from routers.sessions import retry_pending_titles
+            try:
+                result = retry_pending_titles()
+                import json as _json
+                body = _json.loads(result.body)
+                if body.get("processed", 0) > 0:
+                    logger.info(
+                        "Title retry on startup: %d processed, %d failed, %d skipped",
+                        body["processed"],
+                        body["failed"],
+                        body["skipped"],
+                    )
+            except Exception as exc:
+                logger.debug("Title retry on startup failed (non-critical): %s", exc)
+
+        retry_thread = threading.Thread(
+            target=_process_title_retries,
+            name="title-retry",
+            daemon=True,
+        )
+        retry_thread.start()
+    except Exception as exc:
+        logger.debug("Could not start title retry thread: %s", exc)
+
     # Start live session reconciler
     reconciler_task = None
     if settings.reconciler_enabled:

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -2,8 +2,11 @@
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
+[project.scripts]
+karma = "cli.main:cli"
+
 [tool.setuptools.packages.find]
-include = ["models*"]
+include = ["models*", "cli*"]
 
 [project]
 name = "claude-code-models"
@@ -15,6 +18,8 @@ requires-python = ">=3.9"
 dependencies = [
     "pydantic>=2.0",
     "pydantic-settings>=2.0.0",
+    "click>=8.0",
+    "tabulate>=0.9",
 ]
 
 [project.optional-dependencies]

--- a/api/routers/sessions.py
+++ b/api/routers/sessions.py
@@ -7,7 +7,9 @@ Phase 3: HTTP caching with conditional request support.
 import heapq
 import json
 import logging
+import os
 import sqlite3
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1768,3 +1770,144 @@ def set_session_title(uuid: str, request: SetTitleRequest):
         content={"status": "ok", "uuid": uuid, "title": title},
         status_code=200,
     )
+
+
+@router.post("/retry-titles")
+def retry_pending_titles():
+    """
+    Process the title-retry queue, regenerating titles for sessions that
+    previously failed due to usage/rate limits or timeouts.
+
+    Reads ~/.claude_karma/title-retry/{uuid}.json files written by the
+    session_title_generator hook, attempts Haiku generation for each,
+    and removes the file on success.
+
+    Returns a summary of processed sessions.
+    """
+    from config import settings as app_settings
+
+    retry_dir = app_settings.karma_base / "title-retry"
+    if not retry_dir.is_dir():
+        return JSONResponse(content={"processed": 0, "failed": 0, "skipped": 0})
+
+    retry_files = list(retry_dir.glob("*.json"))
+    processed = 0
+    failed = 0
+    skipped = 0
+
+    for retry_file in retry_files:
+        try:
+            payload = json.loads(retry_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            skipped += 1
+            continue
+
+        session_id = payload.get("session_id", "")
+        initial_prompt = payload.get("initial_prompt", "")
+        first_response = payload.get("first_response")
+
+        if not session_id or not initial_prompt:
+            skipped += 1
+            retry_file.unlink(missing_ok=True)
+            continue
+
+        # Skip sessions that already have a title
+        existing = title_cache.get_titles(
+            _resolve_encoded_name(session_id), session_id
+        )
+        if existing:
+            skipped += 1
+            retry_file.unlink(missing_ok=True)
+            continue
+
+        # Attempt Haiku title generation
+        parts = [f"User asked: {initial_prompt}"]
+        if first_response:
+            parts.append(f"Assistant did: {first_response}")
+        context = "\n".join(parts)
+        prompt = (
+            "Generate a concise 5-10 word title for this coding session.\n"
+            "The title should describe what was accomplished or attempted.\n"
+            "Return ONLY the title, no quotes, no explanation.\n\n"
+            f"{context}\n\nTitle:"
+        )
+
+        try:
+            env = os.environ.copy()
+            env.pop("CLAUDECODE", None)
+            result = subprocess.run(
+                [
+                    "claude", "-p", prompt,
+                    "--model", "haiku",
+                    "--no-session-persistence",
+                    "--output-format", "text",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env=env,
+            )
+
+            if result.returncode == 0 and result.stdout.strip():
+                title_text = result.stdout.strip().strip("\"'")
+                words = title_text.split()
+                if len(words) > 10:
+                    title_text = " ".join(words[:10])
+
+                # Store the title
+                enc = _resolve_encoded_name(session_id)
+                if enc:
+                    title_cache.set_title(enc, session_id, title_text)
+                    _persist_title_sqlite(session_id, title_text)
+
+                retry_file.unlink(missing_ok=True)
+                processed += 1
+            else:
+                # Still rate-limited or failed — leave file for next retry
+                failed += 1
+
+        except subprocess.TimeoutExpired:
+            failed += 1
+        except Exception as exc:
+            logger.warning("Error retrying title for %s: %s", session_id, exc)
+            failed += 1
+
+    return JSONResponse(
+        content={"processed": processed, "failed": failed, "skipped": skipped}
+    )
+
+
+def _resolve_encoded_name(uuid: str) -> Optional[str]:
+    """Resolve the encoded project name for a session UUID."""
+    result = find_session_with_project(uuid)
+    return result.project_encoded_name if result else None
+
+
+def _persist_title_sqlite(uuid: str, title: str) -> None:
+    """Update session_titles in SQLite for a single session."""
+    from config import settings as app_settings
+
+    if not app_settings.use_sqlite:
+        return
+    try:
+        from db.connection import get_writer_db
+
+        conn = get_writer_db()
+        row = conn.execute(
+            "SELECT session_titles FROM sessions WHERE uuid = ?", (uuid,)
+        ).fetchone()
+        if row:
+            existing: list = []
+            if row["session_titles"]:
+                try:
+                    existing = json.loads(row["session_titles"])
+                except json.JSONDecodeError:
+                    pass
+            if title not in existing:
+                conn.execute(
+                    "UPDATE sessions SET session_titles = ? WHERE uuid = ?",
+                    (json.dumps([title] + existing), uuid),
+                )
+                conn.commit()
+    except Exception as exc:
+        logger.warning("Failed to update SQLite title for %s: %s", uuid, exc)

--- a/api/services/session_title_cache.py
+++ b/api/services/session_title_cache.py
@@ -186,6 +186,15 @@ class SessionTitleCache:
             # Persist to disk
             self._save_to_disk(cache_path, data)
 
+            # Also write to pending-titles file so JSONL build can find it
+            # (covers the case where SQLite is not enabled)
+            try:
+                pending_dir = settings.karma_base / "session-titles"
+                pending_dir.mkdir(parents=True, exist_ok=True)
+                (pending_dir / f"{uuid}.txt").write_text(title, encoding="utf-8")
+            except OSError:
+                pass
+
     # -------------------------------------------------------------------------
     # Staleness detection
     # -------------------------------------------------------------------------
@@ -452,6 +461,33 @@ class SessionTitleCache:
             )
             return None
 
+    @staticmethod
+    def _load_pending_titles() -> Dict[str, str]:
+        """
+        Load titles saved locally by the hook when the API was unavailable.
+
+        Reads ~/.claude_karma/session-titles/{uuid}.txt files written by the
+        session_title_generator hook as a fallback when the API is offline.
+
+        Returns:
+            Dict mapping session UUID to title string.
+        """
+        pending: Dict[str, str] = {}
+        pending_dir = settings.karma_base / "session-titles"
+        if not pending_dir.is_dir():
+            return pending
+
+        for title_file in pending_dir.glob("*.txt"):
+            uuid = title_file.stem
+            try:
+                title = title_file.read_text(encoding="utf-8").strip()
+                if title:
+                    pending[uuid] = title
+            except OSError:
+                pass
+
+        return pending
+
     def _build_from_jsonl(self, encoded_name: str) -> Dict[str, TitleEntry]:
         """
         Build title cache by scanning all session JSONL files (slow fallback).
@@ -468,6 +504,9 @@ class SessionTitleCache:
             for entry in index.entries:
                 if entry.summary:
                     index_summaries[entry.session_id] = entry.summary
+
+        # Load titles saved locally by the hook when API was unavailable
+        pending_titles = self._load_pending_titles()
 
         data: Dict[str, TitleEntry] = {}
 
@@ -493,6 +532,11 @@ class SessionTitleCache:
                 fallback = index_summaries.get(uuid)
                 if fallback:
                     titles = [fallback]
+
+            if not titles:
+                pending = pending_titles.get(uuid)
+                if pending:
+                    titles = [pending]
 
             data[uuid] = TitleEntry(titles=titles, slug=slug, mtime=mtime_ms)
 

--- a/api/tests/test_cli_db.py
+++ b/api/tests/test_cli_db.py
@@ -1,0 +1,37 @@
+"""Tests for CLI database reader."""
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from cli.db import get_read_connection, DB_PATH
+
+
+def test_db_path_points_to_karma_metadata():
+    """DB_PATH should resolve to ~/.claude_karma/metadata.db."""
+    expected = Path.home() / ".claude_karma" / "metadata.db"
+    assert DB_PATH == expected
+
+
+def test_get_read_connection_returns_readonly_connection(tmp_path):
+    """get_read_connection should return a read-only sqlite3 connection."""
+    db_file = tmp_path / "test.db"
+    conn = sqlite3.connect(str(db_file))
+    conn.execute("CREATE TABLE t (id INTEGER)")
+    conn.commit()
+    conn.close()
+
+    with patch("cli.db.DB_PATH", db_file):
+        read_conn = get_read_connection()
+        assert read_conn is not None
+        read_conn.execute("SELECT * FROM t")
+        read_conn.close()
+
+
+def test_get_read_connection_raises_if_db_missing(tmp_path):
+    """get_read_connection should raise if database file does not exist."""
+    fake_path = tmp_path / "nonexistent.db"
+    with patch("cli.db.DB_PATH", fake_path):
+        with pytest.raises(FileNotFoundError):
+            get_read_connection()

--- a/api/tests/test_cli_format.py
+++ b/api/tests/test_cli_format.py
@@ -1,0 +1,46 @@
+"""Tests for CLI output formatters."""
+from cli.formatters import format_table, format_for_claude
+
+
+def _sample_sessions():
+    return [
+        {
+            "uuid": "abc12345-1234-1234-1234-123456789012",
+            "slug": "happy-coding-turing",
+            "git_branch": "feat/1610",
+            "start_time": "2026-03-15T10:00:00+00:00",
+            "duration_seconds": 2520.0,
+            "message_count": 45,
+            "total_cost": 1.25,
+            "initial_prompt": "Vamos criar um plano para refatorar o auth",
+            "session_titles": "Refactor auth middleware",
+            "skills": "ralph-loop, tlc-spec-driven",
+            "tools": "Bash(10), Read(25), Edit(8)",
+            "project_path": "/home/user/my-project",
+        }
+    ]
+
+
+def test_format_table_returns_string():
+    result = format_table(_sample_sessions())
+    assert isinstance(result, str)
+    assert "feat/1610" in result
+    assert "abc123" in result
+
+
+def test_format_for_claude_returns_markdown():
+    result = format_for_claude(_sample_sessions())
+    assert "## Session" in result
+    assert "feat/1610" in result
+    assert "ralph-loop" in result
+    assert "Refactor auth middleware" in result
+
+
+def test_format_for_claude_empty_list():
+    result = format_for_claude([])
+    assert "No sessions found" in result
+
+
+def test_format_table_empty_list():
+    result = format_table([])
+    assert "No sessions found" in result

--- a/api/tests/test_cli_search.py
+++ b/api/tests/test_cli_search.py
@@ -1,0 +1,138 @@
+"""Tests for karma search command."""
+import pytest
+import sqlite3
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+
+@pytest.fixture
+def sample_db(tmp_path):
+    """Create a temporary SQLite database with sample session data."""
+    db_file = tmp_path / "metadata.db"
+    conn = sqlite3.connect(str(db_file))
+    conn.executescript("""
+        CREATE TABLE sessions (
+            uuid TEXT PRIMARY KEY,
+            slug TEXT,
+            project_encoded_name TEXT NOT NULL,
+            project_path TEXT,
+            start_time TEXT,
+            end_time TEXT,
+            message_count INTEGER DEFAULT 0,
+            duration_seconds REAL,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cache_creation_tokens INTEGER DEFAULT 0,
+            cache_read_tokens INTEGER DEFAULT 0,
+            total_cost REAL DEFAULT 0,
+            initial_prompt TEXT,
+            git_branch TEXT,
+            models_used TEXT,
+            session_titles TEXT,
+            is_continuation_marker INTEGER DEFAULT 0,
+            was_compacted INTEGER DEFAULT 0,
+            compaction_count INTEGER DEFAULT 0,
+            file_snapshot_count INTEGER DEFAULT 0,
+            subagent_count INTEGER DEFAULT 0,
+            jsonl_mtime REAL NOT NULL,
+            jsonl_size INTEGER DEFAULT 0,
+            session_source TEXT,
+            source_encoded_name TEXT,
+            indexed_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE TABLE session_tools (
+            session_uuid TEXT NOT NULL,
+            tool_name TEXT NOT NULL,
+            count INTEGER DEFAULT 1,
+            PRIMARY KEY (session_uuid, tool_name)
+        );
+        CREATE TABLE session_skills (
+            session_uuid TEXT NOT NULL,
+            skill_name TEXT NOT NULL,
+            invocation_source TEXT NOT NULL DEFAULT 'skill_tool',
+            count INTEGER DEFAULT 1,
+            PRIMARY KEY (session_uuid, skill_name, invocation_source)
+        );
+        CREATE VIRTUAL TABLE sessions_fts USING fts5(
+            uuid, slug, initial_prompt, session_titles, project_path,
+            content=sessions, content_rowid=rowid
+        );
+    """)
+    conn.execute("""
+        INSERT INTO sessions (uuid, slug, project_encoded_name, project_path,
+            start_time, duration_seconds, message_count, total_cost,
+            initial_prompt, git_branch, session_titles, jsonl_mtime)
+        VALUES ('aaaa-1111', 'happy-turing', '-home-user-project',
+            '/home/user/project',
+            '2026-03-15T10:00:00+00:00', 2520, 45, 1.25,
+            'Vamos criar um plano para refatorar', 'APR-1610-feature',
+            'Refactor auth', 1710500000)
+    """)
+    conn.execute("""
+        INSERT INTO sessions (uuid, slug, project_encoded_name, project_path,
+            start_time, duration_seconds, message_count, total_cost,
+            initial_prompt, git_branch, session_titles, jsonl_mtime)
+        VALUES ('bbbb-2222', 'cool-beaver', '-home-user-project',
+            '/home/user/project',
+            '2026-03-15T14:00:00+00:00', 1800, 30, 0.80,
+            'Fix bug no login', 'main',
+            'Fix login bug', 1710500000)
+    """)
+    conn.execute("INSERT INTO session_tools VALUES ('aaaa-1111', 'Bash', 10)")
+    conn.execute("INSERT INTO session_tools VALUES ('aaaa-1111', 'Read', 25)")
+    conn.execute("INSERT INTO session_skills VALUES ('aaaa-1111', 'ralph-loop', 'skill_tool', 1)")
+    conn.execute("""
+        INSERT INTO sessions_fts(rowid, uuid, slug, initial_prompt, session_titles, project_path)
+        SELECT rowid, uuid, slug, initial_prompt, session_titles, project_path FROM sessions
+    """)
+    conn.commit()
+    conn.close()
+    return db_file
+
+
+def test_search_by_branch(sample_db):
+    runner = CliRunner()
+    with patch("cli.db.DB_PATH", sample_db):
+        result = runner.invoke(cli, ["search", "--branch", "1610"])
+    assert result.exit_code == 0
+    assert "aaaa" in result.output
+    assert "bbbb" not in result.output
+
+
+def test_search_by_date(sample_db):
+    runner = CliRunner()
+    with patch("cli.db.DB_PATH", sample_db):
+        result = runner.invoke(cli, ["search", "--date", "2026-03-15"])
+    assert result.exit_code == 0
+    assert "aaaa" in result.output
+    assert "bbbb" in result.output
+
+
+def test_search_by_keyword(sample_db):
+    runner = CliRunner()
+    with patch("cli.db.DB_PATH", sample_db):
+        result = runner.invoke(cli, ["search", "--keyword", "refatorar"])
+    assert result.exit_code == 0
+    assert "aaaa" in result.output
+    assert "bbbb" not in result.output
+
+
+def test_search_for_claude_output(sample_db):
+    runner = CliRunner()
+    with patch("cli.db.DB_PATH", sample_db):
+        result = runner.invoke(cli, ["search", "--branch", "1610", "--for-claude"])
+    assert result.exit_code == 0
+    assert "## Session" in result.output
+    assert "ralph-loop" in result.output
+    assert "Bash(10)" in result.output
+
+
+def test_search_no_results(sample_db):
+    runner = CliRunner()
+    with patch("cli.db.DB_PATH", sample_db):
+        result = runner.invoke(cli, ["search", "--branch", "nonexistent"])
+    assert result.exit_code == 0
+    assert "No sessions found" in result.output

--- a/api/tests/test_cli_sessions.py
+++ b/api/tests/test_cli_sessions.py
@@ -1,0 +1,108 @@
+"""Tests for karma sessions get command."""
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from cli.main import cli
+
+
+@pytest.fixture
+def sample_db(tmp_path):
+    """Create a temporary SQLite database with a sample session."""
+    db_file = tmp_path / "metadata.db"
+    conn = sqlite3.connect(str(db_file))
+    conn.executescript("""
+        CREATE TABLE sessions (
+            uuid TEXT PRIMARY KEY,
+            slug TEXT,
+            project_encoded_name TEXT NOT NULL,
+            project_path TEXT,
+            start_time TEXT,
+            end_time TEXT,
+            message_count INTEGER DEFAULT 0,
+            duration_seconds REAL,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cache_creation_tokens INTEGER DEFAULT 0,
+            cache_read_tokens INTEGER DEFAULT 0,
+            total_cost REAL DEFAULT 0,
+            initial_prompt TEXT,
+            git_branch TEXT,
+            models_used TEXT,
+            session_titles TEXT,
+            is_continuation_marker INTEGER DEFAULT 0,
+            was_compacted INTEGER DEFAULT 0,
+            compaction_count INTEGER DEFAULT 0,
+            file_snapshot_count INTEGER DEFAULT 0,
+            subagent_count INTEGER DEFAULT 0,
+            jsonl_mtime REAL NOT NULL,
+            jsonl_size INTEGER DEFAULT 0,
+            session_source TEXT,
+            source_encoded_name TEXT,
+            indexed_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE TABLE session_tools (
+            session_uuid TEXT NOT NULL,
+            tool_name TEXT NOT NULL,
+            count INTEGER DEFAULT 1,
+            PRIMARY KEY (session_uuid, tool_name)
+        );
+        CREATE TABLE session_skills (
+            session_uuid TEXT NOT NULL,
+            skill_name TEXT NOT NULL,
+            invocation_source TEXT NOT NULL DEFAULT 'skill_tool',
+            count INTEGER DEFAULT 1,
+            PRIMARY KEY (session_uuid, skill_name, invocation_source)
+        );
+    """)
+    conn.execute("""
+        INSERT INTO sessions (uuid, slug, project_encoded_name, project_path,
+            start_time, duration_seconds, message_count, total_cost,
+            initial_prompt, git_branch, session_titles, jsonl_mtime)
+        VALUES ('aaaa-1111-2222-3333', 'happy-turing', '-home-user-project',
+            '/home/user/project',
+            '2026-03-15T10:00:00+00:00', 2520, 45, 1.25,
+            'Vamos criar um plano', 'feat/1610',
+            'Refactor auth', 1710500000)
+    """)
+    conn.execute("INSERT INTO session_tools VALUES ('aaaa-1111-2222-3333', 'Read', 25)")
+    conn.execute("INSERT INTO session_skills VALUES ('aaaa-1111-2222-3333', 'ralph-loop', 'skill_tool', 1)")
+    conn.commit()
+    conn.close()
+    return db_file
+
+
+def test_sessions_get_metadata(sample_db):
+    runner = CliRunner()
+    with patch("cli.db.DB_PATH", sample_db):
+        result = runner.invoke(cli, ["sessions", "get", "aaaa-1111-2222-3333"])
+    assert result.exit_code == 0
+    assert "aaaa" in result.output
+
+
+def test_sessions_get_for_claude(sample_db):
+    runner = CliRunner()
+    with patch("cli.db.DB_PATH", sample_db):
+        result = runner.invoke(cli, ["sessions", "get", "aaaa-1111-2222-3333", "--for-claude"])
+    assert result.exit_code == 0
+    assert "## Session" in result.output
+    assert "ralph-loop" in result.output
+
+
+def test_sessions_get_not_found(sample_db):
+    runner = CliRunner()
+    with patch("cli.db.DB_PATH", sample_db):
+        result = runner.invoke(cli, ["sessions", "get", "nonexistent"])
+    assert result.exit_code == 0
+    assert "not found" in result.output.lower()
+
+
+def test_sessions_get_partial_uuid(sample_db):
+    """Should find session by partial UUID prefix."""
+    runner = CliRunner()
+    with patch("cli.db.DB_PATH", sample_db):
+        result = runner.invoke(cli, ["sessions", "get", "aaaa-1111"])
+    assert result.exit_code == 0
+    assert "aaaa" in result.output

--- a/api/tests/test_session_title_cache_pending.py
+++ b/api/tests/test_session_title_cache_pending.py
@@ -1,0 +1,191 @@
+"""
+Unit tests for SessionTitleCache — pending titles (offline hook fallback).
+
+Covers _load_pending_titles and the integration with _build_from_jsonl.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from services.session_title_cache import SessionTitleCache, TitleEntry  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _load_pending_titles
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPendingTitles:
+    def test_returns_empty_when_dir_missing(self, tmp_path: Path):
+        with patch("services.session_title_cache.settings") as mock_settings:
+            mock_settings.karma_base = tmp_path / "nonexistent"
+            result = SessionTitleCache._load_pending_titles()
+        assert result == {}
+
+    def test_reads_txt_files(self, tmp_path: Path):
+        pending_dir = tmp_path / "session-titles"
+        pending_dir.mkdir()
+        (pending_dir / "uuid-abc.txt").write_text("Extract PDF to Excel")
+        (pending_dir / "uuid-def.txt").write_text("Fix login bug")
+
+        with patch("services.session_title_cache.settings") as mock_settings:
+            mock_settings.karma_base = tmp_path
+            result = SessionTitleCache._load_pending_titles()
+
+        assert result["uuid-abc"] == "Extract PDF to Excel"
+        assert result["uuid-def"] == "Fix login bug"
+
+    def test_skips_empty_files(self, tmp_path: Path):
+        pending_dir = tmp_path / "session-titles"
+        pending_dir.mkdir()
+        (pending_dir / "empty-uuid.txt").write_text("   ")
+
+        with patch("services.session_title_cache.settings") as mock_settings:
+            mock_settings.karma_base = tmp_path
+            result = SessionTitleCache._load_pending_titles()
+
+        assert "empty-uuid" not in result
+
+    def test_skips_unreadable_files(self, tmp_path: Path):
+        pending_dir = tmp_path / "session-titles"
+        pending_dir.mkdir()
+        txt = pending_dir / "bad-uuid.txt"
+        txt.write_text("A title")
+        txt.chmod(0o000)
+
+        with patch("services.session_title_cache.settings") as mock_settings:
+            mock_settings.karma_base = tmp_path
+            result = SessionTitleCache._load_pending_titles()
+
+        # Should not raise, and bad file should be absent
+        assert "bad-uuid" not in result
+
+        txt.chmod(0o644)  # restore for cleanup
+
+
+# ---------------------------------------------------------------------------
+# set_title — also writes pending-titles txt
+# ---------------------------------------------------------------------------
+
+
+class TestSetTitleWritesPendingFile:
+    def _make_cache_and_project(self, tmp_path: Path):
+        project_dir = tmp_path / "projects" / "-home-user-repo"
+        project_dir.mkdir(parents=True)
+        jsonl = project_dir / "test-uuid.jsonl"
+        jsonl.write_text(
+            json.dumps({"type": "user", "message": {"role": "user", "content": "hello"}}) + "\n"
+        )
+        return project_dir, jsonl
+
+    def test_set_title_writes_txt(self, tmp_path: Path):
+        project_dir, jsonl = self._make_cache_and_project(tmp_path)
+        cache_dir = tmp_path / "cache" / "titles"
+        cache_dir.mkdir(parents=True)
+
+        with patch("services.session_title_cache.settings") as mock_settings:
+            mock_settings.projects_dir = tmp_path / "projects"
+            mock_settings.karma_base = tmp_path
+            mock_settings.use_sqlite = False
+
+            tc = SessionTitleCache()
+            tc.set_title("-home-user-repo", "test-uuid", "My New Title")
+
+        txt = tmp_path / "session-titles" / "test-uuid.txt"
+        assert txt.exists()
+        assert txt.read_text() == "My New Title"
+
+    def test_set_title_txt_oserror_does_not_raise(self, tmp_path: Path):
+        project_dir, jsonl = self._make_cache_and_project(tmp_path)
+
+        # Make karma_base a file so mkdir fails
+        fake_base = tmp_path / "not-a-dir"
+        fake_base.write_text("blocker")
+
+        with patch("services.session_title_cache.settings") as mock_settings:
+            mock_settings.projects_dir = tmp_path / "projects"
+            mock_settings.karma_base = fake_base
+            mock_settings.use_sqlite = False
+
+            tc = SessionTitleCache()
+            # Must not raise
+            tc.set_title("-home-user-repo", "test-uuid", "Title")
+
+
+# ---------------------------------------------------------------------------
+# _build_from_jsonl — picks up pending titles for sessions without summary
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFromJsonlUsesPendingTitles:
+    def _write_session(self, project_dir: Path, uuid: str) -> Path:
+        """Write a minimal JSONL with no summary entry."""
+        jsonl = project_dir / f"{uuid}.jsonl"
+        lines = [
+            json.dumps({"type": "user", "slug": "test-slug", "message": {"role": "user", "content": "help"}}),
+            json.dumps({"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "ok"}]}}),
+        ]
+        jsonl.write_text("\n".join(lines))
+        return jsonl
+
+    def test_pending_title_used_when_no_summary(self, tmp_path: Path):
+        project_dir = tmp_path / "projects" / "-home-user-repo"
+        project_dir.mkdir(parents=True)
+        uuid = "pending-session-uuid"
+        self._write_session(project_dir, uuid)
+
+        # Write a pending title
+        pending_dir = tmp_path / "session-titles"
+        pending_dir.mkdir()
+        (pending_dir / f"{uuid}.txt").write_text("Pending Generated Title")
+
+        with patch("services.session_title_cache.settings") as mock_settings:
+            mock_settings.projects_dir = tmp_path / "projects"
+            mock_settings.karma_base = tmp_path
+            mock_settings.use_sqlite = False
+
+            tc = SessionTitleCache()
+            # Bypass SessionIndex loading
+            with patch("services.session_title_cache.SessionIndex") as mock_index:
+                mock_index.load.return_value = None
+                data = tc._build_from_jsonl("-home-user-repo")
+
+        assert uuid in data
+        assert data[uuid].titles == ["Pending Generated Title"]
+
+    def test_summary_entry_takes_priority_over_pending(self, tmp_path: Path):
+        project_dir = tmp_path / "projects" / "-home-user-repo"
+        project_dir.mkdir(parents=True)
+        uuid = "summary-session-uuid"
+
+        # Write a JSONL with a summary entry
+        jsonl = project_dir / f"{uuid}.jsonl"
+        lines = [
+            json.dumps({"type": "user", "message": {"role": "user", "content": "help"}}),
+            json.dumps({"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "ok"}]}}),
+            json.dumps({"type": "summary", "summary": "Title From JSONL Summary"}),
+        ]
+        jsonl.write_text("\n".join(lines))
+
+        # Also write a pending title (should be ignored)
+        pending_dir = tmp_path / "session-titles"
+        pending_dir.mkdir()
+        (pending_dir / f"{uuid}.txt").write_text("Should Be Ignored")
+
+        with patch("services.session_title_cache.settings") as mock_settings:
+            mock_settings.projects_dir = tmp_path / "projects"
+            mock_settings.karma_base = tmp_path
+            mock_settings.use_sqlite = False
+
+            tc = SessionTitleCache()
+            with patch("services.session_title_cache.SessionIndex") as mock_index:
+                mock_index.load.return_value = None
+                data = tc._build_from_jsonl("-home-user-repo")
+
+        assert data[uuid].titles == ["Title From JSONL Summary"]

--- a/api/tests/test_session_title_generator.py
+++ b/api/tests/test_session_title_generator.py
@@ -1,0 +1,283 @@
+"""
+Unit tests for session_title_generator hook.
+
+Covers rate-limit detection, retry enqueueing, local title persistence,
+and fallback behaviour.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# The hook lives outside api/ — add it to the path.
+HOOKS_DIR = Path(__file__).parent.parent.parent / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+import session_title_generator as gen  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _is_rate_limit_error
+# ---------------------------------------------------------------------------
+
+
+class TestIsRateLimitError:
+    def test_detects_usage_limit(self):
+        assert gen._is_rate_limit_error("claude ai usage limit reached")
+
+    def test_detects_rate_limit(self):
+        assert gen._is_rate_limit_error("error: rate limit exceeded")
+
+    def test_detects_too_many_requests(self):
+        assert gen._is_rate_limit_error("too many requests, please retry")
+
+    def test_detects_quota_exceeded(self):
+        assert gen._is_rate_limit_error("quota exceeded for this billing period")
+
+    def test_detects_overloaded(self):
+        assert gen._is_rate_limit_error("api overloaded, try again later")
+
+    def test_does_not_match_generic_error(self):
+        assert not gen._is_rate_limit_error("connection refused")
+
+    def test_does_not_match_empty(self):
+        assert not gen._is_rate_limit_error("")
+
+    def test_case_insensitive(self):
+        assert gen._is_rate_limit_error("USAGE LIMIT")
+
+
+# ---------------------------------------------------------------------------
+# generate_title — rate-limit and timeout paths
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateTitleRateLimit:
+    """generate_title returns (None, 'rate_limited') when claude exits non-zero
+    with a rate-limit message in stderr."""
+
+    def _run_with_stderr(self, stderr_text: str, returncode: int = 1):
+        mock_result = MagicMock()
+        mock_result.returncode = returncode
+        mock_result.stdout = ""
+        mock_result.stderr = stderr_text
+
+        with patch("subprocess.run", return_value=mock_result):
+            return gen.generate_title("do something", "I did it", None)
+
+    def test_rate_limited_returns_none_and_source(self):
+        title, source = self._run_with_stderr("usage limit reached")
+        assert title is None
+        assert source == "rate_limited"
+
+    def test_non_rate_limit_error_falls_back_to_prompt(self):
+        title, source = self._run_with_stderr("unknown error", returncode=1)
+        assert source == "fallback"
+        assert title is not None
+
+    def test_timeout_returns_none_and_timeout_source(self):
+        import subprocess
+
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("claude", 30)):
+            title, source = gen.generate_title("do something", None, None)
+
+        assert title is None
+        assert source == "timeout"
+
+    def test_successful_haiku_response(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Extract PDF budget to Excel"
+        mock_result.stderr = ""
+
+        with patch("subprocess.run", return_value=mock_result):
+            title, source = gen.generate_title("extract pdf", "done", None)
+
+        assert title == "Extract PDF budget to Excel"
+        assert source == "haiku"
+
+    def test_git_context_skips_haiku(self):
+        """When git context is available, title comes from git without calling subprocess."""
+        with patch("subprocess.run") as mock_run:
+            title, source = gen.generate_title("anything", None, "abc1234 feat: add export button")
+
+        mock_run.assert_not_called()
+        assert source == "git"
+        assert "add export button" in title
+
+    def test_long_title_truncated_to_max_words(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "one two three four five six seven eight nine ten eleven"
+        mock_result.stderr = ""
+
+        with patch("subprocess.run", return_value=mock_result):
+            title, source = gen.generate_title("do something", None, None)
+
+        assert len(title.split()) <= gen.TITLE_MAX_WORDS
+
+
+# ---------------------------------------------------------------------------
+# enqueue_title_retry
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueTitleRetry:
+    def test_creates_retry_file(self, tmp_path: Path):
+        with patch.object(gen, "KARMA_BASE", tmp_path):
+            gen.enqueue_title_retry(
+                session_id="test-uuid-123",
+                transcript_path="/some/path.jsonl",
+                initial_prompt="extract pdf",
+                first_response="done",
+                cwd="/home/user/project",
+            )
+
+        retry_file = tmp_path / "title-retry" / "test-uuid-123.json"
+        assert retry_file.exists()
+
+        payload = json.loads(retry_file.read_text())
+        assert payload["session_id"] == "test-uuid-123"
+        assert payload["initial_prompt"] == "extract pdf"
+        assert payload["first_response"] == "done"
+        assert payload["cwd"] == "/home/user/project"
+
+    def test_none_first_response_stored(self, tmp_path: Path):
+        with patch.object(gen, "KARMA_BASE", tmp_path):
+            gen.enqueue_title_retry("uuid-abc", "/t.jsonl", "prompt", None, "/cwd")
+
+        payload = json.loads((tmp_path / "title-retry" / "uuid-abc.json").read_text())
+        assert payload["first_response"] is None
+
+    def test_oserror_does_not_raise(self, tmp_path: Path):
+        """enqueue_title_retry must never propagate OSError."""
+        read_only = tmp_path / "ro"
+        read_only.mkdir()
+        read_only.chmod(0o444)
+
+        with patch.object(gen, "KARMA_BASE", read_only):
+            # Should not raise
+            gen.enqueue_title_retry("uuid", "/t.jsonl", "prompt", None, "/cwd")
+
+
+# ---------------------------------------------------------------------------
+# save_title_locally
+# ---------------------------------------------------------------------------
+
+
+class TestSaveTitleLocally:
+    def test_writes_title_to_txt_file(self, tmp_path: Path):
+        with patch.object(gen, "PENDING_TITLES_DIR", tmp_path / "session-titles"):
+            gen.save_title_locally("my-uuid", "My Title")
+
+        txt = tmp_path / "session-titles" / "my-uuid.txt"
+        assert txt.exists()
+        assert txt.read_text() == "My Title"
+
+    def test_oserror_does_not_raise(self, tmp_path: Path):
+        read_only = tmp_path / "ro"
+        read_only.mkdir()
+        read_only.chmod(0o444)
+
+        with patch.object(gen, "PENDING_TITLES_DIR", read_only / "subdir"):
+            gen.save_title_locally("uuid", "Title")
+
+
+# ---------------------------------------------------------------------------
+# post_title — fallback on API failure
+# ---------------------------------------------------------------------------
+
+
+class TestPostTitle:
+    def test_saves_locally_when_api_unavailable(self, tmp_path: Path):
+        import urllib.error
+
+        with (
+            patch("urllib.request.urlopen", side_effect=urllib.error.URLError("refused")),
+            patch.object(gen, "PENDING_TITLES_DIR", tmp_path / "session-titles"),
+        ):
+            result = gen.post_title("uuid-offline", "Offline Title")
+
+        assert result is False
+        txt = tmp_path / "session-titles" / "uuid-offline.txt"
+        assert txt.exists()
+        assert txt.read_text() == "Offline Title"
+
+    def test_returns_true_on_success(self):
+        mock_response = MagicMock()
+        with patch("urllib.request.urlopen", return_value=mock_response):
+            result = gen.post_title("uuid-ok", "My Title")
+
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# main() integration — enqueue on rate_limited / timeout
+# ---------------------------------------------------------------------------
+
+
+class TestMainEnqueuesOnRateLimit:
+    def _make_minimal_jsonl(self, tmp_path: Path) -> Path:
+        jsonl = tmp_path / "session.jsonl"
+        lines = [
+            json.dumps({"type": "user", "message": {"role": "user", "content": "help me"}, "timestamp": "2026-01-01T00:00:00Z"}),
+            json.dumps({"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "sure"}]}}),
+        ]
+        jsonl.write_text("\n".join(lines))
+        return jsonl
+
+    def test_enqueues_when_rate_limited(self, tmp_path: Path):
+        jsonl = self._make_minimal_jsonl(tmp_path)
+        hook_input = json.dumps({
+            "session_id": "rate-uuid",
+            "transcript_path": str(jsonl),
+            "cwd": str(tmp_path),
+            "reason": "normal",
+        })
+
+        import subprocess
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "usage limit reached"
+
+        with (
+            patch("subprocess.run", return_value=mock_result),
+            patch.object(gen, "KARMA_BASE", tmp_path),
+            patch("sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.read.return_value = hook_input
+            gen.main()
+
+        retry_file = tmp_path / "title-retry" / "rate-uuid.json"
+        assert retry_file.exists()
+
+    def test_does_not_enqueue_on_fallback_error(self, tmp_path: Path):
+        jsonl = self._make_minimal_jsonl(tmp_path)
+        hook_input = json.dumps({
+            "session_id": "fallback-uuid",
+            "transcript_path": str(jsonl),
+            "cwd": str(tmp_path),
+            "reason": "normal",
+        })
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "some unknown error"
+
+        with (
+            patch("subprocess.run", return_value=mock_result),
+            patch.object(gen, "KARMA_BASE", tmp_path),
+            patch("sys.stdin") as mock_stdin,
+            patch.object(gen, "post_title", return_value=True),
+        ):
+            mock_stdin.read.return_value = hook_input
+            gen.main()
+
+        retry_file = tmp_path / "title-retry" / "fallback-uuid.json"
+        assert not retry_file.exists()

--- a/hooks/session_title_generator.py
+++ b/hooks/session_title_generator.py
@@ -95,6 +95,9 @@ def main():
 
     if title:
         post_title(session_id, title)
+    elif source in ("rate_limited", "timeout"):
+        # Enqueue for retry so the API can regenerate when limits reset
+        enqueue_title_retry(session_id, transcript_path, initial_prompt, first_response, cwd)
 
 
 def extract_session_context(transcript_path: str) -> Tuple[Optional[str], Optional[str]]:
@@ -216,7 +219,7 @@ Title:"""
             ["claude", "-p", prompt, "--model", "haiku", "--no-session-persistence", "--output-format", "text"],
             capture_output=True,
             text=True,
-            timeout=12,
+            timeout=30,
             env=env,
         )
 
@@ -228,7 +231,16 @@ Title:"""
                 title = " ".join(words[:TITLE_MAX_WORDS])
             return title, "haiku"
 
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        # Non-zero exit — check if it was a usage/rate limit error
+        stderr_lower = (result.stderr or "").lower()
+        if _is_rate_limit_error(stderr_lower):
+            return None, "rate_limited"
+
+    except subprocess.TimeoutExpired:
+        # Timeout likely means the system is under heavy load (e.g. active session)
+        # Return None so the caller can queue for retry rather than storing a bad title
+        return None, "timeout"
+    except (FileNotFoundError, OSError):
         pass
 
     # 3. Fallback: truncated initial prompt
@@ -236,6 +248,64 @@ Title:"""
     if len(initial_prompt) > 60:
         fallback += "..."
     return fallback, "fallback"
+
+
+_RATE_LIMIT_PHRASES = (
+    "usage limit",
+    "rate limit",
+    "too many requests",
+    "quota exceeded",
+    "overloaded",
+    "context window",
+)
+
+
+def _is_rate_limit_error(stderr: str) -> bool:
+    stderr_lower = stderr.lower()
+    return any(phrase in stderr_lower for phrase in _RATE_LIMIT_PHRASES)
+
+
+def enqueue_title_retry(
+    session_id: str,
+    transcript_path: str,
+    initial_prompt: str,
+    first_response: Optional[str],
+    cwd: str,
+) -> None:
+    """
+    Save session context to the retry queue so the API can regenerate the
+    title later (e.g. after a usage limit resets or system load drops).
+
+    Written to ~/.claude_karma/title-retry/{uuid}.json.
+    """
+    try:
+        retry_dir = KARMA_BASE / "title-retry"
+        retry_dir.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "session_id": session_id,
+            "transcript_path": transcript_path,
+            "initial_prompt": initial_prompt,
+            "first_response": first_response,
+            "cwd": cwd,
+        }
+        (retry_dir / f"{session_id}.json").write_text(
+            json.dumps(payload, ensure_ascii=False), encoding="utf-8"
+        )
+    except OSError:
+        pass
+
+
+KARMA_BASE = Path(os.path.expanduser("~/.claude_karma"))
+PENDING_TITLES_DIR = KARMA_BASE / "session-titles"
+
+
+def save_title_locally(session_id: str, title: str) -> None:
+    """Save title to a local file as fallback when API is unavailable."""
+    try:
+        PENDING_TITLES_DIR.mkdir(parents=True, exist_ok=True)
+        (PENDING_TITLES_DIR / f"{session_id}.txt").write_text(title, encoding="utf-8")
+    except OSError:
+        pass
 
 
 def post_title(session_id: str, title: str) -> bool:
@@ -256,6 +326,8 @@ def post_title(session_id: str, title: str) -> bool:
         urllib.request.urlopen(req, timeout=5)
         return True
     except (urllib.error.URLError, OSError):
+        # API unavailable — persist locally so the cache can pick it up later
+        save_title_locally(session_id, title)
         return False
 
 

--- a/karma-search/SKILL.md
+++ b/karma-search/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: karma-search
+description: Search and retrieve context from past Claude Code sessions using the karma CLI. Use this skill WHENEVER the user asks about previous work, what was done on a branch, past sessions, previous conversations, session history, or wants to recall what happened in a specific timeframe, project, or feature. Also trigger when the user references a branch name, date, or keyword in the context of past work (e.g., "what did we do on branch X", "yesterday's session", "when did we use ralph-loop"). This skill is the bridge between past session data and current context — if the user's question requires knowledge from a previous session, use this skill.
+---
+
+# Karma Search — Session Context Retrieval
+
+Retrieve context from past Claude Code sessions using the `karma` CLI, which reads directly from the SQLite index at `~/.claude_karma/metadata.db`. No server needed.
+
+## When to Use
+
+- User asks about past work: "what did we do on branch X?", "what happened yesterday?"
+- User references a branch, date, or feature from a previous session
+- User wants to recall decisions, plans, or code changes from earlier sessions
+- User asks to compare work across sessions or branches
+- You need context from a previous session to inform current work
+
+## Workflow
+
+### Step 1: Search for relevant sessions
+
+Extract search criteria from the user's message and run the appropriate search. Always use `--for-claude` for structured output you can analyze.
+
+```bash
+# By branch (most common — partial match works)
+karma search --branch 1610 --for-claude
+
+# By date
+karma search --date 2026-03-15 --for-claude
+
+# By keyword (full-text search in prompts and titles)
+karma search --keyword "refactor auth" --for-claude
+
+# By skill used
+karma search --skill ralph-loop --for-claude
+
+# Combine filters
+karma search --branch 1610 --date 2026-03-12 --for-claude
+```
+
+**Choosing filters:** Start broad — prefer `--branch` alone over combining multiple filters. You can narrow down after seeing results. The goal is to give yourself enough context to answer the user's question, not to find one exact session.
+
+### Step 2: Analyze the search results
+
+Read the output and identify which sessions are relevant to the user's question. The `--for-claude` output includes:
+- Session title and initial prompt
+- Branch name and date
+- Duration, message count, and cost
+- Skills and tools used
+- Full UUID (for drilling into specific sessions)
+
+Often this metadata alone is enough to answer the user's question. If not, proceed to Step 3.
+
+### Step 3: Get full session content (only if needed)
+
+If the metadata doesn't provide enough detail, retrieve the cleaned conversation content for specific sessions:
+
+```bash
+karma sessions get <uuid> --content --for-claude
+```
+
+This calls `clean-session.py` internally, which strips noise (tool_use, tool_result, thinking blocks, progress records) and returns only the actual conversation text — keeping token usage efficient.
+
+**Use partial UUIDs** — the first 8 characters are usually enough:
+
+```bash
+karma sessions get 180c170c --content --for-claude
+```
+
+### Step 4: Synthesize and respond
+
+Combine the session context with your understanding of the user's question. Present findings in a clear, structured way. Reference specific sessions when relevant.
+
+## Command Reference
+
+| Command | Purpose |
+|---------|---------|
+| `karma search --branch <name>` | Find sessions by branch (partial match) |
+| `karma search --date <YYYY-MM-DD>` | Find sessions by date |
+| `karma search --keyword <text>` | Full-text search in prompts/titles |
+| `karma search --skill <name>` | Find sessions that used a specific skill |
+| `karma search --limit <N>` | Limit results (default: 50) |
+| `karma sessions get <uuid>` | Get session metadata |
+| `karma sessions get <uuid> --content` | Get metadata + cleaned conversation |
+| `--for-claude` | Add to any command for structured markdown output |
+
+## Tips
+
+- **Start broad, narrow later.** `--branch 1610` is better than `--branch 1610 --skill X --date Y` as a first query — you might miss relevant context with overly specific filters.
+- **Use `--content` sparingly.** Full conversation content can be large. Only fetch it for sessions you've identified as relevant from the search results.
+- **Multiple sessions are normal.** A single feature often spans many sessions. Scan all of them for a complete picture before synthesizing.
+- **Branch names are partial matches.** `--branch 1610` matches `APR-1610-feature-name`, `fix/1610-bug`, etc.


### PR DESCRIPTION
## Problem

Sessions were displaying random slugs (e.g. `generic-crafting-karp`) instead of meaningful titles. There were two independent root causes:

**1. API not running at session end**

The `session_title_generator.py` hook fires on `SessionEnd` and POSTs the generated title to `http://localhost:8000`. If the API is not running at that moment, the POST fails and the title is silently lost — no local fallback existed. The session then permanently displayed its random slug.

**2. Rate limit / timeout during Haiku generation**

When the `claude -p` subprocess failed due to a usage/rate limit (or timed out — likely because a Claude Code session was already consuming resources), the hook fell through to a generic fallback that stored the raw truncated initial prompt as the title. This produced display names like `/home/user/Downloads/file.pdf Extract...` — worse than the slug in many cases.

The Haiku subprocess timeout was also set to 12s, which proved insufficient when Claude Code was already running.

## Changes

### `hooks/session_title_generator.py`

- **Rate-limit detection**: inspect `stderr` after a non-zero exit for known phrases (`usage limit`, `rate limit`, `too many requests`, `quota exceeded`, `overloaded`). Made case-insensitive.
- **Retry queue**: on rate-limit or timeout, write session context to `~/.claude_karma/title-retry/{uuid}.json` instead of storing a bad fallback title.
- **Local persistence fallback**: when the API POST fails (`URLError`), persist the title to `~/.claude_karma/session-titles/{uuid}.txt` so it is recovered when the API comes back up.
- **Timeout increased**: Haiku subprocess timeout raised from 12s → 30s.

### `api/services/session_title_cache.py`

- **`_load_pending_titles()`**: reads `~/.claude_karma/session-titles/*.txt` files written by the hook when the API was offline. Returns a `{uuid: title}` dict.
- **`_build_from_jsonl()`**: integrates pending titles as a fallback source after JSONL summary entries and `sessions-index.json` summaries (existing sources keep priority).
- **`set_title()`**: also writes to the pending-titles `.txt` file for consistency when SQLite is not enabled, ensuring the title survives a cache rebuild.

### `api/routers/sessions.py`

- **`POST /sessions/retry-titles`**: processes the `title-retry` queue — attempts Haiku generation for each queued session and removes the file on success. Leaves the file untouched on failure (rate limit still active) so it will be retried on the next API restart.
- **`_resolve_encoded_name(uuid)`**: helper to look up the project encoded name for a session.
- **`_persist_title_sqlite(uuid, title)`**: helper to update `session_titles` in SQLite (extracted from the existing `set_session_title` handler to avoid duplication).

### `api/main.py`

- Processes the retry queue in a **background daemon thread at startup** so sessions queued while the rate limit was active are retried automatically once the API comes back up and the limit has reset.

## Tests

31 new tests across two files, all passing:

**`api/tests/test_session_title_generator.py`** (23 tests)
- `_is_rate_limit_error()`: all phrase variants, case insensitivity, false positives
- `generate_title()`: rate-limited path, timeout path, successful Haiku, git context short-circuits subprocess, word truncation
- `enqueue_title_retry()`: correct JSON payload, `None` first_response, silent OSError
- `save_title_locally()`: writes txt file, silent OSError
- `post_title()`: saves locally on API failure, returns True on success
- `main()` integration: enqueues on rate-limit, does not enqueue on generic fallback

**`api/tests/test_session_title_cache_pending.py`** (8 tests)
- `_load_pending_titles()`: missing dir, reads files, skips empty, skips unreadable
- `set_title()`: writes txt alongside disk cache, handles OSError
- `_build_from_jsonl()`: uses pending title when no summary, JSONL summary takes priority

## Test plan

- [ ] End a session while the API is offline → check `~/.claude_karma/session-titles/{uuid}.txt` is created
- [ ] Start the API → confirm the startup log shows titles processed from retry queue
- [ ] End a session while at the usage limit → check `~/.claude_karma/title-retry/{uuid}.json` is created
- [ ] Reset limit, restart API → confirm session now shows a generated title
- [ ] `POST /sessions/retry-titles` → returns `{"processed": N, "failed": 0, "skipped": 0}`
- [ ] Normal session end with API running → behaviour unchanged, title set via existing POST flow
- [ ] Run `pytest api/tests/test_session_title_generator.py api/tests/test_session_title_cache_pending.py` → 31 passed