### PR TITLE
Extract titles from custom-title JSONL entries + one-command dev script

### DIFF
--- a/api/models/compaction_detector.py
+++ b/api/models/compaction_detector.py
@@ -73,6 +73,7 @@ class CompactionDetector:
         from .message import (
             AssistantMessage,
             CompactBoundaryMessage,
+            CustomTitleMessage,
             SessionTitleMessage,
             UserMessage,
         )
@@ -104,6 +105,11 @@ class CompactionDetector:
                     self.project_context_summaries.append(msg.summary)
                 if msg.leaf_uuid:
                     self.project_context_leaf_uuids.append(msg.leaf_uuid)
+
+        # Handle CustomTitleMessage - user-set titles via /title command
+        if isinstance(msg, CustomTitleMessage):
+            if msg.custom_title:
+                self.session_titles.append(msg.custom_title)
 
         self.message_index += 1
         self.total_message_count += 1

--- a/api/models/message.py
+++ b/api/models/message.py
@@ -273,6 +273,31 @@ class SessionTitleMessage(BaseModel):
     )
 
 
+class CustomTitleMessage(BaseModel):
+    """
+    User-set session title via Claude Code's /title command.
+
+    Newer JSONL format for user-driven session renames (distinct from the
+    auto-generated SessionTitleMessage `summary` type). These represent user
+    intent — worth surfacing in title search.
+
+    Structure:
+    {
+      "type": "custom-title",
+      "customTitle": "Title text",
+      "sessionId": "uuid"
+    }
+    """
+
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
+
+    type: Literal["custom-title"] = "custom-title"
+    custom_title: str = Field(..., alias="customTitle", description="User-set title text")
+    session_id: Optional[str] = Field(
+        default=None, alias="sessionId", description="Session UUID this title applies to"
+    )
+
+
 class CompactBoundaryMessage(BaseModel):
     """
     Compact boundary message indicating true context compaction.
@@ -450,6 +475,7 @@ Message = Union[
     AssistantMessage,
     FileHistorySnapshot,
     SessionTitleMessage,
+    CustomTitleMessage,
     CompactBoundaryMessage,
     QueueOperationMessage,
     ProgressMessage,
@@ -462,6 +488,7 @@ _MESSAGE_PARSERS: Dict[str, Callable[[Dict[str, Any]], Message]] = {
     "assistant": AssistantMessage.model_validate,
     "file-history-snapshot": FileHistorySnapshot.model_validate,
     "summary": SessionTitleMessage.model_validate,
+    "custom-title": CustomTitleMessage.model_validate,
     "queue-operation": QueueOperationMessage.model_validate,
     "progress": ProgressMessage.model_validate,
 }

--- a/api/services/session_title_cache.py
+++ b/api/services/session_title_cache.py
@@ -556,6 +556,12 @@ class SessionTitleCache:
                     if isinstance(summary_text, str) and summary_text:
                         titles.append(summary_text)
 
+                # Capture user-set titles from /title command (newer Claude Code format)
+                if msg_type == "custom-title":
+                    custom_title = data.get("customTitle")
+                    if isinstance(custom_title, str) and custom_title:
+                        titles.append(custom_title)
+
         return titles, slug
 
     # -------------------------------------------------------------------------

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -893,3 +893,29 @@ select:focus {
 	color: var(--bg-base);
 	border-color: var(--accent);
 }
+
+/* ============================================
+   TAB COUNT BADGE (shared across tabbed lists)
+   ============================================ */
+
+.tab-count {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 22px;
+	padding: 0 6px;
+	margin-left: 6px;
+	font-family: var(--font-mono);
+	font-size: 10px;
+	font-weight: 500;
+	font-variant-numeric: tabular-nums;
+	color: var(--text-muted);
+	background: var(--bg-muted);
+	border-radius: 999px;
+	line-height: 1.6;
+}
+
+[data-state='active'] .tab-count {
+	color: var(--accent);
+	background: var(--accent-subtle);
+}

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,160 +1,160 @@
 @import 'tailwindcss';
 
 @theme {
-	--font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-	--font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	--font-sans: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+	--font-serif: 'Instrument Serif', 'Cormorant Garamond', Georgia, 'Times New Roman', serif;
+	--font-mono: 'Geist Mono', 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 /* ============================================
-   DESIGN SYSTEM TOKENS
+   DESIGN SYSTEM — "ARCHIVE"
+   Editorial observability for Claude Code sessions.
+   Warm ink on warm paper. Single amber signature.
+   Instrument Serif italic for voice; Geist for structure;
+   Geist Mono for data. Grain overlays for paper warmth.
    ============================================ */
 
 :root {
 	/* Typography */
-	--font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-	--font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	--font-sans: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+	--font-serif: 'Instrument Serif', 'Cormorant Garamond', Georgia, 'Times New Roman', serif;
+	--font-mono: 'Geist Mono', 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
 
-	/* Light Mode Colors (Cool Slate Foundation) */
-	--bg-base: #ffffff;
-	--bg-subtle: #f8fafc;
-	--bg-muted: #f1f5f9;
+	/* Light Mode — cream paper, ink, single brass accent */
+	--bg-base: #f3ede1;
+	--bg-subtle: #ebe3d2;
+	--bg-muted: #dfd4bd;
 
-	--text-primary: #0f172a;
-	--text-secondary: #475569;
-	--text-muted: #64748b;
-	--text-faint: #94a3b8;
+	--text-primary: #1b1712;
+	--text-secondary: #47403a;
+	--text-muted: #766d60;
+	--text-faint: #a89d89;
 
-	--border: rgba(0, 0, 0, 0.08);
-	--border-subtle: rgba(0, 0, 0, 0.05);
+	--border: rgba(27, 23, 18, 0.11);
+	--border-subtle: rgba(27, 23, 18, 0.06);
+	--border-hover: rgba(27, 23, 18, 0.22);
 
-	/* Missing tokens (referenced but were undefined) */
 	--accent-primary: var(--accent);
-	--border-hover: rgba(0, 0, 0, 0.12);
 	--radius-xs: 2px;
-	--duration-normal: 300ms;
+	--duration-normal: 280ms;
 
-	/* RGB values for opacity control in gradients */
-	--accent-rgb: 124, 58, 237;
-	--success-rgb: 16, 185, 129;
-	--warning-rgb: 245, 158, 11;
-	--error-rgb: 239, 68, 68;
-	--info-rgb: 59, 130, 246;
+	--accent-rgb: 168, 124, 30;
+	--success-rgb: 90, 113, 64;
+	--warning-rgb: 168, 124, 30;
+	--error-rgb: 138, 58, 58;
+	--info-rgb: 58, 85, 120;
 
-	/* Accent (Violet - Claude brand) */
-	--accent: #7c3aed;
-	--accent-hover: #6d28d9;
-	--accent-subtle: rgba(124, 58, 237, 0.1);
-	--accent-muted: rgba(124, 58, 237, 0.05);
+	/* Accent — sulphur brass, the one signature */
+	--accent: #a87c1e;
+	--accent-hover: #876218;
+	--accent-subtle: rgba(168, 124, 30, 0.12);
+	--accent-muted: rgba(168, 124, 30, 0.06);
 
-	/* Semantic Colors */
-	--success: #10b981;
-	--success-subtle: rgba(16, 185, 129, 0.1);
+	/* Semantic — muted editorial palette */
+	--success: #5a7140;
+	--success-subtle: rgba(90, 113, 64, 0.12);
+	--error: #8a3a3a;
+	--error-subtle: rgba(138, 58, 58, 0.12);
+	--warning: #a06030;
+	--warning-subtle: rgba(160, 96, 48, 0.12);
+	--info: #3a5578;
+	--info-subtle: rgba(58, 85, 120, 0.12);
 
-	--error: #ef4444;
-	--error-subtle: rgba(239, 68, 68, 0.1);
+	/* Model Family — editorial inks */
+	--model-opus: #a87c1e;
+	--model-opus-subtle: rgba(168, 124, 30, 0.12);
+	--model-sonnet: #3a5578;
+	--model-sonnet-subtle: rgba(58, 85, 120, 0.12);
+	--model-haiku: #5a7140;
+	--model-haiku-subtle: rgba(90, 113, 64, 0.12);
 
-	--warning: #f59e0b;
-	--warning-subtle: rgba(245, 158, 11, 0.1);
+	/* Event Type Colors — editorial ink family */
+	--event-prompt: #3a5578;
+	--event-prompt-subtle: rgba(58, 85, 120, 0.16);
+	--event-tool: #5a7140;
+	--event-tool-subtle: rgba(90, 113, 64, 0.16);
+	--event-subagent: #63557b;
+	--event-subagent-subtle: rgba(99, 85, 123, 0.16);
+	--event-thinking: #a87c1e;
+	--event-thinking-subtle: rgba(168, 124, 30, 0.18);
+	--event-response: #5a5750;
+	--event-response-subtle: rgba(90, 87, 80, 0.16);
+	--event-todo: #7a4868;
+	--event-todo-subtle: rgba(122, 72, 104, 0.16);
+	--event-plan: #3a6868;
+	--event-plan-subtle: rgba(58, 104, 104, 0.16);
+	--event-builtin: #766d60;
+	--event-builtin-subtle: rgba(118, 109, 96, 0.16);
+	--event-command: #3a6868;
+	--event-command-subtle: rgba(58, 104, 104, 0.16);
 
-	--info: #3b82f6;
-	--info-subtle: rgba(59, 130, 246, 0.1);
-
-	/* Model Family Colors */
-	--model-opus: #7c3aed;
-	--model-opus-subtle: rgba(124, 58, 237, 0.1);
-	--model-sonnet: #3b82f6;
-	--model-sonnet-subtle: rgba(59, 130, 246, 0.1);
-	--model-haiku: #10b981;
-	--model-haiku-subtle: rgba(16, 185, 129, 0.1);
-
-	/* Event Type Colors */
-	--event-prompt: #2563eb;
-	--event-prompt-subtle: rgba(37, 99, 235, 0.18);
-	--event-tool: #059669;
-	--event-tool-subtle: rgba(5, 150, 105, 0.18);
-	--event-subagent: #7c3aed;
-	--event-subagent-subtle: rgba(124, 58, 237, 0.18);
-	--event-thinking: #d97706;
-	--event-thinking-subtle: rgba(217, 119, 6, 0.18);
-	--event-response: #475569;
-	--event-response-subtle: rgba(71, 85, 105, 0.18);
-	--event-todo: #6d28d9;
-	--event-todo-subtle: rgba(109, 40, 217, 0.18);
-	--event-plan: #0891b2;
-	--event-plan-subtle: rgba(8, 145, 178, 0.18);
-	--event-builtin: #64748b;
-	--event-builtin-subtle: rgba(100, 116, 139, 0.18);
-	--event-command: #14b8a6;
-	--event-command-subtle: rgba(20, 184, 166, 0.18);
-
-	/* Data Visualization Palette */
+	/* Data Visualization — ink palette */
 	--data-primary: var(--accent);
-	--data-secondary: var(--info);
-	--data-tertiary: var(--success);
-	--data-quaternary: var(--warning);
-	--data-quinary: var(--error);
+	--data-secondary: #3a5578;
+	--data-tertiary: #5a7140;
+	--data-quaternary: #a06030;
+	--data-quinary: #8a3a3a;
 
-	/* Navigation Card Colors (for icon backgrounds) */
-	--nav-blue: #3b82f6;
-	--nav-blue-subtle: rgba(59, 130, 246, 0.08);
-	--nav-green: #10b981;
-	--nav-green-subtle: rgba(16, 185, 129, 0.08);
-	--nav-orange: #f97316;
-	--nav-orange-subtle: rgba(249, 115, 22, 0.08);
-	--nav-purple: #8b5cf6;
-	--nav-purple-subtle: rgba(139, 92, 246, 0.08);
-	--nav-gray: #64748b;
-	--nav-gray-subtle: rgba(100, 116, 139, 0.08);
-	--nav-red: #f43f5e;
-	--nav-red-subtle: rgba(244, 63, 94, 0.08);
-	--nav-teal: #0891b2;
-	--nav-teal-subtle: rgba(8, 145, 178, 0.1);
-	--nav-yellow: #ca8a04;
-	--nav-yellow-subtle: rgba(202, 138, 4, 0.08);
-	--nav-violet: #db2777;
-	--nav-violet-subtle: rgba(219, 39, 119, 0.1);
-	--nav-indigo: #6366f1;
-	--nav-indigo-subtle: rgba(99, 102, 241, 0.1);
-	--nav-amber: #d97706;
-	--nav-amber-subtle: rgba(217, 119, 6, 0.08);
+	/* Navigation — pressed-ink palette (light) */
+	--nav-blue: #3a5578;
+	--nav-blue-subtle: rgba(58, 85, 120, 0.1);
+	--nav-green: #5a7140;
+	--nav-green-subtle: rgba(90, 113, 64, 0.1);
+	--nav-orange: #a06030;
+	--nav-orange-subtle: rgba(160, 96, 48, 0.1);
+	--nav-purple: #63557b;
+	--nav-purple-subtle: rgba(99, 85, 123, 0.1);
+	--nav-gray: #5a5750;
+	--nav-gray-subtle: rgba(90, 87, 80, 0.1);
+	--nav-red: #8a3a3a;
+	--nav-red-subtle: rgba(138, 58, 58, 0.1);
+	--nav-teal: #3a6868;
+	--nav-teal-subtle: rgba(58, 104, 104, 0.12);
+	--nav-yellow: #8a7230;
+	--nav-yellow-subtle: rgba(138, 114, 48, 0.1);
+	--nav-violet: #7a4868;
+	--nav-violet-subtle: rgba(122, 72, 104, 0.12);
+	--nav-indigo: #475088;
+	--nav-indigo-subtle: rgba(71, 80, 136, 0.12);
+	--nav-amber: #956a30;
+	--nav-amber-subtle: rgba(149, 106, 48, 0.1);
 
-	/* Live Session Status Background Tints (subtle card backgrounds) */
-	--status-starting-bg: rgba(139, 92, 246, 0.05);
-	--status-active-bg: rgba(16, 185, 129, 0.05);
-	--status-idle-bg: rgba(245, 158, 11, 0.05);
-	--status-waiting-bg: rgba(59, 130, 246, 0.05);
-	--status-stopped-bg: rgba(100, 116, 139, 0.03);
-	--status-ended-bg: rgba(148, 163, 184, 0.03);
-	--status-stale-bg: rgba(239, 68, 68, 0.05);
+	/* Live Session Status Background Tints (light) */
+	--status-starting-bg: rgba(99, 85, 123, 0.06);
+	--status-active-bg: rgba(90, 113, 64, 0.06);
+	--status-idle-bg: rgba(168, 124, 30, 0.07);
+	--status-waiting-bg: rgba(58, 85, 120, 0.06);
+	--status-stopped-bg: rgba(90, 87, 80, 0.04);
+	--status-ended-bg: rgba(90, 87, 80, 0.03);
+	--status-stale-bg: rgba(138, 58, 58, 0.06);
 
-	/* Subagent Type Colors (light mode - vibrant, high contrast) */
-	--subagent-explore: #0284c7;
-	--subagent-explore-subtle: rgba(2, 132, 199, 0.12);
-	--subagent-plan: #ca8a04;
-	--subagent-plan-subtle: rgba(202, 138, 4, 0.12);
-	--subagent-bash: #16a34a;
-	--subagent-bash-subtle: rgba(22, 163, 74, 0.12);
-	--subagent-default: #7c3aed;
-	--subagent-default-subtle: rgba(124, 58, 237, 0.12);
-	/* Claude Tax - internal overhead agents (warmup, cache priming) - rust orange */
-	--subagent-claude-tax: #c2410c;
-	--subagent-claude-tax-subtle: rgba(194, 65, 12, 0.12);
-	/* System Agents - auto-spawned by Claude Code for internal operations */
-	--subagent-acompact: #475569; /* Slate - context compaction/cleanup */
-	--subagent-acompact-subtle: rgba(71, 85, 105, 0.12);
-	--subagent-prompt-suggestion: #6366f1; /* Indigo - AI-powered suggestions */
-	--subagent-prompt-suggestion-subtle: rgba(99, 102, 241, 0.12);
-	/* OKLCH params for plugin identity colors (hue set per-plugin in JS) */
-	--plugin-l: 0.5;
-	--plugin-c: 0.14;
-	--plugin-l-subtle: 0.96;
+	/* Subagent Type Colors (light) */
+	--subagent-explore: #3a5578;
+	--subagent-explore-subtle: rgba(58, 85, 120, 0.12);
+	--subagent-plan: #8a7230;
+	--subagent-plan-subtle: rgba(138, 114, 48, 0.12);
+	--subagent-bash: #5a7140;
+	--subagent-bash-subtle: rgba(90, 113, 64, 0.12);
+	--subagent-default: #63557b;
+	--subagent-default-subtle: rgba(99, 85, 123, 0.12);
+	--subagent-claude-tax: #a06030;
+	--subagent-claude-tax-subtle: rgba(160, 96, 48, 0.12);
+	--subagent-acompact: #5a5750;
+	--subagent-acompact-subtle: rgba(90, 87, 80, 0.12);
+	--subagent-prompt-suggestion: #475088;
+	--subagent-prompt-suggestion-subtle: rgba(71, 80, 136, 0.12);
+
+	/* OKLCH params for plugin identity colors (light) */
+	--plugin-l: 0.45;
+	--plugin-c: 0.09;
+	--plugin-l-subtle: 0.94;
 	--plugin-c-subtle: 0.025;
 
-	/* Scope category colors (fixed) */
-	--scope-project: #d97706;
-	--scope-project-subtle: rgba(217, 119, 6, 0.12);
-	--scope-user: #0d9488;
-	--scope-user-subtle: rgba(13, 148, 136, 0.12);
+	/* Scope category colors (light) */
+	--scope-project: #a06030;
+	--scope-project-subtle: rgba(160, 96, 48, 0.12);
+	--scope-user: #3a6868;
+	--scope-user-subtle: rgba(58, 104, 104, 0.12);
 
 	/* Spacing (4px Grid) */
 	--spacing-1: 4px;
@@ -166,33 +166,243 @@
 	--spacing-8: 32px;
 	--spacing-12: 48px;
 
-	/* Border Radius (Sharp System) */
-	--radius-sm: 4px;
-	--radius-md: 6px;
-	--radius-lg: 8px;
+	/* Radii — slightly sharper for editorial feel */
+	--radius-sm: 3px;
+	--radius-md: 5px;
+	--radius-lg: 7px;
 
-	/* Extended Shadow System */
-	--shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
-	--shadow-md: 0 2px 8px rgba(0, 0, 0, 0.08);
-	--shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.12);
-	--shadow-elevated: 0 0 0 0.5px var(--border), 0 4px 12px rgba(0, 0, 0, 0.12);
+	/* Shadows — softer, warmer */
+	--shadow-sm: 0 1px 2px rgba(27, 23, 18, 0.06);
+	--shadow-md: 0 2px 10px rgba(27, 23, 18, 0.08);
+	--shadow-lg: 0 6px 24px rgba(27, 23, 18, 0.12);
+	--shadow-elevated: 0 0 0 0.5px var(--border), 0 6px 20px rgba(27, 23, 18, 0.1);
 
 	/* Animation */
-	--duration-fast: 150ms;
-	--duration-base: 200ms;
-	--ease: cubic-bezier(0.25, 1, 0.5, 1);
+	--duration-fast: 140ms;
+	--duration-base: 220ms;
+	--ease: cubic-bezier(0.22, 0.68, 0, 1);
 
-	/* Focus Ring (Keyboard Accessibility) */
+	/* Focus Ring */
 	--focus-ring-width: 2px;
 	--focus-ring-offset: 2px;
 	--focus-ring-color: var(--accent);
 }
 
 /* ============================================
-   KEYBOARD ACCESSIBILITY - FOCUS SYSTEM
+   DARK MODE — warm charcoal, candle-cream ink
    ============================================ */
 
-/* Global focus styles for interactive elements */
+:root[data-theme='dark'] {
+	--bg-base: #141210;
+	--bg-subtle: #1b1814;
+	--bg-muted: #24201a;
+
+	--text-primary: #f2ecde;
+	--text-secondary: #c5bda9;
+	--text-muted: #8e8676;
+	--text-faint: #5d564b;
+
+	--border: rgba(242, 236, 222, 0.08);
+	--border-subtle: rgba(242, 236, 222, 0.04);
+	--border-hover: rgba(242, 236, 222, 0.2);
+
+	--accent: #e8c547;
+	--accent-hover: #f3d660;
+	--accent-subtle: rgba(232, 197, 71, 0.14);
+	--accent-muted: rgba(232, 197, 71, 0.07);
+	--accent-primary: var(--accent);
+	--accent-rgb: 232, 197, 71;
+	--success-rgb: 160, 184, 106;
+	--warning-rgb: 232, 197, 71;
+	--error-rgb: 215, 136, 130;
+	--info-rgb: 124, 154, 209;
+
+	--success: #a0b86a;
+	--success-subtle: rgba(160, 184, 106, 0.16);
+	--error: #d78882;
+	--error-subtle: rgba(215, 136, 130, 0.16);
+	--warning: #e8c547;
+	--warning-subtle: rgba(232, 197, 71, 0.16);
+	--info: #7c9ad1;
+	--info-subtle: rgba(124, 154, 209, 0.16);
+
+	--model-opus: #e8c547;
+	--model-opus-subtle: rgba(232, 197, 71, 0.18);
+	--model-sonnet: #7c9ad1;
+	--model-sonnet-subtle: rgba(124, 154, 209, 0.18);
+	--model-haiku: #a0b86a;
+	--model-haiku-subtle: rgba(160, 184, 106, 0.18);
+
+	--event-prompt: #7c9ad1;
+	--event-prompt-subtle: rgba(124, 154, 209, 0.24);
+	--event-tool: #a0b86a;
+	--event-tool-subtle: rgba(160, 184, 106, 0.24);
+	--event-subagent: #b19ad1;
+	--event-subagent-subtle: rgba(177, 154, 209, 0.24);
+	--event-thinking: #e8c547;
+	--event-thinking-subtle: rgba(232, 197, 71, 0.24);
+	--event-response: #a39d8e;
+	--event-response-subtle: rgba(163, 157, 142, 0.24);
+	--event-todo: #c794b5;
+	--event-todo-subtle: rgba(199, 148, 181, 0.24);
+	--event-plan: #7ab5a8;
+	--event-plan-subtle: rgba(122, 181, 168, 0.24);
+	--event-builtin: #a39d8e;
+	--event-builtin-subtle: rgba(163, 157, 142, 0.24);
+	--event-command: #7ab5a8;
+	--event-command-subtle: rgba(122, 181, 168, 0.24);
+
+	--nav-blue: #7c9ad1;
+	--nav-blue-subtle: rgba(124, 154, 209, 0.12);
+	--nav-green: #a0b86a;
+	--nav-green-subtle: rgba(160, 184, 106, 0.12);
+	--nav-orange: #d69260;
+	--nav-orange-subtle: rgba(214, 146, 96, 0.12);
+	--nav-purple: #b19ad1;
+	--nav-purple-subtle: rgba(177, 154, 209, 0.12);
+	--nav-gray: #a39d8e;
+	--nav-gray-subtle: rgba(163, 157, 142, 0.1);
+	--nav-red: #d78882;
+	--nav-red-subtle: rgba(215, 136, 130, 0.12);
+	--nav-teal: #7ab5a8;
+	--nav-teal-subtle: rgba(122, 181, 168, 0.12);
+	--nav-yellow: #d1b76a;
+	--nav-yellow-subtle: rgba(209, 183, 106, 0.12);
+	--nav-violet: #c794b5;
+	--nav-violet-subtle: rgba(199, 148, 181, 0.12);
+	--nav-indigo: #8c93d6;
+	--nav-indigo-subtle: rgba(140, 147, 214, 0.12);
+	--nav-amber: #d6a362;
+	--nav-amber-subtle: rgba(214, 163, 98, 0.12);
+
+	--status-starting-bg: rgba(177, 154, 209, 0.07);
+	--status-active-bg: rgba(160, 184, 106, 0.07);
+	--status-idle-bg: rgba(232, 197, 71, 0.07);
+	--status-waiting-bg: rgba(124, 154, 209, 0.07);
+	--status-stopped-bg: rgba(163, 157, 142, 0.04);
+	--status-ended-bg: rgba(163, 157, 142, 0.03);
+	--status-stale-bg: rgba(215, 136, 130, 0.07);
+
+	--subagent-explore: #7c9ad1;
+	--subagent-explore-subtle: rgba(124, 154, 209, 0.18);
+	--subagent-plan: #d1b76a;
+	--subagent-plan-subtle: rgba(209, 183, 106, 0.18);
+	--subagent-bash: #a0b86a;
+	--subagent-bash-subtle: rgba(160, 184, 106, 0.18);
+	--subagent-default: #b19ad1;
+	--subagent-default-subtle: rgba(177, 154, 209, 0.18);
+	--subagent-claude-tax: #d69260;
+	--subagent-claude-tax-subtle: rgba(214, 146, 96, 0.18);
+	--subagent-acompact: #a39d8e;
+	--subagent-acompact-subtle: rgba(163, 157, 142, 0.18);
+	--subagent-prompt-suggestion: #8c93d6;
+	--subagent-prompt-suggestion-subtle: rgba(140, 147, 214, 0.18);
+
+	--plugin-l: 0.78;
+	--plugin-c: 0.1;
+	--plugin-l-subtle: 0.22;
+	--plugin-c-subtle: 0.035;
+
+	--scope-project: #d69260;
+	--scope-project-subtle: rgba(214, 146, 96, 0.18);
+	--scope-user: #7ab5a8;
+	--scope-user-subtle: rgba(122, 181, 168, 0.18);
+
+	--shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.35);
+	--shadow-md: 0 2px 10px rgba(0, 0, 0, 0.45);
+	--shadow-lg: 0 6px 24px rgba(0, 0, 0, 0.55);
+	--shadow-elevated: 0 0 0 0.5px var(--border), 0 6px 20px rgba(0, 0, 0, 0.5);
+}
+
+/* ============================================
+   BASE — paper, ink, grain
+   ============================================ */
+
+html {
+	background-color: var(--bg-base);
+}
+
+body {
+	font-family: var(--font-sans);
+	background-color: var(--bg-base);
+	color: var(--text-primary);
+	font-variant-numeric: tabular-nums;
+	font-feature-settings: 'ss01', 'cv11';
+	-webkit-font-smoothing: antialiased;
+	text-rendering: optimizeLegibility;
+	min-height: 100vh;
+	/* Isolate so the grain pseudo-element at z-index:-1 lives in this
+	   stacking context without escaping to cover modals/popovers. */
+	isolation: isolate;
+}
+
+/* Subtle paper grain — lives behind body content, cannot trap fixed children.
+   opacity is low enough that the turbulence reads as texture, not static. */
+body::before {
+	content: '';
+	position: fixed;
+	inset: 0;
+	z-index: -1;
+	pointer-events: none;
+	opacity: 0.05;
+	mix-blend-mode: multiply;
+	background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 260 260' xmlns='http://www.w3.org/2000/svg'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+}
+
+:root[data-theme='dark'] body::before {
+	opacity: 0.07;
+	mix-blend-mode: screen;
+}
+
+/* ============================================
+   TYPOGRAPHY PRIMITIVES
+   ============================================ */
+
+.font-serif {
+	font-family: var(--font-serif);
+	letter-spacing: -0.01em;
+}
+
+.serif-display {
+	font-family: var(--font-serif);
+	font-style: italic;
+	letter-spacing: -0.02em;
+	line-height: 0.95;
+}
+
+.eyebrow {
+	font-family: var(--font-mono);
+	font-size: 10px;
+	text-transform: uppercase;
+	letter-spacing: 0.2em;
+	color: var(--text-muted);
+	font-weight: 500;
+}
+
+.rule {
+	height: 1px;
+	background: var(--border);
+}
+
+.rule-strong {
+	height: 1px;
+	background: var(--text-primary);
+	opacity: 0.9;
+}
+
+.dot {
+	display: inline-block;
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: currentColor;
+	flex-shrink: 0;
+}
+
+/* ============================================
+   FOCUS SYSTEM
+   ============================================ */
+
 a:focus-visible,
 button:focus-visible,
 [role='button']:focus-visible,
@@ -204,7 +414,6 @@ button:focus-visible,
 	border-radius: var(--radius-md);
 }
 
-/* Focus styles for form inputs - enhance existing border */
 input:focus,
 textarea:focus,
 select:focus {
@@ -213,7 +422,6 @@ select:focus {
 	box-shadow: 0 0 0 3px var(--accent-subtle) !important;
 }
 
-/* High contrast mode support */
 @media (forced-colors: active) {
 	a:focus-visible,
 	button:focus-visible,
@@ -224,7 +432,6 @@ select:focus {
 	}
 }
 
-/* Utility class for components needing explicit focus ring */
 .focus-ring {
 	outline: none;
 }
@@ -236,266 +443,28 @@ select:focus {
 }
 
 /* ============================================
-   DARK MODE TOKENS
+   MARKDOWN PREVIEW
    ============================================ */
 
-:root[data-theme='dark'] {
-	/* Background (dark slate) */
-	--bg-base: #0f1419;
-	--bg-subtle: #1a1f26;
-	--bg-muted: #242b35;
-
-	/* Text (soft off-white, easier on eyes) */
-	--text-primary: #e2e8f0;
-	--text-secondary: #a1a1aa;
-	--text-muted: #71717a;
-	--text-faint: #52525b;
-
-	/* Borders (white-based for dark bg) */
-	--border: rgba(255, 255, 255, 0.08);
-	--border-subtle: rgba(255, 255, 255, 0.05);
-	--border-hover: rgba(255, 255, 255, 0.15);
-
-	/* Accent (lighter for dark mode) */
-	--accent: #a78bfa;
-	--accent-hover: #c4b5fd;
-	--accent-subtle: rgba(167, 139, 250, 0.15);
-	--accent-muted: rgba(167, 139, 250, 0.08);
-	--accent-primary: var(--accent);
-
-	/* RGB values for dark mode */
-	--accent-rgb: 167, 139, 250;
-	--success-rgb: 52, 211, 153;
-	--warning-rgb: 251, 191, 36;
-	--error-rgb: 248, 113, 113;
-	--info-rgb: 96, 165, 250;
-
-	/* Semantic (adjusted for contrast) */
-	--success: #34d399;
-	--success-subtle: rgba(52, 211, 153, 0.15);
-	--error: #f87171;
-	--error-subtle: rgba(248, 113, 113, 0.15);
-	--warning: #fbbf24;
-	--warning-subtle: rgba(251, 191, 36, 0.15);
-	--info: #60a5fa;
-	--info-subtle: rgba(96, 165, 250, 0.15);
-
-	/* Model Colors (lighter for dark mode) */
-	--model-opus: #a78bfa;
-	--model-opus-subtle: rgba(167, 139, 250, 0.2);
-	--model-sonnet: #60a5fa;
-	--model-sonnet-subtle: rgba(96, 165, 250, 0.2);
-	--model-haiku: #34d399;
-	--model-haiku-subtle: rgba(52, 211, 153, 0.2);
-
-	/* Event Colors (lighter) */
-	--event-prompt: #60a5fa;
-	--event-prompt-subtle: rgba(96, 165, 250, 0.32);
-	--event-tool: #34d399;
-	--event-tool-subtle: rgba(52, 211, 153, 0.32);
-	--event-subagent: #a78bfa;
-	--event-subagent-subtle: rgba(167, 139, 250, 0.32);
-	--event-thinking: #fbbf24;
-	--event-thinking-subtle: rgba(251, 191, 36, 0.32);
-	--event-response: #94a3b8;
-	--event-response-subtle: rgba(148, 163, 184, 0.32);
-	--event-todo: #a78bfa;
-	--event-todo-subtle: rgba(167, 139, 250, 0.32);
-	--event-plan: #22d3ee;
-	--event-plan-subtle: rgba(34, 211, 238, 0.32);
-	--event-builtin: #94a3b8;
-	--event-builtin-subtle: rgba(148, 163, 184, 0.32);
-	--event-command: #2dd4bf;
-	--event-command-subtle: rgba(45, 212, 191, 0.32);
-
-	/* Navigation Colors */
-	--nav-blue: #60a5fa;
-	--nav-blue-subtle: rgba(96, 165, 250, 0.15);
-	--nav-green: #34d399;
-	--nav-green-subtle: rgba(52, 211, 153, 0.15);
-	--nav-orange: #fb923c;
-	--nav-orange-subtle: rgba(251, 146, 60, 0.15);
-	--nav-purple: #a78bfa;
-	--nav-purple-subtle: rgba(167, 139, 250, 0.15);
-	--nav-gray: #94a3b8;
-	--nav-gray-subtle: rgba(148, 163, 184, 0.15);
-	--nav-red: #fb7185;
-	--nav-red-subtle: rgba(251, 113, 133, 0.15);
-	--nav-teal: #22d3ee;
-	--nav-teal-subtle: rgba(34, 211, 238, 0.18);
-	--nav-yellow: #fbbf24;
-	--nav-yellow-subtle: rgba(251, 191, 36, 0.15);
-	--nav-violet: #f472b6;
-	--nav-violet-subtle: rgba(244, 114, 182, 0.18);
-	--nav-indigo: #818cf8;
-	--nav-indigo-subtle: rgba(129, 140, 248, 0.18);
-	--nav-amber: #fbbf24;
-	--nav-amber-subtle: rgba(251, 191, 36, 0.15);
-
-	/* Live Session Status Background Tints (dark mode - slightly higher opacity) */
-	--status-starting-bg: rgba(167, 139, 250, 0.08);
-	--status-active-bg: rgba(52, 211, 153, 0.08);
-	--status-idle-bg: rgba(251, 191, 36, 0.08);
-	--status-waiting-bg: rgba(96, 165, 250, 0.08);
-	--status-stopped-bg: rgba(148, 163, 184, 0.05);
-	--status-ended-bg: rgba(148, 163, 184, 0.04);
-	--status-stale-bg: rgba(248, 113, 113, 0.08);
-
-	/* Shadows (deeper for dark mode) */
-	--shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
-	--shadow-md: 0 2px 8px rgba(0, 0, 0, 0.4);
-	--shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.5);
-	--shadow-elevated: 0 0 0 0.5px var(--border), 0 4px 12px rgba(0, 0, 0, 0.4);
-
-	/* OKLCH params for plugin identity colors (dark mode) */
-	--plugin-l: 0.75;
-	--plugin-c: 0.13;
-	--plugin-l-subtle: 0.23;
-	--plugin-c-subtle: 0.04;
-
-	/* Scope category colors (dark mode) */
-	--scope-project: #fbbf24;
-	--scope-project-subtle: rgba(251, 191, 36, 0.2);
-	--scope-user: #2dd4bf;
-	--scope-user-subtle: rgba(45, 212, 191, 0.2);
-}
-
-/* System preference fallback */
-@media (prefers-color-scheme: dark) {
-	:root:not([data-theme='light']) {
-		--bg-base: #0f1419;
-		--bg-subtle: #1a1f26;
-		--bg-muted: #242b35;
-		--text-primary: #e2e8f0;
-		--text-secondary: #a1a1aa;
-		--text-muted: #71717a;
-		--text-faint: #52525b;
-		--border: rgba(255, 255, 255, 0.08);
-		--border-subtle: rgba(255, 255, 255, 0.05);
-		--border-hover: rgba(255, 255, 255, 0.15);
-		--accent: #a78bfa;
-		--accent-hover: #c4b5fd;
-		--accent-subtle: rgba(167, 139, 250, 0.15);
-		--accent-muted: rgba(167, 139, 250, 0.08);
-		--accent-primary: var(--accent);
-		--success: #34d399;
-		--success-subtle: rgba(52, 211, 153, 0.15);
-		--error: #f87171;
-		--error-subtle: rgba(248, 113, 113, 0.15);
-		--warning: #fbbf24;
-		--warning-subtle: rgba(251, 191, 36, 0.15);
-		--info: #60a5fa;
-		--info-subtle: rgba(96, 165, 250, 0.15);
-		--model-opus: #a78bfa;
-		--model-opus-subtle: rgba(167, 139, 250, 0.2);
-		--model-sonnet: #60a5fa;
-		--model-sonnet-subtle: rgba(96, 165, 250, 0.2);
-		--model-haiku: #34d399;
-		--model-haiku-subtle: rgba(52, 211, 153, 0.2);
-		--event-prompt: #60a5fa;
-		--event-prompt-subtle: rgba(96, 165, 250, 0.25);
-		--event-tool: #34d399;
-		--event-tool-subtle: rgba(52, 211, 153, 0.25);
-		--event-subagent: #a78bfa;
-		--event-subagent-subtle: rgba(167, 139, 250, 0.25);
-		--event-thinking: #fbbf24;
-		--event-thinking-subtle: rgba(251, 191, 36, 0.25);
-		--event-response: #94a3b8;
-		--event-response-subtle: rgba(148, 163, 184, 0.25);
-		--event-todo: #a78bfa;
-		--event-todo-subtle: rgba(167, 139, 250, 0.25);
-		--event-plan: #22d3ee;
-		--event-plan-subtle: rgba(34, 211, 238, 0.25);
-		--event-builtin: #94a3b8;
-		--event-builtin-subtle: rgba(148, 163, 184, 0.25);
-		--event-command: #2dd4bf;
-		--event-command-subtle: rgba(45, 212, 191, 0.25);
-		--nav-blue: #60a5fa;
-		--nav-blue-subtle: rgba(96, 165, 250, 0.15);
-		--nav-green: #34d399;
-		--nav-green-subtle: rgba(52, 211, 153, 0.15);
-		--nav-orange: #fb923c;
-		--nav-orange-subtle: rgba(251, 146, 60, 0.15);
-		--nav-purple: #a78bfa;
-		--nav-purple-subtle: rgba(167, 139, 250, 0.15);
-		--nav-gray: #94a3b8;
-		--nav-gray-subtle: rgba(148, 163, 184, 0.15);
-		--nav-red: #fb7185;
-		--nav-red-subtle: rgba(251, 113, 133, 0.15);
-		--nav-teal: #22d3ee;
-		--nav-teal-subtle: rgba(34, 211, 238, 0.18);
-		--nav-yellow: #fbbf24;
-		--nav-yellow-subtle: rgba(251, 191, 36, 0.15);
-		--nav-violet: #f472b6;
-		--nav-violet-subtle: rgba(244, 114, 182, 0.18);
-		--nav-indigo: #818cf8;
-		--nav-indigo-subtle: rgba(129, 140, 248, 0.18);
-		--nav-amber: #fbbf24;
-		--nav-amber-subtle: rgba(251, 191, 36, 0.15);
-		/* Live Session Status Background Tints (dark mode) */
-		--status-starting-bg: rgba(167, 139, 250, 0.08);
-		--status-active-bg: rgba(52, 211, 153, 0.08);
-		--status-idle-bg: rgba(251, 191, 36, 0.08);
-		--status-waiting-bg: rgba(96, 165, 250, 0.08);
-		--status-stopped-bg: rgba(148, 163, 184, 0.05);
-		--status-ended-bg: rgba(148, 163, 184, 0.04);
-		--status-stale-bg: rgba(248, 113, 113, 0.08);
-		/* Subagent Type Colors (dark mode - lighter for contrast) */
-		--subagent-explore: #22d3ee;
-		--subagent-explore-subtle: rgba(34, 211, 238, 0.2);
-		--subagent-plan: #fbbf24;
-		--subagent-plan-subtle: rgba(251, 191, 36, 0.2);
-		--subagent-bash: #34d399;
-		--subagent-bash-subtle: rgba(52, 211, 153, 0.2);
-		--subagent-default: #a78bfa;
-		--subagent-default-subtle: rgba(167, 139, 250, 0.2);
-		/* Claude Tax - internal overhead agents (warmup, cache priming) - rust orange */
-		--subagent-claude-tax: #fb923c;
-		--subagent-claude-tax-subtle: rgba(251, 146, 60, 0.2);
-		/* System Agents - auto-spawned by Claude Code for internal operations (dark mode) */
-		--subagent-acompact: #94a3b8; /* Slate - context compaction/cleanup */
-		--subagent-acompact-subtle: rgba(148, 163, 184, 0.2);
-		--subagent-prompt-suggestion: #a5b4fc; /* Indigo - AI-powered suggestions */
-		--subagent-prompt-suggestion-subtle: rgba(165, 180, 252, 0.2);
-		/* OKLCH params for plugin identity colors (dark mode) */
-		--plugin-l: 0.75;
-		--plugin-c: 0.13;
-		--plugin-l-subtle: 0.23;
-		--plugin-c-subtle: 0.04;
-
-		/* Scope category colors (dark mode) */
-		--scope-project: #fbbf24;
-		--scope-project-subtle: rgba(251, 191, 36, 0.2);
-		--scope-user: #2dd4bf;
-		--scope-user-subtle: rgba(45, 212, 191, 0.2);
-		--shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
-		--shadow-md: 0 2px 8px rgba(0, 0, 0, 0.4);
-		--shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.5);
-		--shadow-elevated: 0 0 0 0.5px var(--border), 0 4px 12px rgba(0, 0, 0, 0.4);
-	}
-}
-
-body {
-	font-family: var(--font-sans);
-	background-color: var(--bg-base);
-	color: var(--text-primary);
-	font-variant-numeric: tabular-nums;
-}
-
-/* Markdown Preview Styles */
 .markdown-preview {
 	@apply leading-relaxed;
 	color: var(--text-primary);
 }
 
 .markdown-preview h1 {
-	@apply text-2xl font-semibold mt-8 mb-4 tracking-tight pb-2;
+	@apply text-3xl mt-8 mb-4 pb-2;
+	font-family: var(--font-serif);
+	font-weight: 400;
+	letter-spacing: -0.015em;
 	color: var(--text-primary);
 	border-bottom: 1px solid var(--border);
 }
 
 .markdown-preview h2 {
-	@apply text-xl font-semibold mt-8 mb-3 tracking-tight;
+	@apply text-2xl mt-8 mb-3;
+	font-family: var(--font-serif);
+	font-weight: 400;
+	letter-spacing: -0.015em;
 	color: var(--text-primary);
 }
 
@@ -543,9 +512,12 @@ body {
 }
 
 .markdown-preview blockquote {
-	@apply pl-4 py-1 my-6 italic rounded-r-lg;
-	border-left: 4px solid var(--accent);
-	color: var(--text-muted);
+	@apply pl-4 py-1 my-6 rounded-r-lg;
+	font-family: var(--font-serif);
+	font-style: italic;
+	font-size: 1.05em;
+	border-left: 3px solid var(--accent);
+	color: var(--text-secondary);
 	background-color: var(--accent-muted);
 }
 
@@ -564,7 +536,6 @@ body {
 	border-color: var(--border);
 }
 
-/* Table Styles */
 .markdown-preview table {
 	@apply w-full mb-6 text-sm;
 	border-collapse: collapse;
@@ -578,7 +549,12 @@ body {
 }
 
 .markdown-preview th {
-	@apply px-4 py-2.5 text-left font-semibold;
+	@apply px-4 py-2.5 text-left;
+	font-family: var(--font-mono);
+	font-size: 11px;
+	text-transform: uppercase;
+	letter-spacing: 0.1em;
+	font-weight: 500;
 	color: var(--text-primary);
 	border-bottom: 2px solid var(--border);
 }
@@ -605,7 +581,6 @@ body {
 	@apply text-xs;
 }
 
-/* Task List Styles (Checkboxes) */
 .markdown-preview input[type='checkbox'] {
 	@apply mr-2 rounded;
 	accent-color: var(--accent);
@@ -616,7 +591,6 @@ body {
 	@apply list-none ml-0;
 }
 
-/* Definition List Styles */
 .markdown-preview dl {
 	@apply mb-4;
 }
@@ -631,21 +605,16 @@ body {
 	color: var(--text-secondary);
 }
 
-/* Image Styles */
 .markdown-preview img {
 	@apply max-w-full h-auto rounded-lg my-4;
 	border: 1px solid var(--border);
 }
 
-/* Nested List Spacing */
 .markdown-preview li > ul,
 .markdown-preview li > ol {
 	@apply mt-1 mb-0;
 }
 
-/* ── Markdown inline copy buttons (injected by markdownCopyButtons action) ── */
-
-/* pre needs relative positioning for the absolute code-copy button */
 .markdown-preview pre {
 	position: relative;
 }
@@ -661,7 +630,10 @@ body {
 	color: var(--text-muted);
 	cursor: pointer;
 	opacity: 0;
-	transition: opacity 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+	transition:
+		opacity 0.15s ease,
+		color 0.15s ease,
+		border-color 0.15s ease;
 	flex-shrink: 0;
 	line-height: 1;
 }
@@ -677,7 +649,6 @@ body {
 	opacity: 1 !important;
 }
 
-/* Code block button: always visible (no hover required) */
 .md-copy-btn--code {
 	position: absolute;
 	top: 0.5rem;
@@ -685,22 +656,15 @@ body {
 	opacity: 1;
 }
 
-/* Section button: inline after heading text, revealed on parent hover */
 .md-copy-btn--section {
 	vertical-align: middle;
 	margin-left: 0.5rem;
 	transform: translateY(-1px);
 }
 
-/* All section copy buttons — always visible */
 .md-copy-btn--section {
 	opacity: 1;
 }
-
-
-/* ── Custom tooltip for the global "copy entire response" button ── */
-/* Uses data-tooltip attribute + ::before pseudo-element so it appears
-   instantly on hover without the OS-imposed delay of the native title attr. */
 
 .md-global-copy {
 	position: relative;
@@ -735,7 +699,6 @@ body {
    VIM-STYLE LIST NAVIGATION
    ============================================ */
 
-/* Vim selection highlight - distinct from focus */
 [data-list-item][data-vim-selected='true'] {
 	background-color: var(--accent-subtle) !important;
 	outline: 2px solid var(--accent);
@@ -743,7 +706,6 @@ body {
 	border-radius: var(--radius-md);
 }
 
-/* Smooth transition for vim selection */
 [data-list-item] {
 	transition:
 		outline 150ms ease,
@@ -751,10 +713,9 @@ body {
 }
 
 /* ============================================
-   SKELETON LOADING SYSTEM
+   SKELETON LOADING
    ============================================ */
 
-/* Shimmer animation keyframes */
 @keyframes skeleton-shimmer {
 	0% {
 		background-position: -200% 0;
@@ -764,7 +725,6 @@ body {
 	}
 }
 
-/* Base skeleton shimmer class */
 .skeleton-shimmer {
 	background: linear-gradient(
 		90deg,
@@ -776,7 +736,6 @@ body {
 	animation: skeleton-shimmer 1.5s ease-in-out infinite;
 }
 
-/* Reduced motion support for accessibility */
 @media (prefers-reduced-motion: reduce) {
 	.skeleton-shimmer {
 		animation: none;
@@ -788,36 +747,32 @@ body {
    ENHANCED UI UTILITIES
    ============================================ */
 
-/* Gradient text utility */
 .gradient-text {
-	color: var(--accent); /* Fallback for browsers without background-clip support */
-	background: linear-gradient(135deg, var(--accent) 0%, #a78bfa 100%);
+	color: var(--accent);
+	background: linear-gradient(135deg, var(--accent) 0%, var(--accent-hover) 100%);
 	-webkit-background-clip: text;
 	-webkit-text-fill-color: transparent;
 	background-clip: text;
 }
 
-/* Card lift effect */
 .hover-lift-lg {
 	transition:
-		transform 300ms var(--ease),
-		box-shadow 300ms var(--ease);
+		transform 280ms var(--ease),
+		box-shadow 280ms var(--ease);
 }
 .hover-lift-lg:hover {
-	transform: translateY(-4px);
+	transform: translateY(-2px);
 	box-shadow: var(--shadow-lg);
 }
 
-/* Subtle glow effect - uses design system color variable for dark mode support */
 .glow-accent {
-	box-shadow: 0 0 20px rgba(var(--accent-rgb), 0.12);
+	box-shadow: 0 0 24px rgba(var(--accent-rgb), 0.14);
 }
 
-/* Stagger children animation */
 @keyframes fade-in-up {
 	from {
 		opacity: 0;
-		transform: translateY(10px);
+		transform: translateY(8px);
 	}
 	to {
 		opacity: 1;
@@ -825,7 +780,6 @@ body {
 	}
 }
 
-/* Results update animation - subtle fade and highlight */
 @keyframes results-update {
 	0% {
 		opacity: 0.5;
@@ -845,40 +799,21 @@ body {
 }
 
 .stagger-children > * {
-	animation: fade-in-up 0.4s ease-out backwards;
+	animation: fade-in-up 0.5s var(--ease) backwards;
 }
-.stagger-children > *:nth-child(1) {
-	animation-delay: 0ms;
-}
-.stagger-children > *:nth-child(2) {
-	animation-delay: 50ms;
-}
-.stagger-children > *:nth-child(3) {
-	animation-delay: 100ms;
-}
-.stagger-children > *:nth-child(4) {
-	animation-delay: 150ms;
-}
-.stagger-children > *:nth-child(5) {
-	animation-delay: 200ms;
-}
-.stagger-children > *:nth-child(6) {
-	animation-delay: 250ms;
-}
-.stagger-children > *:nth-child(7) {
-	animation-delay: 300ms;
-}
-.stagger-children > *:nth-child(8) {
-	animation-delay: 350ms;
-}
-.stagger-children > *:nth-child(9) {
-	animation-delay: 400ms;
-}
-.stagger-children > *:nth-child(10) {
-	animation-delay: 450ms;
-}
+.stagger-children > *:nth-child(1) { animation-delay: 0ms; }
+.stagger-children > *:nth-child(2) { animation-delay: 60ms; }
+.stagger-children > *:nth-child(3) { animation-delay: 120ms; }
+.stagger-children > *:nth-child(4) { animation-delay: 180ms; }
+.stagger-children > *:nth-child(5) { animation-delay: 240ms; }
+.stagger-children > *:nth-child(6) { animation-delay: 300ms; }
+.stagger-children > *:nth-child(7) { animation-delay: 360ms; }
+.stagger-children > *:nth-child(8) { animation-delay: 420ms; }
+.stagger-children > *:nth-child(9) { animation-delay: 480ms; }
+.stagger-children > *:nth-child(10) { animation-delay: 540ms; }
+.stagger-children > *:nth-child(11) { animation-delay: 600ms; }
+.stagger-children > *:nth-child(12) { animation-delay: 660ms; }
 
-/* Reduced motion support for new animations */
 @media (prefers-reduced-motion: reduce) {
 	.hover-lift-lg {
 		transition: none;
@@ -889,17 +824,21 @@ body {
 	.stagger-children > * {
 		animation: none;
 	}
-	/* Disable blur effects for users who prefer reduced motion */
 	.blur-3xl {
 		filter: none !important;
 	}
 }
 
-/* Session last-opened highlight ring — fades out after mount */
 @keyframes session-highlight-fade {
-	0%   { box-shadow: 0 0 0 2px var(--accent); }
-	60%  { box-shadow: 0 0 0 2px var(--accent); }
-	100% { box-shadow: 0 0 0 2px transparent; }
+	0% {
+		box-shadow: 0 0 0 2px var(--accent);
+	}
+	60% {
+		box-shadow: 0 0 0 2px var(--accent);
+	}
+	100% {
+		box-shadow: 0 0 0 2px transparent;
+	}
 }
 .session-highlight {
 	animation: session-highlight-fade 1.8s ease-out forwards;
@@ -911,9 +850,46 @@ body {
 	}
 }
 
-/* Search highlighting */
 .search-highlight {
-	background: color-mix(in srgb, var(--warning) 30%, transparent);
+	background: color-mix(in srgb, var(--accent) 35%, transparent);
 	border-radius: 2px;
 	padding: 0 1px;
+}
+
+/* ============================================
+   EDITORIAL PRIMITIVES
+   ============================================ */
+
+.ink-button {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 14px;
+	font-family: var(--font-mono);
+	font-size: 11px;
+	letter-spacing: 0.15em;
+	text-transform: uppercase;
+	color: var(--text-primary);
+	background: transparent;
+	border: 1px solid var(--border);
+	border-radius: var(--radius-sm);
+	transition: all var(--duration-fast) var(--ease);
+	cursor: pointer;
+}
+
+.ink-button:hover {
+	background: var(--text-primary);
+	color: var(--bg-base);
+	border-color: var(--text-primary);
+}
+
+.ink-button--accent {
+	color: var(--accent);
+	border-color: var(--accent);
+}
+
+.ink-button--accent:hover {
+	background: var(--accent);
+	color: var(--bg-base);
+	border-color: var(--accent);
 }

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -10,15 +10,21 @@
 				if (theme === 'light' || theme === 'dark') {
 					document.documentElement.setAttribute('data-theme', theme);
 				} else {
-					// Default to system preference
-					const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+					// Default to dark (the editorial aesthetic reads strongest at night)
+					const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
 					document.documentElement.setAttribute(
 						'data-theme',
-						prefersDark ? 'dark' : 'light'
+						prefersLight ? 'light' : 'dark'
 					);
 				}
 			})();
 		</script>
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@300..700&family=Geist+Mono:wght@400..600&display=swap"
+			rel="stylesheet"
+		/>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/frontend/src/lib/components/CommandFooter.svelte
+++ b/frontend/src/lib/components/CommandFooter.svelte
@@ -93,20 +93,23 @@
 		align-items: center;
 		gap: 0.5rem;
 		padding: 0.375rem 0.75rem;
-		font-size: 0.75rem;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
 		font-weight: 500;
 		color: var(--text-muted);
 		background: transparent;
 		border: 1px solid var(--border);
-		border-radius: 0.5rem;
+		border-radius: var(--radius-sm);
 		cursor: pointer;
-		transition: all 150ms ease;
+		transition: all 150ms var(--ease);
 	}
 
 	.command-btn:hover {
 		color: var(--text-primary);
-		background: var(--bg-muted);
-		border-color: var(--border-strong);
+		background: var(--bg-subtle);
+		border-color: var(--border-hover);
 	}
 
 	.label {

--- a/frontend/src/lib/components/GlobalSessionCard.svelte
+++ b/frontend/src/lib/components/GlobalSessionCard.svelte
@@ -168,8 +168,7 @@
 
 				<!-- Session Name (title → slug → uuid) -->
 				<span
-					class="text-xs font-medium truncate flex-1"
-					class:text-[var(--accent)]={hasTitle}
+					class="text-xs font-medium truncate flex-1 text-[var(--text-primary)] group-hover:text-[var(--accent)] transition-colors"
 					class:text-[var(--text-secondary)]={!hasTitle}
 					class:italic={!hasTitle}
 					class:font-mono={!hasTitle && !displaySlug}
@@ -249,8 +248,7 @@
 					<div class="flex items-center justify-between gap-2 mb-0.5">
 						<div class="flex items-center gap-2 min-w-0">
 							<span
-								class="text-sm font-medium truncate"
-								class:text-[var(--accent)]={hasTitle}
+								class="text-sm font-medium truncate text-[var(--text-primary)] group-hover:text-[var(--accent)] transition-colors"
 								class:text-[var(--text-secondary)]={!hasTitle}
 								class:italic={!hasTitle}
 								class:font-mono={!hasTitle && !displaySlug}

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -1,348 +1,460 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { Menu, X, Settings } from 'lucide-svelte';
-	import LogoIcon from '$lib/assets/LogoIcon.svelte';
 
 	let mobileMenuOpen = $state(false);
 
 	let isHome = $derived($page.url.pathname === '/');
 
+	// Dispatch number — deterministic per-day issue number, editorial flourish
+	const issueNo = $derived.by(() => {
+		const start = new Date('2024-01-01').getTime();
+		const today = new Date();
+		today.setHours(0, 0, 0, 0);
+		const days = Math.floor((today.getTime() - start) / (1000 * 60 * 60 * 24));
+		return String(days % 999).padStart(3, '0');
+	});
+
+	const todayLabel = $derived.by(() => {
+		return new Date()
+			.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: '2-digit' })
+			.toUpperCase();
+	});
+
 	function toggleMobileMenu() {
 		mobileMenuOpen = !mobileMenuOpen;
 	}
-
 	function closeMobileMenu() {
 		mobileMenuOpen = false;
 	}
-
 	function handleKeydown(e: KeyboardEvent) {
-		if (e.key === 'Escape' && mobileMenuOpen) {
-			closeMobileMenu();
-		}
+		if (e.key === 'Escape' && mobileMenuOpen) closeMobileMenu();
 	}
+
+	const navItems = [
+		{ href: '/projects', label: 'Projects' },
+		{ href: '/sessions', label: 'Sessions' },
+		{ href: '/plans', label: 'Plans' },
+		{ href: '/agents', label: 'Agents' },
+		{ href: '/skills', label: 'Skills' },
+		{ href: '/commands', label: 'Commands' },
+		{ href: '/tools', label: 'Tools' },
+		{ href: '/hooks', label: 'Hooks' },
+		{ href: '/plugins', label: 'Plugins' },
+		{ href: '/analytics', label: 'Analytics' },
+		{ href: '/archived', label: 'Archived' }
+	];
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
 
 {#if isHome}
-	<!-- Big Centered Header (Home) -->
-	<header
-		class="w-full max-w-[1000px] mx-auto pt-8 sm:pt-12 md:pt-16 pb-6 md:pb-8 px-4 flex items-center justify-center relative"
-	>
-		<div class="flex flex-col items-center gap-4 md:gap-5">
-			<div class="logo-wrapper logo-wrapper-lg">
-				<img src="/logo.png" alt="Claude Code Karma" class="w-16 h-16 md:w-20 md:h-20 object-contain" />
-			</div>
-			<div class="text-center flex flex-col items-center gap-1">
-				<h1
-					class="text-2xl sm:text-3xl font-semibold tracking-tight text-[var(--text-primary)]"
-				>
-					Claude <span class="font-bold">Code Karma</span>
-				</h1>
-				<p
-					class="mt-1 text-sm tracking-wide"
-					style="background: linear-gradient(135deg, #a855f7, #7c3aed); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;"
-				>
-					Track work, not terminals
-				</p>
-			</div>
+	<!-- Editorial masthead (home) -->
+	<header class="masthead">
+		<div class="masthead__rule rule"></div>
+		<div class="masthead__meta">
+			<span class="eyebrow">№ {issueNo}</span>
+			<span class="eyebrow">Claude Code · Dispatch</span>
+			<span class="eyebrow">{todayLabel}</span>
 		</div>
+		<div class="masthead__rule-strong rule-strong"></div>
+
+		<div class="masthead__title">
+			<span class="masthead__kicker">track work · not terminals</span>
+			<h1 class="masthead__display">
+				<span class="masthead__word">karma</span><span class="masthead__amp">.</span>
+			</h1>
+			<p class="masthead__sub">
+				A quiet, meticulous log of your <em>Claude Code</em> sessions — projects, plans,
+				tools, agents, and skills, all indexed.
+			</p>
+		</div>
+
+		<div class="masthead__rule rule"></div>
 	</header>
 {:else}
-	<!-- Compact Inline Header (Routes) -->
-	<header
-		class="sticky top-0 z-50 bg-[var(--bg-base)]/90 backdrop-blur-md border-b border-[var(--border)] h-14 flex items-center"
-	>
-		<div
-			class="w-full max-w-[1200px] mx-auto px-4 md:px-6 grid grid-cols-[auto_1fr_auto] items-center"
-		>
-			<!-- Left: Brand -->
-			<div class="flex items-center gap-3">
-				<a
-					href="/"
-					class="flex items-center gap-2 md:gap-3 hover:opacity-80 transition-opacity group"
-				>
-					<div class="logo-wrapper logo-wrapper-sm">
-						<img src="/logo.png" alt="Claude Code Karma" class="w-7 h-7 object-contain" />
-					</div>
-					<h1
-						class="hidden sm:block text-sm font-semibold tracking-tight text-[var(--text-primary)]"
-					>
-						Claude <span class="font-bold">Code Karma</span>
-					</h1>
-				</a>
-			</div>
+	<!-- Compact route header -->
+	<header class="route-header">
+		<div class="route-header__bar">
+			<a href="/" class="route-header__brand" aria-label="Home">
+				<span class="route-header__dot"></span>
+				<span class="route-header__name">
+					<span class="route-header__name-display">karma</span>
+					<span class="route-header__name-sub">Claude Code</span>
+				</span>
+			</a>
 
-			<!-- Center: Desktop Navigation -->
-			<nav
-				class="hidden md:flex items-center justify-center gap-4 overflow-visible"
-				aria-label="Main navigation"
-			>
-				<a
-					href="/projects"
-					class="text-sm font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/projects')}
-					aria-current={$page.url.pathname.startsWith('/projects') ? 'page' : undefined}
-				>
-					Projects
-				</a>
-				<a
-					href="/sessions"
-					class="text-sm font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/sessions')}
-					aria-current={$page.url.pathname.startsWith('/sessions') ? 'page' : undefined}
-				>
-					Sessions
-				</a>
-				<a
-					href="/plans"
-					class="text-sm font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/plans')}
-					aria-current={$page.url.pathname.startsWith('/plans') ? 'page' : undefined}
-				>
-					Plans
-				</a>
-				<a
-					href="/agents"
-					class="text-sm font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/agents')}
-					aria-current={$page.url.pathname.startsWith('/agents') ? 'page' : undefined}
-				>
-					Agents
-				</a>
-				<a
-					href="/skills"
-					class="text-sm font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/skills')}
-					aria-current={$page.url.pathname.startsWith('/skills') ? 'page' : undefined}
-				>
-					Skills
-				</a>
-				<a
-					href="/commands"
-					class="text-sm font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/commands')}
-					aria-current={$page.url.pathname.startsWith('/commands') ? 'page' : undefined}
-				>
-					Commands
-				</a>
-				<a
-					href="/tools"
-					class="text-sm font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/tools')}
-					aria-current={$page.url.pathname.startsWith('/tools') ? 'page' : undefined}
-				>
-					Tools
-				</a>
-				<a
-					href="/hooks"
-					class="text-sm font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/hooks')}
-					aria-current={$page.url.pathname.startsWith('/hooks') ? 'page' : undefined}
-				>
-					Hooks
-				</a>
-				<a
-					href="/plugins"
-					class="text-sm font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/plugins')}
-					aria-current={$page.url.pathname.startsWith('/plugins') ? 'page' : undefined}
-				>
-					Plugins
-				</a>
-				<a
-					href="/analytics"
-					class="text-sm font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/analytics')}
-					aria-current={$page.url.pathname.startsWith('/analytics') ? 'page' : undefined}
-				>
-					Analytics
-				</a>
-				<a
-					href="/archived"
-					class="text-sm font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/archived')}
-					aria-current={$page.url.pathname.startsWith('/archived') ? 'page' : undefined}
-				>
-					Archived
-				</a>
+			<nav class="route-header__nav" aria-label="Main navigation">
+				{#each navItems as item (item.href)}
+					<a
+						href={item.href}
+						class="route-header__link"
+						class:is-active={$page.url.pathname.startsWith(item.href)}
+						aria-current={$page.url.pathname.startsWith(item.href) ? 'page' : undefined}
+					>
+						{item.label}
+					</a>
+				{/each}
 			</nav>
 
-			<div class="flex items-center justify-end gap-3">
-				<a
-					href="/settings"
-					class="p-2 rounded-lg hover:bg-[var(--bg-muted)] transition-colors text-[var(--text-muted)] hover:text-[var(--text-primary)]"
-					title="Settings"
-				>
-					<Settings size={18} strokeWidth={2} />
+			<div class="route-header__right">
+				<a href="/settings" class="route-header__icon" title="Settings">
+					<Settings size={16} strokeWidth={1.75} />
 				</a>
-
-				<!-- Mobile Menu Button - visible only on mobile -->
 				<button
 					onclick={toggleMobileMenu}
-					class="md:hidden p-2 rounded-lg hover:bg-[var(--bg-muted)] transition-colors text-[var(--text-muted)]"
+					class="route-header__icon route-header__mobile"
 					aria-label="Toggle menu"
 				>
 					{#if mobileMenuOpen}
-						<X size={20} strokeWidth={2} />
+						<X size={18} strokeWidth={1.75} />
 					{:else}
-						<Menu size={20} strokeWidth={2} />
+						<Menu size={18} strokeWidth={1.75} />
 					{/if}
 				</button>
 			</div>
 		</div>
 	</header>
 
-	<!-- Mobile Menu Overlay -->
 	{#if mobileMenuOpen}
 		<div
-			class="fixed inset-0 top-14 z-40 bg-[var(--bg-base)]/95 backdrop-blur-md md:hidden"
+			class="mobile-menu"
 			onclick={closeMobileMenu}
 			role="presentation"
 		>
-			<nav class="flex flex-col p-6 gap-1" aria-label="Mobile navigation">
-				<a
-					href="/projects"
-					onclick={closeMobileMenu}
-					class="text-base font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-subtle)] py-3 px-4 rounded-lg transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/projects')}
-					class:bg-[var(--bg-subtle)]={$page.url.pathname.startsWith('/projects')}
-					aria-current={$page.url.pathname.startsWith('/projects') ? 'page' : undefined}
-				>
-					Projects
-				</a>
-				<a
-					href="/sessions"
-					onclick={closeMobileMenu}
-					class="text-base font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-subtle)] py-3 px-4 rounded-lg transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/sessions')}
-					class:bg-[var(--bg-subtle)]={$page.url.pathname.startsWith('/sessions')}
-					aria-current={$page.url.pathname.startsWith('/sessions') ? 'page' : undefined}
-				>
-					Sessions
-				</a>
-				<a
-					href="/plans"
-					onclick={closeMobileMenu}
-					class="text-base font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-subtle)] py-3 px-4 rounded-lg transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/plans')}
-					class:bg-[var(--bg-subtle)]={$page.url.pathname.startsWith('/plans')}
-					aria-current={$page.url.pathname.startsWith('/plans') ? 'page' : undefined}
-				>
-					Plans
-				</a>
-				<a
-					href="/agents"
-					onclick={closeMobileMenu}
-					class="text-base font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-subtle)] py-3 px-4 rounded-lg transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/agents')}
-					class:bg-[var(--bg-subtle)]={$page.url.pathname.startsWith('/agents')}
-					aria-current={$page.url.pathname.startsWith('/agents') ? 'page' : undefined}
-				>
-					Agents
-				</a>
-				<a
-					href="/skills"
-					onclick={closeMobileMenu}
-					class="text-base font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-subtle)] py-3 px-4 rounded-lg transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/skills')}
-					class:bg-[var(--bg-subtle)]={$page.url.pathname.startsWith('/skills')}
-					aria-current={$page.url.pathname.startsWith('/skills') ? 'page' : undefined}
-				>
-					Skills
-				</a>
-				<a
-					href="/commands"
-					onclick={closeMobileMenu}
-					class="text-base font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-subtle)] py-3 px-4 rounded-lg transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/commands')}
-					class:bg-[var(--bg-subtle)]={$page.url.pathname.startsWith('/commands')}
-					aria-current={$page.url.pathname.startsWith('/commands') ? 'page' : undefined}
-				>
-					Commands
-				</a>
-				<a
-					href="/tools"
-					onclick={closeMobileMenu}
-					class="text-base font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-subtle)] py-3 px-4 rounded-lg transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/tools')}
-					class:bg-[var(--bg-subtle)]={$page.url.pathname.startsWith('/tools')}
-					aria-current={$page.url.pathname.startsWith('/tools') ? 'page' : undefined}
-				>
-					Tools
-				</a>
-				<a
-					href="/hooks"
-					onclick={closeMobileMenu}
-					class="text-base font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-subtle)] py-3 px-4 rounded-lg transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/hooks')}
-					class:bg-[var(--bg-subtle)]={$page.url.pathname.startsWith('/hooks')}
-					aria-current={$page.url.pathname.startsWith('/hooks') ? 'page' : undefined}
-				>
-					Hooks
-				</a>
-				<a
-					href="/plugins"
-					onclick={closeMobileMenu}
-					class="text-base font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-subtle)] py-3 px-4 rounded-lg transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/plugins')}
-					class:bg-[var(--bg-subtle)]={$page.url.pathname.startsWith('/plugins')}
-					aria-current={$page.url.pathname.startsWith('/plugins') ? 'page' : undefined}
-				>
-					Plugins
-				</a>
-				<a
-					href="/analytics"
-					onclick={closeMobileMenu}
-					class="text-base font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-subtle)] py-3 px-4 rounded-lg transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/analytics')}
-					class:bg-[var(--bg-subtle)]={$page.url.pathname.startsWith('/analytics')}
-					aria-current={$page.url.pathname.startsWith('/analytics') ? 'page' : undefined}
-				>
-					Analytics
-				</a>
-				<a
-					href="/archived"
-					onclick={closeMobileMenu}
-					class="text-base font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-subtle)] py-3 px-4 rounded-lg transition-colors"
-					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/archived')}
-					class:bg-[var(--bg-subtle)]={$page.url.pathname.startsWith('/archived')}
-					aria-current={$page.url.pathname.startsWith('/archived') ? 'page' : undefined}
-				>
-					Archived
-				</a>
+			<nav aria-label="Mobile navigation">
+				{#each navItems as item (item.href)}
+					<a
+						href={item.href}
+						onclick={closeMobileMenu}
+						class="mobile-menu__link"
+						class:is-active={$page.url.pathname.startsWith(item.href)}
+						aria-current={$page.url.pathname.startsWith(item.href) ? 'page' : undefined}
+					>
+						{item.label}
+					</a>
+				{/each}
 			</nav>
 		</div>
 	{/if}
 {/if}
 
 <style>
-	.logo-wrapper {
-		border-radius: 50%;
+	/* ====== Editorial masthead (home) ====== */
+	.masthead {
+		width: 100%;
+		max-width: 1100px;
+		margin: 0 auto;
+		padding: 32px 24px 8px;
+	}
+
+	.masthead__meta {
 		display: flex;
 		align-items: center;
-		justify-content: center;
-		transition: background-color 0.3s ease;
+		justify-content: space-between;
+		gap: 16px;
+		padding: 10px 0 12px;
 	}
 
-	.logo-wrapper {
-		background: radial-gradient(circle, #2d2240 55%, transparent 100%);
+	.masthead__rule {
+		width: 100%;
 	}
 
-	.logo-wrapper-lg {
-		width: 5.5rem;
-		height: 5.5rem;
+	.masthead__rule-strong {
+		width: 100%;
+		margin-bottom: 18px;
 	}
 
-	.logo-wrapper-sm {
-		width: 2.25rem;
-		height: 2.25rem;
+	.masthead__title {
+		padding: 20px 0 36px;
+		display: grid;
+		grid-template-columns: auto 1fr;
+		grid-template-rows: auto auto;
+		column-gap: 28px;
+		row-gap: 14px;
+		align-items: end;
 	}
 
-	@media (min-width: 768px) {
-		.logo-wrapper-lg {
-			width: 6.5rem;
-			height: 6.5rem;
+	.masthead__kicker {
+		grid-column: 1 / -1;
+		font-family: var(--font-mono);
+		font-size: 11px;
+		letter-spacing: 0.22em;
+		text-transform: uppercase;
+		color: var(--accent);
+		font-weight: 500;
+	}
+
+	.masthead__display {
+		font-family: var(--font-serif);
+		font-style: italic;
+		font-weight: 400;
+		font-size: clamp(84px, 15vw, 180px);
+		line-height: 0.9;
+		letter-spacing: -0.04em;
+		color: var(--text-primary);
+		margin: 0;
+		grid-column: 1;
+	}
+
+	.masthead__word {
+		display: inline-block;
+	}
+
+	.masthead__amp {
+		color: var(--accent);
+	}
+
+	.masthead__sub {
+		grid-column: 2;
+		font-size: 15px;
+		line-height: 1.55;
+		color: var(--text-secondary);
+		max-width: 360px;
+		padding-bottom: 16px;
+		border-left: 1px solid var(--border);
+		padding-left: 20px;
+	}
+
+	.masthead__sub em {
+		font-family: var(--font-serif);
+		font-style: italic;
+		font-size: 1.08em;
+		color: var(--text-primary);
+	}
+
+	@media (max-width: 720px) {
+		.masthead {
+			padding: 20px 16px 4px;
 		}
+		.masthead__title {
+			grid-template-columns: 1fr;
+			padding: 12px 0 24px;
+			row-gap: 10px;
+		}
+		.masthead__sub {
+			grid-column: 1;
+			border-left: none;
+			border-top: 1px solid var(--border);
+			padding-left: 0;
+			padding-top: 14px;
+		}
+		.masthead__meta .eyebrow:nth-child(2) {
+			display: none;
+		}
+	}
+
+	/* ====== Compact route header ====== */
+	.route-header {
+		position: sticky;
+		top: 0;
+		z-index: 50;
+		background: color-mix(in srgb, var(--bg-base) 88%, transparent);
+		backdrop-filter: blur(14px) saturate(1.2);
+		-webkit-backdrop-filter: blur(14px) saturate(1.2);
+		border-bottom: 1px solid var(--border);
+	}
+
+	.route-header__bar {
+		width: 100%;
+		max-width: 1200px;
+		margin: 0 auto;
+		padding: 0 20px;
+		height: 56px;
+		display: grid;
+		grid-template-columns: auto 1fr auto;
+		align-items: center;
+		gap: 16px;
+	}
+
+	.route-header__brand {
+		display: inline-flex;
+		align-items: center;
+		gap: 10px;
+		text-decoration: none;
+		color: var(--text-primary);
+		transition: opacity var(--duration-fast);
+	}
+
+	.route-header__brand:hover {
+		opacity: 0.75;
+	}
+
+	.route-header__dot {
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		background: var(--accent);
+		box-shadow: 0 0 0 3px var(--accent-muted);
+		flex-shrink: 0;
+	}
+
+	.route-header__name {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 8px;
+	}
+
+	.route-header__name-display {
+		font-family: var(--font-serif);
+		font-style: italic;
+		font-size: 22px;
+		line-height: 1;
+		letter-spacing: -0.02em;
+		color: var(--text-primary);
+	}
+
+	.route-header__name-sub {
+		display: none;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		letter-spacing: 0.2em;
+		text-transform: uppercase;
+		color: var(--text-muted);
+	}
+
+	@media (min-width: 640px) {
+		.route-header__name-sub {
+			display: inline;
+		}
+	}
+
+	.route-header__nav {
+		display: none;
+		justify-self: center;
+		align-items: center;
+		gap: 4px;
+	}
+
+	@media (min-width: 900px) {
+		.route-header__nav {
+			display: flex;
+		}
+	}
+
+	.route-header__link {
+		position: relative;
+		padding: 6px 10px;
+		font-family: var(--font-mono);
+		font-size: 11px;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--text-muted);
+		text-decoration: none;
+		transition: color var(--duration-fast);
+		white-space: nowrap;
+	}
+
+	.route-header__link::after {
+		content: '';
+		position: absolute;
+		left: 10px;
+		right: 10px;
+		bottom: -1px;
+		height: 1px;
+		background: var(--accent);
+		transform: scaleX(0);
+		transform-origin: left center;
+		transition: transform var(--duration-base) var(--ease);
+	}
+
+	.route-header__link:hover {
+		color: var(--text-primary);
+	}
+
+	.route-header__link.is-active {
+		color: var(--text-primary);
+	}
+
+	.route-header__link.is-active::after {
+		transform: scaleX(1);
+	}
+
+	.route-header__right {
+		display: flex;
+		align-items: center;
+		justify-self: end;
+		gap: 6px;
+	}
+
+	.route-header__icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border-radius: var(--radius-sm);
+		color: var(--text-muted);
+		background: transparent;
+		border: 1px solid transparent;
+		cursor: pointer;
+		transition: all var(--duration-fast);
+		text-decoration: none;
+	}
+
+	.route-header__icon:hover {
+		color: var(--text-primary);
+		background: var(--bg-subtle);
+		border-color: var(--border);
+	}
+
+	.route-header__mobile {
+		display: inline-flex;
+	}
+
+	@media (min-width: 900px) {
+		.route-header__mobile {
+			display: none;
+		}
+	}
+
+	/* ====== Mobile menu ====== */
+	.mobile-menu {
+		position: fixed;
+		inset: 56px 0 0 0;
+		z-index: 40;
+		background: color-mix(in srgb, var(--bg-base) 96%, transparent);
+		backdrop-filter: blur(18px);
+		-webkit-backdrop-filter: blur(18px);
+	}
+
+	@media (min-width: 900px) {
+		.mobile-menu {
+			display: none;
+		}
+	}
+
+	.mobile-menu nav {
+		display: flex;
+		flex-direction: column;
+		padding: 20px;
+		gap: 2px;
+		max-width: 1200px;
+		margin: 0 auto;
+	}
+
+	.mobile-menu__link {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 14px 16px;
+		font-family: var(--font-mono);
+		font-size: 12px;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--text-secondary);
+		text-decoration: none;
+		border-bottom: 1px solid var(--border-subtle);
+		transition: all var(--duration-fast);
+	}
+
+	.mobile-menu__link:hover,
+	.mobile-menu__link.is-active {
+		color: var(--text-primary);
+	}
+
+	.mobile-menu__link.is-active {
+		background: var(--accent-muted);
+		border-color: var(--accent);
 	}
 </style>

--- a/frontend/src/lib/components/NavigationCard.svelte
+++ b/frontend/src/lib/components/NavigationCard.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import type { Component } from 'svelte';
-
 	interface Props {
 		title: string;
 		description?: string;
@@ -19,6 +17,7 @@
 			| 'indigo'
 			| 'amber';
 		disabled?: boolean;
+		index?: number;
 	}
 
 	let {
@@ -27,184 +26,196 @@
 		href,
 		icon: IconComponent,
 		color = 'blue',
-		disabled = false
+		disabled = false,
+		index = 0
 	}: Props = $props();
 
-	// Color config with gradients and glow effects
-	const colorConfig = {
-		blue: {
-			text: 'var(--nav-blue)',
-			bg: 'var(--nav-blue-subtle)',
-			border: 'var(--nav-blue)',
-			gradient:
-				'linear-gradient(135deg, var(--nav-blue-subtle) 0%, rgba(59, 130, 246, 0.15) 100%)',
-			glow: '0 4px 20px -2px rgba(59, 130, 246, 0.25)'
-		},
-		green: {
-			text: 'var(--nav-green)',
-			bg: 'var(--nav-green-subtle)',
-			border: 'var(--nav-green)',
-			gradient:
-				'linear-gradient(135deg, var(--nav-green-subtle) 0%, rgba(16, 185, 129, 0.15) 100%)',
-			glow: '0 4px 20px -2px rgba(16, 185, 129, 0.25)'
-		},
-		orange: {
-			text: 'var(--nav-orange)',
-			bg: 'var(--nav-orange-subtle)',
-			border: 'var(--nav-orange)',
-			gradient:
-				'linear-gradient(135deg, var(--nav-orange-subtle) 0%, rgba(249, 115, 22, 0.15) 100%)',
-			glow: '0 4px 20px -2px rgba(249, 115, 22, 0.25)'
-		},
-		purple: {
-			text: 'var(--nav-purple)',
-			bg: 'var(--nav-purple-subtle)',
-			border: 'var(--nav-purple)',
-			gradient:
-				'linear-gradient(135deg, var(--nav-purple-subtle) 0%, rgba(139, 92, 246, 0.15) 100%)',
-			glow: '0 4px 20px -2px rgba(139, 92, 246, 0.25)'
-		},
-		gray: {
-			text: 'var(--nav-gray)',
-			bg: 'var(--nav-gray-subtle)',
-			border: 'var(--nav-gray)',
-			gradient:
-				'linear-gradient(135deg, var(--nav-gray-subtle) 0%, rgba(100, 116, 139, 0.12) 100%)',
-			glow: '0 4px 20px -2px rgba(100, 116, 139, 0.2)'
-		},
-		red: {
-			text: 'var(--nav-red)',
-			bg: 'var(--nav-red-subtle)',
-			border: 'var(--nav-red)',
-			gradient:
-				'linear-gradient(135deg, var(--nav-red-subtle) 0%, rgba(244, 63, 94, 0.15) 100%)',
-			glow: '0 4px 20px -2px rgba(244, 63, 94, 0.25)'
-		},
-		yellow: {
-			text: 'var(--nav-yellow)',
-			bg: 'var(--nav-yellow-subtle)',
-			border: 'var(--nav-yellow)',
-			gradient:
-				'linear-gradient(135deg, var(--nav-yellow-subtle) 0%, rgba(202, 138, 4, 0.15) 100%)',
-			glow: '0 4px 20px -2px rgba(202, 138, 4, 0.25)'
-		},
-		teal: {
-			text: 'var(--nav-teal)',
-			bg: 'var(--nav-teal-subtle)',
-			border: 'var(--nav-teal)',
-			gradient:
-				'linear-gradient(135deg, var(--nav-teal-subtle) 0%, rgba(8, 145, 178, 0.15) 100%)',
-			glow: '0 4px 20px -2px rgba(8, 145, 178, 0.25)'
-		},
-		violet: {
-			text: 'var(--nav-violet)',
-			bg: 'var(--nav-violet-subtle)',
-			border: 'var(--nav-violet)',
-			gradient:
-				'linear-gradient(135deg, var(--nav-violet-subtle) 0%, rgba(219, 39, 119, 0.15) 100%)',
-			glow: '0 4px 20px -2px rgba(219, 39, 119, 0.25)'
-		},
-		indigo: {
-			text: 'var(--nav-indigo)',
-			bg: 'var(--nav-indigo-subtle)',
-			border: 'var(--nav-indigo)',
-			gradient:
-				'linear-gradient(135deg, var(--nav-indigo-subtle) 0%, rgba(99, 102, 241, 0.15) 100%)',
-			glow: '0 4px 20px -2px rgba(99, 102, 241, 0.25)'
-		},
-		amber: {
-			text: 'var(--nav-amber)',
-			bg: 'var(--nav-amber-subtle)',
-			border: 'var(--nav-amber)',
-			gradient:
-				'linear-gradient(135deg, var(--nav-amber-subtle) 0%, rgba(217, 119, 6, 0.15) 100%)',
-			glow: '0 4px 20px -2px rgba(217, 119, 6, 0.25)'
-		}
-	};
+	const accentVar = $derived(`var(--nav-${color})`);
+	const accentSubtleVar = $derived(`var(--nav-${color}-subtle)`);
 
-	const config = $derived(colorConfig[color]);
+	const indexLabel = $derived(String(index + 1).padStart(2, '0'));
 </script>
 
-{#if description}
-	<!-- Full card layout with description -->
+{#if disabled}
+	<div class="card card--disabled" style="--ink: {accentVar}; --ink-tint: {accentSubtleVar};">
+		<span class="card__index">{indexLabel}</span>
+		<span class="card__dot"></span>
+		<span class="card__title">{title}</span>
+		<IconComponent size={15} strokeWidth={1.75} class="card__icon" />
+		<span class="card__soon">Soon</span>
+	</div>
+{:else if description}
 	<a
 		{href}
-		class="group flex flex-col p-4 bg-[var(--bg-base)] border border-[var(--border)] rounded-[6px] transition-all duration-200 hover:scale-[1.01] active:scale-[0.99] active:bg-[var(--bg-subtle)] no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]"
-		style="--hover-glow: {config.glow};"
-		onmouseenter={(e) => {
-			e.currentTarget.style.boxShadow = config.glow;
-			e.currentTarget.style.borderColor = config.border;
-		}}
-		onmouseleave={(e) => {
-			e.currentTarget.style.boxShadow = 'none';
-			e.currentTarget.style.borderColor = '';
-		}}
+		class="card card--full"
+		style="--ink: {accentVar}; --ink-tint: {accentSubtleVar};"
 	>
-		<div class="flex items-start justify-between mb-3">
-			<div
-				class="flex items-center justify-center w-8 h-8 rounded-md"
-				style="color: {config.text}; background: {config.gradient};"
-			>
-				<IconComponent size={20} strokeWidth={2} />
-			</div>
+		<div class="card__header">
+			<span class="card__index">{indexLabel}</span>
+			<span class="card__dot"></span>
+			<IconComponent size={15} strokeWidth={1.75} class="card__icon" />
 		</div>
-
-		<div class="flex flex-col gap-1.5">
-			<h3
-				class="text-base font-medium tracking-tight text-[var(--text-primary)] group-hover:text-[var(--text-primary)] transition-colors"
-			>
-				{title}
-			</h3>
-			<p
-				class="text-sm text-[var(--text-muted)] leading-relaxed group-hover:text-[var(--text-secondary)] transition-colors"
-			>
-				{description}
-			</p>
+		<div class="card__body">
+			<h3 class="card__title">{title}</h3>
+			<p class="card__desc">{description}</p>
 		</div>
 	</a>
-{:else if disabled}
-	<!-- Disabled/placeholder compact card -->
-	<div
-		class="group relative flex items-center justify-center px-4 py-3 bg-[var(--bg-subtle)] border border-[var(--border)] border-dashed rounded-[6px] opacity-50 cursor-not-allowed"
-	>
-		<div
-			class="absolute left-4 flex items-center justify-center w-7 h-7 rounded-md"
-			style="color: {config.text}; background: {config.gradient};"
-		>
-			<IconComponent size={18} strokeWidth={2} />
-		</div>
-		<h3 class="text-sm font-medium tracking-tight text-[var(--text-muted)]">
-			{title}
-		</h3>
-		<span
-			class="absolute right-4 text-[10px] font-medium text-[var(--text-faint)] uppercase tracking-wider"
-			>Soon</span
-		>
-	</div>
 {:else}
-	<!-- Compact layout without description -->
 	<a
 		{href}
-		class="group relative flex items-center justify-center px-4 py-3 bg-[var(--bg-base)] border border-[var(--border)] rounded-[6px] transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] active:bg-[var(--bg-subtle)] no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]"
-		onmouseenter={(e) => {
-			e.currentTarget.style.boxShadow = config.glow;
-			e.currentTarget.style.borderColor = config.border;
-		}}
-		onmouseleave={(e) => {
-			e.currentTarget.style.boxShadow = 'none';
-			e.currentTarget.style.borderColor = '';
-		}}
+		class="card"
+		style="--ink: {accentVar}; --ink-tint: {accentSubtleVar};"
 	>
-		<div
-			class="absolute left-4 flex items-center justify-center w-7 h-7 rounded-md transition-all duration-200"
-			style="color: {config.text}; background: {config.gradient};"
-		>
-			<IconComponent size={18} strokeWidth={2} />
-		</div>
-		<h3
-			class="text-sm font-medium tracking-tight text-[var(--text-primary)] group-hover:text-[var(--text-primary)] transition-colors"
-		>
-			{title}
-		</h3>
+		<span class="card__index">{indexLabel}</span>
+		<span class="card__dot"></span>
+		<span class="card__title">{title}</span>
+		<IconComponent size={15} strokeWidth={1.75} class="card__icon" />
 	</a>
 {/if}
+
+<style>
+	.card {
+		position: relative;
+		display: grid;
+		grid-template-columns: auto auto 1fr auto;
+		align-items: center;
+		gap: 10px;
+		padding: 12px 14px;
+		background: var(--bg-base);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		text-decoration: none;
+		color: var(--text-primary);
+		transition:
+			background var(--duration-fast) var(--ease),
+			border-color var(--duration-fast) var(--ease),
+			transform var(--duration-fast) var(--ease);
+		overflow: hidden;
+	}
+
+	/* Thin ink accent line on the left, only visible on hover */
+	.card::before {
+		content: '';
+		position: absolute;
+		left: 0;
+		top: 0;
+		bottom: 0;
+		width: 2px;
+		background: var(--ink);
+		transform: scaleY(0);
+		transform-origin: top center;
+		transition: transform var(--duration-base) var(--ease);
+	}
+
+	.card:hover {
+		background: var(--ink-tint);
+		border-color: var(--ink);
+	}
+
+	.card:hover::before {
+		transform: scaleY(1);
+	}
+
+	.card:active {
+		transform: translateY(1px);
+	}
+
+	.card__index {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		letter-spacing: 0.08em;
+		color: var(--text-faint);
+		font-variant-numeric: tabular-nums;
+		min-width: 20px;
+	}
+
+	.card__dot {
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
+		background: var(--ink);
+		flex-shrink: 0;
+	}
+
+	.card__title {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--text-primary);
+		font-weight: 500;
+		white-space: nowrap;
+	}
+
+	.card :global(.card__icon) {
+		color: var(--text-faint);
+		transition: color var(--duration-fast);
+	}
+
+	.card:hover :global(.card__icon) {
+		color: var(--ink);
+	}
+
+	/* ===== Full card with description ===== */
+	.card--full {
+		display: flex;
+		flex-direction: column;
+		padding: 16px;
+		gap: 14px;
+		min-height: 120px;
+	}
+
+	.card--full .card__header {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+	}
+
+	.card--full .card__header .card__index {
+		margin-left: auto;
+		order: 3;
+	}
+
+	.card--full .card__body {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.card--full .card__title {
+		font-family: var(--font-serif);
+		font-style: italic;
+		font-size: 22px;
+		line-height: 1;
+		letter-spacing: -0.015em;
+		text-transform: none;
+		color: var(--text-primary);
+	}
+
+	.card__desc {
+		font-size: 13px;
+		line-height: 1.5;
+		color: var(--text-muted);
+	}
+
+	/* ===== Disabled ===== */
+	.card--disabled {
+		background: var(--bg-subtle);
+		border-style: dashed;
+		opacity: 0.55;
+		cursor: not-allowed;
+	}
+
+	.card--disabled:hover {
+		background: var(--bg-subtle);
+		border-color: var(--border);
+	}
+
+	.card__soon {
+		font-family: var(--font-mono);
+		font-size: 9px;
+		letter-spacing: 0.2em;
+		text-transform: uppercase;
+		color: var(--text-faint);
+	}
+</style>

--- a/frontend/src/lib/components/ProjectCard.svelte
+++ b/frontend/src/lib/components/ProjectCard.svelte
@@ -109,7 +109,7 @@
 			<div class="min-w-0 flex-1">
 				<div class="flex items-start justify-between gap-2 mb-1">
 					<h4
-						class="text-sm font-mono font-medium text-[var(--accent)] leading-tight truncate"
+						class="text-sm font-medium text-[var(--text-primary)] leading-tight truncate group-hover:text-[var(--accent)] transition-colors"
 					>
 						{relativePath || getProjectName(project.path)}
 					</h4>
@@ -211,7 +211,7 @@
 
 			<div class="min-w-0 flex-1">
 				<h3
-					class="text-sm font-mono font-medium text-[var(--accent)] leading-tight truncate mb-0.5"
+					class="text-sm font-medium text-[var(--text-primary)] leading-tight truncate mb-0.5 group-hover:text-[var(--accent)] transition-colors"
 				>
 					{getProjectName(project.path)}
 				</h3>

--- a/frontend/src/lib/components/SessionCard.svelte
+++ b/frontend/src/lib/components/SessionCard.svelte
@@ -160,8 +160,7 @@
 
 				<!-- Session Name (title → slug → uuid) -->
 				<span
-					class="text-xs font-medium truncate flex-1"
-					class:text-[var(--accent)]={hasTitle}
+					class="text-xs font-medium truncate flex-1 text-[var(--text-primary)] group-hover:text-[var(--accent)] transition-colors"
 					class:text-[var(--text-secondary)]={!hasTitle}
 					class:italic={!hasTitle}
 					class:font-mono={!hasTitle && !displaySlug}
@@ -240,8 +239,7 @@
 						<!-- Session Name (title → slug → uuid) -->
 						<div class="flex items-center gap-2 min-w-0">
 							<span
-								class="text-sm font-medium truncate"
-								class:text-[var(--accent)]={hasTitle}
+								class="text-sm font-medium truncate text-[var(--text-primary)] group-hover:text-[var(--accent)] transition-colors"
 								class:text-[var(--text-secondary)]={!hasTitle}
 								class:italic={!hasTitle}
 								class:font-mono={!hasTitle && !displaySlug}

--- a/frontend/src/lib/components/StatsCard.svelte
+++ b/frontend/src/lib/components/StatsCard.svelte
@@ -10,7 +10,6 @@
 		icon?: any;
 		class?: string;
 		color?: StatColor;
-		// Token breakdown visualization
 		tokenIn?: number;
 		tokenOut?: number;
 	}
@@ -26,44 +25,30 @@
 		tokenOut
 	}: Props = $props();
 
-	// Color map matching NavigationCard pattern for icon backgrounds
-	const colorClasses: Record<StatColor, { bg: string; text: string }> = {
-		blue: {
-			bg: 'bg-[var(--nav-blue-subtle)] border-[var(--nav-blue)]/20',
-			text: 'text-[var(--nav-blue)]'
-		},
-		green: {
-			bg: 'bg-[var(--nav-green-subtle)] border-[var(--nav-green)]/20',
-			text: 'text-[var(--nav-green)]'
-		},
-		orange: {
-			bg: 'bg-[var(--nav-orange-subtle)] border-[var(--nav-orange)]/20',
-			text: 'text-[var(--nav-orange)]'
-		},
-		purple: {
-			bg: 'bg-[var(--nav-purple-subtle)] border-[var(--nav-purple)]/20',
-			text: 'text-[var(--nav-purple)]'
-		},
-		teal: {
-			bg: 'bg-[var(--nav-teal-subtle)] border-[var(--nav-teal)]/20',
-			text: 'text-[var(--nav-teal)]'
-		},
-		gray: {
-			bg: 'bg-[var(--bg-base)] border-[var(--border)]',
-			text: 'text-[var(--text-muted)]'
-		},
-		accent: {
-			bg: 'bg-[var(--accent-subtle)] border-[var(--accent)]/20',
-			text: 'text-[var(--accent)]'
-		}
+	// Ink palette per color key. Tokens already retuned in app.css.
+	const inkColor: Record<StatColor, string> = {
+		blue: 'var(--nav-blue)',
+		green: 'var(--nav-green)',
+		orange: 'var(--nav-orange)',
+		purple: 'var(--nav-purple)',
+		teal: 'var(--nav-teal)',
+		gray: 'var(--text-muted)',
+		accent: 'var(--accent)'
 	};
 
-	// Derive icon container and text classes based on color prop
-	let iconBgClass = $derived(color ? colorClasses[color].bg : colorClasses.gray.bg);
-	let iconTextClass = $derived(color ? colorClasses[color].text : colorClasses.gray.text);
+	const inkTint: Record<StatColor, string> = {
+		blue: 'var(--nav-blue-subtle)',
+		green: 'var(--nav-green-subtle)',
+		orange: 'var(--nav-orange-subtle)',
+		purple: 'var(--nav-purple-subtle)',
+		teal: 'var(--nav-teal-subtle)',
+		gray: 'var(--bg-muted)',
+		accent: 'var(--accent-subtle)'
+	};
 
-	// Calculate token percentages for visualization
-	// Only show breakdown if at least one token value is greater than 0
+	const ink = $derived(color ? inkColor[color] : 'var(--text-muted)');
+	const tint = $derived(color ? inkTint[color] : 'var(--bg-muted)');
+
 	let hasTokenBreakdown = $derived(
 		tokenIn !== undefined && tokenOut !== undefined && (tokenIn > 0 || tokenOut > 0)
 	);
@@ -72,75 +57,174 @@
 	let outPercent = $derived(totalTokens > 0 ? ((tokenOut || 0) / totalTokens) * 100 : 0);
 </script>
 
-<div
-	class="
-		p-5
-		bg-[var(--bg-base)]
-		border border-[var(--border)]
-		rounded-xl
-		shadow-sm hover:shadow-md
-		transition-all duration-300
-		{className}
-	"
->
-	<!-- Label at top with optional description in brackets -->
-	<div class="text-xs uppercase tracking-wider font-semibold text-[var(--text-muted)] mb-3">
-		{title}{#if description}<span class="normal-case tracking-normal font-normal">
-				({description})</span
-			>{/if}
+<div class="stat {className}" style="--ink: {ink}; --tint: {tint};">
+	<div class="stat__label">
+		<span class="stat__dot"></span>
+		<span class="stat__title">{title}</span>
+		{#if description}
+			<span class="stat__desc">({description})</span>
+		{/if}
 	</div>
 
-	<!-- Icon + Value aligned -->
-	<div class="flex items-center gap-3">
+	<div class="stat__row">
 		{#if Icon}
-			<div
-				class="
-					flex items-center justify-center
-					w-11 h-11
-					border
-					rounded-xl
-					shrink-0
-					transition-transform duration-300 hover:scale-105
-					{iconBgClass}
-				"
-			>
-				<Icon size={20} strokeWidth={2.5} class={iconTextClass} />
+			<div class="stat__icon">
+				<Icon size={16} strokeWidth={1.75} />
 			</div>
 		{/if}
-		<div class="flex-1 min-w-0">
-			<div class="text-2xl font-bold metric-value text-[var(--text-primary)] tracking-tight">
-				{value}
-			</div>
-		</div>
+		<div class="stat__value">{value}</div>
 	</div>
 
-	<!-- Token breakdown visualization -->
 	{#if hasTokenBreakdown}
-		<div class="mt-3 space-y-1.5">
-			<!-- Visual bar -->
-			<div class="flex h-2 rounded-full overflow-hidden bg-[var(--bg-muted)]">
-				<div
-					class="bg-[var(--accent)] transition-all duration-300"
-					style="width: {inPercent}%"
-					title="Input: {formatTokens(tokenIn)}"
-				></div>
-				<div
-					class="bg-[var(--nav-teal)] transition-all duration-300"
-					style="width: {outPercent}%"
-					title="Output: {formatTokens(tokenOut)}"
-				></div>
+		<div class="stat__breakdown">
+			<div class="stat__bar">
+				<span class="stat__bar-in" style="width: {inPercent}%" title="Input"></span>
+				<span class="stat__bar-out" style="width: {outPercent}%" title="Output"></span>
 			</div>
-			<!-- Labels -->
-			<div class="flex justify-between text-[10px] text-[var(--text-muted)]">
-				<span class="flex items-center gap-1">
-					<span class="w-2 h-2 rounded-full bg-[var(--accent)]"></span>
-					In: {formatTokens(tokenIn)}
+			<div class="stat__legend">
+				<span class="stat__leg">
+					<span class="stat__leg-dot stat__leg-dot--in"></span>
+					In · {formatTokens(tokenIn)}
 				</span>
-				<span class="flex items-center gap-1">
-					<span class="w-2 h-2 rounded-full bg-[var(--nav-teal)]"></span>
-					Out: {formatTokens(tokenOut)}
+				<span class="stat__leg">
+					<span class="stat__leg-dot stat__leg-dot--out"></span>
+					Out · {formatTokens(tokenOut)}
 				</span>
 			</div>
 		</div>
 	{/if}
 </div>
+
+<style>
+	.stat {
+		position: relative;
+		padding: 18px 18px 20px;
+		background: var(--bg-base);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		transition: border-color var(--duration-fast) var(--ease);
+	}
+
+	.stat:hover {
+		border-color: var(--border-hover);
+	}
+
+	.stat__label {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin-bottom: 14px;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		letter-spacing: 0.16em;
+		text-transform: uppercase;
+		color: var(--text-muted);
+		font-weight: 500;
+	}
+
+	.stat__dot {
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
+		background: var(--ink);
+		flex-shrink: 0;
+	}
+
+	.stat__title {
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.stat__desc {
+		letter-spacing: 0;
+		text-transform: none;
+		font-weight: 400;
+		color: var(--text-faint);
+	}
+
+	.stat__row {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+	}
+
+	.stat__icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border-radius: var(--radius-sm);
+		color: var(--ink);
+		background: var(--tint);
+		flex-shrink: 0;
+	}
+
+	.stat__value {
+		font-size: 28px;
+		font-weight: 600;
+		letter-spacing: -0.02em;
+		line-height: 1.1;
+		color: var(--text-primary);
+		font-variant-numeric: tabular-nums;
+		min-width: 0;
+		flex: 1;
+	}
+
+	.stat__breakdown {
+		margin-top: 14px;
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.stat__bar {
+		display: flex;
+		height: 4px;
+		border-radius: 2px;
+		overflow: hidden;
+		background: var(--bg-muted);
+	}
+
+	.stat__bar-in {
+		background: var(--accent);
+		transition: width var(--duration-base) var(--ease);
+	}
+
+	.stat__bar-out {
+		background: var(--nav-teal);
+		transition: width var(--duration-base) var(--ease);
+	}
+
+	.stat__legend {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.stat__leg {
+		display: inline-flex;
+		align-items: center;
+		gap: 5px;
+	}
+
+	.stat__leg-dot {
+		width: 5px;
+		height: 5px;
+		border-radius: 50%;
+	}
+
+	.stat__leg-dot--in {
+		background: var(--accent);
+	}
+
+	.stat__leg-dot--out {
+		background: var(--nav-teal);
+	}
+</style>

--- a/frontend/src/lib/components/charts/chartConfig.ts
+++ b/frontend/src/lib/components/charts/chartConfig.ts
@@ -1,48 +1,85 @@
 import { Chart } from 'chart.js';
 
+const MONO_STACK = "'Geist Mono', 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace";
+const SANS_STACK = "'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif";
+
 /**
- * Register global Chart.js defaults for consistent styling across all charts
- * Should be called once during app initialization or in each chart component's onMount
+ * Resolve theme colors from CSS custom properties. Chart.js cannot accept
+ * raw `var(--x)` strings — it needs concrete color values at option time.
+ * Read fresh on every config call so theme toggles pick up the new palette
+ * when the consumer rebuilds the chart.
  */
-export function registerChartDefaults() {
-	Chart.defaults.font.family = 'JetBrains Mono, monospace';
-	Chart.defaults.color = 'var(--text-secondary)';
+export function getThemeColors() {
+	if (typeof window === 'undefined') {
+		return {
+			primary: '#a87c1e',
+			text: '#1b1712',
+			textSecondary: '#47403a',
+			textMuted: '#766d60',
+			border: 'rgba(27,23,18,0.11)',
+			bgBase: '#f3ede1',
+			bgMuted: '#dfd4bd',
+			bgSubtle: '#ebe3d2'
+		};
+	}
+	const style = getComputedStyle(document.documentElement);
+	const read = (name: string, fallback: string) =>
+		style.getPropertyValue(name).trim() || fallback;
+	return {
+		primary: read('--accent', '#a87c1e'),
+		text: read('--text-primary', '#1b1712'),
+		textSecondary: read('--text-secondary', '#47403a'),
+		textMuted: read('--text-muted', '#766d60'),
+		border: read('--border', 'rgba(27,23,18,0.11)'),
+		bgBase: read('--bg-base', '#f3ede1'),
+		bgMuted: read('--bg-muted', '#dfd4bd'),
+		bgSubtle: read('--bg-subtle', '#ebe3d2')
+	};
 }
 
 /**
- * Create a responsive chart configuration with common options
- * @param maintainAspectRatio - Whether to maintain aspect ratio (default: false for better container fitting)
- * @returns Base configuration object that can be spread into chart options
+ * Register global Chart.js defaults. Call once on app init.
+ */
+export function registerChartDefaults() {
+	const c = getThemeColors();
+	Chart.defaults.font.family = MONO_STACK;
+	Chart.defaults.color = c.textSecondary;
+}
+
+/**
+ * Base chart config with tooltip + legend styling resolved to concrete
+ * theme colors. Rebuild the chart to respond to a theme toggle.
  */
 export function createResponsiveConfig(maintainAspectRatio = false) {
+	const c = getThemeColors();
 	return {
 		responsive: true,
 		maintainAspectRatio,
 		plugins: {
 			legend: {
 				labels: {
-					color: 'var(--text-secondary)',
+					color: c.textSecondary,
 					font: {
-						family: 'JetBrains Mono, monospace',
+						family: MONO_STACK,
 						size: 11
 					}
 				}
 			},
 			tooltip: {
-				backgroundColor: 'var(--bg-base)', // High contrast background
-				titleColor: 'var(--text-primary)',
-				bodyColor: 'var(--text-secondary)',
-				borderColor: 'var(--border)',
+				backgroundColor: c.bgBase,
+				titleColor: c.text,
+				bodyColor: c.textSecondary,
+				borderColor: c.border,
 				borderWidth: 1,
 				padding: 10,
-				cornerRadius: 8,
-				displayColors: false, // Cleaner look without color box
+				cornerRadius: 6,
+				displayColors: false,
 				titleFont: {
-					family: 'Inter, sans-serif',
+					family: SANS_STACK,
 					weight: 600
 				},
 				bodyFont: {
-					family: 'JetBrains Mono, monospace'
+					family: MONO_STACK
 				}
 			}
 		}
@@ -50,39 +87,20 @@ export function createResponsiveConfig(maintainAspectRatio = false) {
 }
 
 /**
- * Get theme colors from CSS custom properties
- * Useful for dynamic color assignment based on current theme
- * @returns Object containing commonly used theme colors
- */
-export function getThemeColors() {
-	const style = getComputedStyle(document.documentElement);
-	return {
-		primary: style.getPropertyValue('--accent').trim(),
-		text: style.getPropertyValue('--text-primary').trim(),
-		textSecondary: style.getPropertyValue('--text-secondary').trim(),
-		textMuted: style.getPropertyValue('--text-muted').trim(),
-		border: style.getPropertyValue('--border').trim(),
-		bgBase: style.getPropertyValue('--bg-base').trim(),
-		bgMuted: style.getPropertyValue('--bg-muted').trim(),
-		bgSubtle: style.getPropertyValue('--bg-subtle').trim()
-	};
-}
-
-/**
- * Create common scale configuration for line charts
- * @returns Scale configuration object for x and y axes
+ * Common scale config for axis-style charts, with resolved colors.
  */
 export function createCommonScaleConfig() {
+	const c = getThemeColors();
 	return {
 		x: {
 			grid: {
-				color: 'rgba(128, 128, 128, 0.1)', // Subtle grid lines works in light and dark
+				color: 'rgba(128, 128, 128, 0.1)',
 				drawOnChartArea: false
 			},
 			ticks: {
-				color: 'var(--text-muted)',
+				color: c.textMuted,
 				font: {
-					family: 'JetBrains Mono, monospace',
+					family: MONO_STACK,
 					size: 10
 				},
 				maxRotation: 0
@@ -92,12 +110,12 @@ export function createCommonScaleConfig() {
 			beginAtZero: true,
 			grace: '20%',
 			grid: {
-				color: 'rgba(128, 128, 128, 0.1)' // Subtle grid lines
+				color: 'rgba(128, 128, 128, 0.1)'
 			},
 			ticks: {
-				color: 'var(--text-muted)',
+				color: c.textMuted,
 				font: {
-					family: 'JetBrains Mono, monospace',
+					family: MONO_STACK,
 					size: 10
 				},
 				precision: 0
@@ -107,52 +125,47 @@ export function createCommonScaleConfig() {
 }
 
 /**
- * Get chart colors from CSS variables (for dynamic theme support)
- * Call this in onMount or use getComputedStyle for live values
+ * Data palette for series colors. Pulled from --data-* tokens when available.
  */
 export function getChartColorPalette(): string[] {
 	if (typeof window === 'undefined') {
-		// SSR fallback
-		return ['#7c3aed', '#3b82f6', '#10b981', '#f59e0b', '#ef4444'];
+		return ['#a87c1e', '#3a5578', '#5a7140', '#a06030', '#8a3a3a'];
 	}
-
 	const style = getComputedStyle(document.documentElement);
+	const read = (name: string, fallback: string) =>
+		style.getPropertyValue(name).trim() || fallback;
 	return [
-		style.getPropertyValue('--data-primary').trim() || '#7c3aed',
-		style.getPropertyValue('--data-secondary').trim() || '#3b82f6',
-		style.getPropertyValue('--data-tertiary').trim() || '#10b981',
-		style.getPropertyValue('--data-quaternary').trim() || '#f59e0b',
-		style.getPropertyValue('--data-quinary').trim() || '#ef4444'
+		read('--data-primary', '#a87c1e'),
+		read('--data-secondary', '#3a5578'),
+		read('--data-tertiary', '#5a7140'),
+		read('--data-quaternary', '#a06030'),
+		read('--data-quinary', '#8a3a3a')
 	];
 }
 
 /**
- * Color palette for charts (legacy export for backwards compatibility)
- * Note: These CSS variables may not work directly with Chart.js
- * Use getChartColorPalette() in onMount for computed values
+ * Larger palette for charts needing many distinct colors.
+ * Kept in sync with the editorial ink palette.
  */
 export const chartColorPalette = [
-	'#7c3aed', // accent (purple)
-	'#3b82f6', // blue
-	'#10b981', // green
-	'#f59e0b', // amber
-	'#ef4444', // red
-	'#ec4899', // pink
-	'#8b5cf6', // violet
-	'#06b6d4', // cyan
-	'#84cc16', // lime
-	'#f97316', // orange
-	'#6366f1', // indigo
-	'#14b8a6', // teal
-	'#a855f7', // purple
-	'#eab308', // yellow
-	'#0ea5e9', // sky
-	'#d946ef' // fuchsia
+	'#a87c1e', // accent amber
+	'#3a5578', // ink blue
+	'#5a7140', // moss
+	'#a06030', // terracotta
+	'#8a3a3a', // oxblood
+	'#63557b', // iris
+	'#3a6868', // verdigris
+	'#7a4868', // aubergine
+	'#475088', // woad
+	'#8a7230', // ochre
+	'#956a30', // burnt amber
+	'#5a5750', // graphite
+	'#d69260', // warm orange (dark-mode dual)
+	'#b19ad1', // pale iris
+	'#7ab5a8', // teal
+	'#d1b76a' // saffron
 ];
 
-/**
- * Get a color from the palette, cycling if index exceeds palette length
- */
 export function getChartColor(index: number): string {
 	return chartColorPalette[index % chartColorPalette.length];
 }

--- a/frontend/src/lib/components/command-palette/CommandPalette.svelte
+++ b/frontend/src/lib/components/command-palette/CommandPalette.svelte
@@ -581,7 +581,7 @@
 		transform: translateX(-50%);
 		background: var(--bg-base);
 		border: 1px solid var(--border);
-		border-radius: 1rem;
+		border-radius: 0.5rem;
 		overflow: hidden;
 		box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.4);
 		animation: scaleIn 150ms cubic-bezier(0.16, 1, 0.3, 1);
@@ -666,13 +666,14 @@
 		color: var(--text-muted);
 	}
 
-	/* Heading */
+	/* Heading — mono caps eyebrow to match masthead */
 	:global(.cmd-heading) {
 		padding: 0.75rem 0.75rem 0.5rem;
-		font-size: 0.6875rem;
-		font-weight: 600;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		font-weight: 500;
 		text-transform: uppercase;
-		letter-spacing: 0.1em;
+		letter-spacing: 0.18em;
 		color: var(--accent);
 	}
 

--- a/frontend/src/lib/components/layout/PageHeader.svelte
+++ b/frontend/src/lib/components/layout/PageHeader.svelte
@@ -41,105 +41,69 @@
 </script>
 
 <div class={className}>
-	<!-- Breadcrumb Navigation -->
+	<!-- Breadcrumb — mono caps, matches compact header nav -->
 	{#if breadcrumbs.length > 0}
-		<div class="flex items-center gap-2 text-xs text-[var(--text-secondary)] mb-4">
+		<nav class="ph-breadcrumbs" aria-label="Breadcrumb">
 			{#each breadcrumbs as crumb, i}
 				{#if i > 0}
-					<span class="text-[var(--text-faint)]">/</span>
+					<span class="ph-breadcrumb-sep" aria-hidden="true">/</span>
 				{/if}
 				{#if crumb.href}
-					<a
-						href={crumb.href}
-						class="hover:text-[var(--text-primary)] transition-colors"
-						style="transition-duration: var(--duration-fast); transition-timing-function: var(--ease);"
-					>
-						{crumb.label}
-					</a>
+					<a href={crumb.href} class="ph-breadcrumb-link">{crumb.label}</a>
 				{:else}
-					<span class="text-[var(--text-primary)] font-medium">{crumb.label}</span>
+					<span class="ph-breadcrumb-current" aria-current="page">{crumb.label}</span>
 				{/if}
 			{/each}
-		</div>
+		</nav>
 	{/if}
 
-	<!-- Page Header -->
-	<div class="mb-6 pb-6 border-b border-[var(--border)]">
-		<div class="flex items-start gap-4">
-			<!-- Icon -->
+	<!-- Masthead row -->
+	<div class="ph-masthead">
+		<div class="ph-main">
 			{#if Icon}
 				<div
-					class="
-						inline-flex items-center justify-center
-						w-12 h-12
-						border
-						rounded-[var(--radius-md)]
-						shrink-0
-					"
+					class="ph-icon"
 					style={iconColorRaw
-						? `background-color: ${iconColorRaw.subtle}; border-color: ${iconColorRaw.color}; color: ${iconColorRaw.color};`
+						? `background-color: ${iconColorRaw.subtle}; color: ${iconColorRaw.color};`
 						: iconColor
-							? `background-color: var(${iconColor}-subtle); border-color: var(${iconColor}); color: var(${iconColor});`
-							: 'background-color: var(--bg-subtle); border-color: var(--border); color: var(--text-muted);'}
+							? `background-color: var(${iconColor}-subtle); color: var(${iconColor});`
+							: 'background-color: var(--bg-subtle); color: var(--text-muted);'}
 				>
-					<Icon size={24} strokeWidth={2} />
+					<Icon size={20} strokeWidth={1.75} />
 				</div>
 			{/if}
 
-			<!-- Title and Content -->
-			<div class="flex-1 min-w-0">
-				<div class="flex items-center gap-3 mb-2">
-					<h1 class="text-2xl font-semibold tracking-tight text-[var(--text-primary)]">
-						{title}
-					</h1>
+			<div class="ph-body">
+				<div class="ph-title-row">
+					<h1 class="ph-title">{title}</h1>
 					{#if badges}
 						{@render badges()}
 					{/if}
 				</div>
+
 				{#if subtitle}
-					<span
-						class="
-							inline-flex
-							px-2 py-0.5
-							text-xs font-mono
-							text-[var(--text-muted)]
-							bg-[var(--bg-muted)]
-							rounded-[var(--radius-sm)]
-						">{subtitle}</span
-					>
+					<p class="ph-subtitle">{subtitle}</p>
 				{/if}
 
 				{#if metadata.length > 0}
-					<div
-						class="flex items-center gap-3 text-xs text-[var(--text-muted)] mt-3 flex-wrap"
-					>
+					<div class="ph-metadata">
 						{#each metadata as item, i}
 							{#if i > 0}
-								<span class="text-[var(--text-faint)]">•</span>
+								<span class="ph-metadata-sep" aria-hidden="true">·</span>
 							{/if}
 							{#if item.href}
-								<a
-									href={item.href}
-									class="flex items-center gap-1.5 hover:text-[var(--accent)] transition-colors {item.class ||
-										''}"
-								>
+								<a href={item.href} class="ph-metadata-item {item.class || ''}">
 									{#if item.icon}
 										{@const ItemIcon = item.icon}
-										<ItemIcon
-											size={12}
-											strokeWidth={2}
-										/>
+										<ItemIcon size={12} strokeWidth={1.75} />
 									{/if}
 									<span>{item.text}</span>
 								</a>
 							{:else}
-								<div class="flex items-center gap-1.5 {item.class || ''}">
+								<div class="ph-metadata-item ph-metadata-item--static {item.class || ''}">
 									{#if item.icon}
 										{@const ItemIcon = item.icon}
-										<ItemIcon
-											size={12}
-											strokeWidth={2}
-										/>
+										<ItemIcon size={12} strokeWidth={1.75} />
 									{/if}
 									<span>{item.text}</span>
 								</div>
@@ -148,13 +112,144 @@
 					</div>
 				{/if}
 			</div>
-
-			<!-- Right Side Content (e.g., Model Badge) -->
-			{#if headerRight}
-				<div class="shrink-0">
-					{@render headerRight()}
-				</div>
-			{/if}
 		</div>
+
+		{#if headerRight}
+			<div class="ph-right">
+				{@render headerRight()}
+			</div>
+		{/if}
 	</div>
+
+	<div class="ph-rule" aria-hidden="true"></div>
 </div>
+
+<style>
+	.ph-breadcrumbs {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin-bottom: 14px;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--text-muted);
+	}
+
+	.ph-breadcrumb-sep {
+		color: var(--text-faint);
+	}
+
+	.ph-breadcrumb-link {
+		color: var(--text-muted);
+		text-decoration: none;
+		transition: color var(--duration-fast) var(--ease);
+	}
+
+	.ph-breadcrumb-link:hover {
+		color: var(--text-primary);
+	}
+
+	.ph-breadcrumb-current {
+		color: var(--text-primary);
+	}
+
+	.ph-masthead {
+		display: flex;
+		align-items: flex-end;
+		justify-content: space-between;
+		gap: 16px;
+		margin-bottom: 18px;
+	}
+
+	.ph-main {
+		display: flex;
+		align-items: flex-start;
+		gap: 14px;
+		min-width: 0;
+		flex: 1;
+	}
+
+	.ph-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 36px;
+		height: 36px;
+		border-radius: var(--radius-sm);
+		flex-shrink: 0;
+		margin-top: 4px;
+	}
+
+	.ph-body {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+		flex: 1;
+	}
+
+	.ph-title-row {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		flex-wrap: wrap;
+	}
+
+	.ph-title {
+		margin: 0;
+		font-family: var(--font-serif);
+		font-style: italic;
+		font-weight: 400;
+		font-size: 40px;
+		line-height: 1;
+		letter-spacing: -0.025em;
+		color: var(--text-primary);
+	}
+
+	.ph-subtitle {
+		margin: 8px 0 0;
+		font-family: var(--font-mono);
+		font-size: 10px;
+		letter-spacing: 0.16em;
+		text-transform: uppercase;
+		color: var(--text-muted);
+	}
+
+	.ph-metadata {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		margin-top: 12px;
+		flex-wrap: wrap;
+		font-size: 12px;
+		color: var(--text-muted);
+	}
+
+	.ph-metadata-sep {
+		color: var(--text-faint);
+	}
+
+	.ph-metadata-item {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		text-decoration: none;
+		color: var(--text-muted);
+		transition: color var(--duration-fast) var(--ease);
+	}
+
+	a.ph-metadata-item:hover {
+		color: var(--accent);
+	}
+
+	.ph-right {
+		flex-shrink: 0;
+	}
+
+	.ph-rule {
+		height: 1px;
+		background: var(--border);
+		margin-bottom: 24px;
+	}
+</style>

--- a/frontend/src/lib/components/ui/CollapsibleGroup.svelte
+++ b/frontend/src/lib/components/ui/CollapsibleGroup.svelte
@@ -32,6 +32,18 @@
 	}
 </script>
 
+<style>
+	.cg-title {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		font-weight: 500;
+		color: var(--text-primary);
+		margin: 0;
+	}
+</style>
+
 <div class="group {className}">
 	<div
 		class="
@@ -84,7 +96,7 @@
 			{/if}
 
 			<!-- Title -->
-			<h3 class="flex-1 text-sm font-medium text-[var(--text-primary)]">
+			<h3 class="flex-1 cg-title">
 				{title}
 			</h3>
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -16,33 +16,192 @@
 		Webhook,
 		Terminal
 	} from 'lucide-svelte';
+
+	// Index entries — ordered like a table of contents
+	const entries = [
+		{ title: 'Projects', href: '/projects', icon: FolderOpen, color: 'blue' as const },
+		{ title: 'Sessions', href: '/sessions', icon: MessageSquare, color: 'teal' as const },
+		{ title: 'Analytics', href: '/analytics', icon: LineChart, color: 'green' as const },
+		{ title: 'Plans', href: '/plans', icon: FileText, color: 'yellow' as const },
+		{ title: 'Skills', href: '/skills', icon: Wrench, color: 'orange' as const },
+		{ title: 'Agents', href: '/agents', icon: Bot, color: 'purple' as const },
+		{ title: 'Tools', href: '/tools', icon: Cable, color: 'teal' as const },
+		{ title: 'Hooks', href: '/hooks', icon: Webhook, color: 'amber' as const },
+		{ title: 'Commands', href: '/commands', icon: Terminal, color: 'red' as const },
+		{ title: 'Plugins', href: '/plugins', icon: Puzzle, color: 'violet' as const },
+		{ title: 'Archived', href: '/archived', icon: History, color: 'gray' as const },
+		{ title: 'Settings', href: '/settings', icon: Settings, color: 'indigo' as const }
+	];
 </script>
 
-<div
-	class="max-w-[560px] mx-auto flex flex-col items-center justify-center scale-120 origin-top w-full px-4"
->
-	<div class="grid grid-cols-2 sm:grid-cols-3 gap-3 w-full">
-		<NavigationCard title="Projects" href="/projects" icon={FolderOpen} color="blue" />
-		<NavigationCard title="Sessions" href="/sessions" icon={MessageSquare} color="teal" />
-		<NavigationCard title="Analytics" href="/analytics" icon={LineChart} color="green" />
-		<NavigationCard title="Plans" href="/plans" icon={FileText} color="yellow" />
-		<NavigationCard title="Skills" href="/skills" icon={Wrench} color="orange" />
-		<NavigationCard title="Agents" href="/agents" icon={Bot} color="purple" />
-		<NavigationCard title="Tools" href="/tools" icon={Cable} color="teal" />
-		<NavigationCard title="Hooks" href="/hooks" icon={Webhook} color="amber" />
-		<NavigationCard title="Commands" href="/commands" icon={Terminal} color="red" />
-		<NavigationCard title="Plugins" href="/plugins" icon={Puzzle} color="violet" />
-		<NavigationCard title="Archived" href="/archived" icon={History} color="gray" />
-		<NavigationCard title="Settings" href="/settings" icon={Settings} color="indigo" />
-	</div>
-
-	<!-- Live Sessions Terminal -->
-	<div class="mt-6 w-full">
+<div class="home">
+	<!-- Live Wire -->
+	<section class="home__section home__live">
+		<div class="section-head">
+			<span class="section-head__tag">§ 01</span>
+			<h2 class="section-head__title">Live Wire</h2>
+			<span class="section-head__rule rule"></span>
+			<span class="section-head__meta eyebrow">real-time</span>
+		</div>
 		<LiveSessionsTerminal />
-	</div>
+	</section>
 
-	<!-- Terminal Stats Display -->
-	<div class="mt-4 w-full">
-		<TerminalDisplay />
-	</div>
+	<!-- Index (navigation) -->
+	<section class="home__section home__index">
+		<div class="section-head">
+			<span class="section-head__tag">§ 02</span>
+			<h2 class="section-head__title">Index</h2>
+			<span class="section-head__rule rule"></span>
+			<span class="section-head__meta eyebrow">{entries.length} entries</span>
+		</div>
+
+		<div class="entries stagger-children">
+			{#each entries as entry, i (entry.href)}
+				<NavigationCard
+					title={entry.title}
+					href={entry.href}
+					icon={entry.icon}
+					color={entry.color}
+					index={i}
+				/>
+			{/each}
+		</div>
+	</section>
+
+	<!-- Dispatch (typewriter terminal) -->
+	<section class="home__section home__dispatch">
+		<div class="section-head">
+			<span class="section-head__tag">§ 03</span>
+			<h2 class="section-head__title">Dispatch</h2>
+			<span class="section-head__rule rule"></span>
+			<span class="section-head__meta eyebrow">today</span>
+		</div>
+		<div class="dispatch-body">
+			<TerminalDisplay />
+		</div>
+	</section>
+
+	<!-- Colophon -->
+	<footer class="home__colophon">
+		<div class="rule"></div>
+		<div class="colophon-row">
+			<span class="eyebrow">Colophon</span>
+			<span class="colophon-text">
+				Set in <em>Instrument Serif</em> and <em>Geist</em>. Data in <em>Geist Mono</em>.
+				All sessions local to <code>~/.claude/</code>.
+			</span>
+		</div>
+	</footer>
 </div>
+
+<style>
+	.home {
+		display: flex;
+		flex-direction: column;
+		gap: 64px;
+		padding-top: 8px;
+		padding-bottom: 24px;
+	}
+
+	/* ====== Section header — ruled masthead style ====== */
+	.section-head {
+		display: grid;
+		grid-template-columns: auto auto 1fr auto;
+		align-items: center;
+		gap: 14px;
+		margin-bottom: 24px;
+	}
+
+	.section-head__tag {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		letter-spacing: 0.18em;
+		text-transform: uppercase;
+		color: var(--accent);
+		font-weight: 500;
+	}
+
+	.section-head__title {
+		font-family: var(--font-serif);
+		font-style: italic;
+		font-size: 32px;
+		font-weight: 400;
+		line-height: 1;
+		letter-spacing: -0.02em;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.section-head__rule {
+		align-self: center;
+		height: 1px;
+	}
+
+	/* ====== Index grid ====== */
+	.entries {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+		gap: 8px;
+	}
+
+	@media (min-width: 640px) {
+		.entries {
+			grid-template-columns: repeat(2, 1fr);
+		}
+	}
+
+	@media (min-width: 860px) {
+		.entries {
+			grid-template-columns: repeat(3, 1fr);
+		}
+	}
+
+	@media (min-width: 1100px) {
+		.entries {
+			grid-template-columns: repeat(4, 1fr);
+		}
+	}
+
+	/* ====== Dispatch ====== */
+	.dispatch-body {
+		padding: 28px 16px;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		background: var(--bg-subtle);
+	}
+
+	/* ====== Colophon ====== */
+	.home__colophon {
+		margin-top: 24px;
+	}
+
+	.colophon-row {
+		display: flex;
+		align-items: baseline;
+		gap: 16px;
+		padding-top: 16px;
+	}
+
+	.colophon-text {
+		font-size: 13px;
+		color: var(--text-muted);
+		line-height: 1.6;
+	}
+
+	.colophon-text em {
+		font-family: var(--font-serif);
+		font-style: italic;
+		font-size: 1.08em;
+		color: var(--text-secondary);
+	}
+
+	.colophon-text code {
+		font-family: var(--font-mono);
+		font-size: 0.92em;
+		padding: 1px 6px;
+		background: var(--bg-subtle);
+		border: 1px solid var(--border-subtle);
+		border-radius: 3px;
+		color: var(--text-secondary);
+	}
+</style>

--- a/frontend/src/routes/analytics/+page.svelte
+++ b/frontend/src/routes/analytics/+page.svelte
@@ -307,6 +307,8 @@
 		const style = getComputedStyle(document.documentElement);
 		const textMuted = style.getPropertyValue('--text-muted').trim() || '#94a3b8';
 		const textPrimary = style.getPropertyValue('--text-primary').trim() || '#0f172a';
+		const textSecondary = style.getPropertyValue('--text-secondary').trim() || '#475569';
+		const bgMuted = style.getPropertyValue('--bg-muted').trim() || '#f1f5f9';
 		const border = style.getPropertyValue('--border').trim() || 'rgba(0,0,0,0.08)';
 
 		const sessionCounts = sortedDates.map((date) => analytics.sessions_by_date[date]);
@@ -333,7 +335,11 @@
 				plugins: {
 					legend: { display: false },
 					tooltip: {
-						backgroundColor: textPrimary,
+						backgroundColor: bgMuted,
+						titleColor: textPrimary,
+						bodyColor: textSecondary,
+						borderColor: border,
+						borderWidth: 1,
 						padding: 10,
 						cornerRadius: 6,
 						displayColors: false

--- a/frontend/src/routes/plans/+page.server.ts
+++ b/frontend/src/routes/plans/+page.server.ts
@@ -7,7 +7,7 @@ export async function load({ fetch, url }) {
 	const project = url.searchParams.get('project') || '';
 	const branch = url.searchParams.get('branch') || '';
 	const page = parseInt(url.searchParams.get('page') || '1', 10);
-	const perPage = parseInt(url.searchParams.get('per_page') || '24', 10);
+	const perPage = parseInt(url.searchParams.get('per_page') || '100', 10);
 
 	// Build query params for API
 	const params = new URLSearchParams();

--- a/frontend/src/routes/plans/+page.svelte
+++ b/frontend/src/routes/plans/+page.svelte
@@ -204,11 +204,6 @@
 	// Plans from current response
 	let filteredPlans = $derived(plansResponse.plans);
 
-	// Pagination handler
-	function goToPage(page: number) {
-		currentPage = page;
-	}
-
 	// Day-based grouping (operates on current page's plans)
 	type DateGroup = {
 		key: string;

--- a/frontend/src/routes/plans/+page.svelte
+++ b/frontend/src/routes/plans/+page.svelte
@@ -8,6 +8,10 @@
 	import { PlanCard } from '$lib/components/plan';
 	import Pagination from '$lib/components/Pagination.svelte';
 	import TokenSearchInput from '$lib/components/TokenSearchInput.svelte';
+	import Tabs from '$lib/components/ui/Tabs.svelte';
+	import TabsList from '$lib/components/ui/TabsList.svelte';
+	import TabsTrigger from '$lib/components/ui/TabsTrigger.svelte';
+	import TabsContent from '$lib/components/ui/TabsContent.svelte';
 	import { paramToTokens, tokensToParam } from '$lib/search';
 	import { keyboardOverrides } from '$lib/stores/keyboardOverrides';
 	import { API_BASE } from '$lib/config';
@@ -104,7 +108,7 @@
 		if (selectedProject) params.set('project', selectedProject);
 		if (selectedBranch) params.set('branch', selectedBranch);
 		if (currentPage > 1) params.set('page', currentPage.toString());
-		if (perPage !== 24) params.set('per_page', perPage.toString());
+		if (perPage !== 100) params.set('per_page', perPage.toString());
 
 		const newUrl = params.toString() ? `?${params}` : window.location.pathname;
 		try {
@@ -207,6 +211,7 @@
 
 	// Day-based grouping (operates on current page's plans)
 	type DateGroup = {
+		key: string;
 		label: string;
 		plans: PlanWithContext[];
 	};
@@ -235,13 +240,37 @@
 		}
 
 		const groups: DateGroup[] = [];
-		if (today.length > 0) groups.push({ label: 'Today', plans: today });
-		if (yesterday.length > 0) groups.push({ label: 'Yesterday', plans: yesterday });
-		if (thisWeek.length > 0) groups.push({ label: 'This Week', plans: thisWeek });
-		if (thisMonth.length > 0) groups.push({ label: 'This Month', plans: thisMonth });
-		if (older.length > 0) groups.push({ label: 'Older', plans: older });
+		if (today.length > 0) groups.push({ key: 'today', label: 'Today', plans: today });
+		if (yesterday.length > 0)
+			groups.push({ key: 'yesterday', label: 'Yesterday', plans: yesterday });
+		if (thisWeek.length > 0)
+			groups.push({ key: 'thisWeek', label: 'This Week', plans: thisWeek });
+		if (thisMonth.length > 0)
+			groups.push({ key: 'thisMonth', label: 'This Month', plans: thisMonth });
+		if (older.length > 0) groups.push({ key: 'older', label: 'Older', plans: older });
 
 		return groups;
+	});
+
+	// Active date tab; defaults to first non-empty bucket, updates when
+	// the current tab becomes empty (e.g., after a filter narrows results).
+	let activeDateTab = $state<string>('today');
+
+	$effect(() => {
+		if (groupedByDate.length === 0) return;
+		const current = groupedByDate.find((g) => g.key === activeDateTab);
+		if (!current) {
+			activeDateTab = groupedByDate[0].key;
+		}
+	});
+
+	// Per-tab client-side pagination. Resets on tab switch.
+	const TAB_PAGE_SIZE = 30;
+	let activePage = $state(1);
+
+	$effect(() => {
+		void activeDateTab;
+		activePage = 1;
 	});
 
 	// Check if we have any plans
@@ -519,39 +548,51 @@
 				</button>
 			</div>
 		{:else}
-			<!-- Day-based Grouped View -->
-			<div class="space-y-8">
-				{#each groupedByDate as group (group.label)}
-					<div>
-						<!-- Section Header -->
-						<h2
-							class="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-4"
-						>
-							{group.label}
-							<span class="text-[var(--text-faint)] font-medium ml-1.5">
-								({group.plans.length})
-							</span>
-						</h2>
+			<!-- Time-based tabs -->
+			<Tabs bind:value={activeDateTab}>
+				<div class="mb-4">
+					<TabsList>
+						{#each groupedByDate as group (group.key)}
+							<TabsTrigger value={group.key}>
+								<span>{group.label}</span>
+								<span class="tab-count">{group.plans.length}</span>
+							</TabsTrigger>
+						{/each}
+					</TabsList>
+				</div>
 
-						<!-- Plan Cards Grid -->
+				{#each groupedByDate as group (group.key)}
+					<TabsContent value={group.key}>
+						{@const visible = group.plans.slice(
+							(activePage - 1) * TAB_PAGE_SIZE,
+							activePage * TAB_PAGE_SIZE
+						)}
 						<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-							{#each group.plans as plan (plan.slug)}
+							{#each visible as plan (plan.slug)}
 								<PlanCard {plan} />
 							{/each}
 						</div>
-					</div>
-				{/each}
-			</div>
 
-			<!-- Pagination Controls -->
-			<Pagination
-				total={plansResponse.total}
-				page={currentPage}
-				{perPage}
-				totalPages={plansResponse.total_pages}
-				onPageChange={goToPage}
-				itemLabel="plans"
-			/>
+						{#if group.plans.length > TAB_PAGE_SIZE}
+							<Pagination
+								total={group.plans.length}
+								page={activePage}
+								perPage={TAB_PAGE_SIZE}
+								totalPages={Math.ceil(group.plans.length / TAB_PAGE_SIZE)}
+								onPageChange={(p) => (activePage = p)}
+								itemLabel="plans"
+							/>
+						{/if}
+
+						{#if group.key === 'older' && plansResponse.total > plansResponse.plans.length}
+							<p class="mt-6 text-xs text-[var(--text-muted)] tabular-nums">
+								Showing the {plansResponse.plans.length.toLocaleString()} most recent;
+								older entries not displayed.
+							</p>
+						{/if}
+					</TabsContent>
+				{/each}
+			</Tabs>
 		{/if}
 	</div>
 </div>

--- a/frontend/src/routes/projects/+page.svelte
+++ b/frontend/src/routes/projects/+page.svelte
@@ -10,6 +10,10 @@
 	import { listNavigation } from '$lib/actions/listNavigation';
 	import SkeletonBox from '$lib/components/skeleton/SkeletonBox.svelte';
 	import SkeletonText from '$lib/components/skeleton/SkeletonText.svelte';
+	import Tabs from '$lib/components/ui/Tabs.svelte';
+	import TabsList from '$lib/components/ui/TabsList.svelte';
+	import TabsTrigger from '$lib/components/ui/TabsTrigger.svelte';
+	import TabsContent from '$lib/components/ui/TabsContent.svelte';
 
 	let { data } = $props();
 	const allProjects = $derived(data.projects as Project[]);
@@ -31,9 +35,24 @@
 		| 'agents-most'
 		| 'agents-least'
 	>('recent');
-	let filterType = $state<'all' | 'git' | 'non-git'>('all');
+	let filterType = $state<'git' | 'non-git'>('git');
 	let showSortDropdown = $state(false);
-	let showFilterDropdown = $state(false);
+
+	// Counts per tab, reflecting the search query but not the active tab —
+	// so the tab labels stay informative while switching.
+	const tabCounts = $derived.by(() => {
+		let pool = allProjects;
+		if (searchQuery.trim()) {
+			const q = searchQuery.toLowerCase();
+			pool = pool.filter(
+				(p) =>
+					getProjectName(p.path).toLowerCase().includes(q) ||
+					p.path.toLowerCase().includes(q)
+			);
+		}
+		const git = pool.filter((p) => !!p.git_root_path).length;
+		return { git, nonGit: pool.length - git };
+	});
 
 	// Group projects by git root
 	const grouped = $derived(groupProjects(allProjects));
@@ -184,14 +203,6 @@
 		return labels[sort];
 	}
 
-	function getFilterLabel(filter: typeof filterType) {
-		const labels = {
-			all: 'All Projects',
-			git: 'Git Only',
-			'non-git': 'Non-Git Only'
-		};
-		return labels[filter];
-	}
 </script>
 
 <div use:listNavigation>
@@ -387,106 +398,51 @@
 			{/if}
 		</div>
 
-		<!-- Filter Dropdown -->
-		<div class="relative">
-			<button
-				onclick={() => {
-					showFilterDropdown = !showFilterDropdown;
-					showSortDropdown = false;
-				}}
-				class="inline-flex items-center gap-2 px-3 h-9 text-xs font-medium bg-[var(--bg-base)] border border-[var(--border)] rounded-[6px] hover:bg-[var(--bg-subtle)] hover:border-[var(--border-hover)] transition-all whitespace-nowrap text-[var(--text-secondary)]"
-			>
-				<span>Filter:</span>
-				<span class="text-[var(--text-primary)]">{getFilterLabel(filterType)}</span>
-				<ChevronDown size={12} strokeWidth={2} class="text-[var(--text-faint)]" />
-			</button>
-			{#if showFilterDropdown}
-				<div
-					class="absolute right-0 mt-1 w-40 bg-[var(--bg-base)] border border-[var(--border)] rounded-lg shadow-[var(--shadow-md)] z-10 py-1"
-				>
-					<button
-						onclick={() => {
-							filterType = 'all';
-							showFilterDropdown = false;
-						}}
-						class="w-full px-4 py-1.5 text-left text-xs font-medium hover:bg-[var(--bg-subtle)] transition-colors {filterType ===
-						'all'
-							? 'text-[var(--text-primary)]'
-							: 'text-[var(--text-secondary)]'}"
-					>
-						All Projects
-					</button>
-					<button
-						onclick={() => {
-							filterType = 'git';
-							showFilterDropdown = false;
-						}}
-						class="w-full px-4 py-1.5 text-left text-xs font-medium hover:bg-[var(--bg-subtle)] transition-colors {filterType ===
-						'git'
-							? 'text-[var(--text-primary)]'
-							: 'text-[var(--text-secondary)]'}"
-					>
-						Git Only
-					</button>
-					<button
-						onclick={() => {
-							filterType = 'non-git';
-							showFilterDropdown = false;
-						}}
-						class="w-full px-4 py-1.5 text-left text-xs font-medium hover:bg-[var(--bg-subtle)] transition-colors {filterType ===
-						'non-git'
-							? 'text-[var(--text-primary)]'
-							: 'text-[var(--text-secondary)]'}"
-					>
-						Non-Git Only
-					</button>
-				</div>
-			{/if}
-		</div>
 	</div>
 
-	<!-- Git Repositories Section -->
-	{#if filteredGrouped.gitRoots.length > 0 || filteredGrouped.singleGitProjects.length > 0}
-		<div class="mb-8">
-			<!-- Section Header -->
-			<div class="flex items-center justify-between mb-4">
-				<h2
-					class="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)]"
+	<!-- Tabs: Git / Non-Git -->
+	<Tabs bind:value={filterType} class="mb-4">
+		<div class="flex items-center justify-between mb-4 gap-3 flex-wrap">
+			<TabsList>
+				<TabsTrigger value="git" icon={GitBranch}>
+					<span>Git Repositories</span>
+					<span class="tab-count">{tabCounts.git}</span>
+				</TabsTrigger>
+				<TabsTrigger value="non-git" icon={FolderOpen}>
+					<span>Non-Git</span>
+					<span class="tab-count">{tabCounts.nonGit}</span>
+				</TabsTrigger>
+			</TabsList>
+
+			{#if filterType === 'git' && filteredGrouped.gitRoots.length > 0}
+				<button
+					onclick={toggleExpandAll}
+					class="
+						inline-flex items-center gap-1.5
+						px-3 py-1.5
+						text-xs font-medium
+						text-[var(--text-secondary)]
+						hover:text-[var(--text-primary)]
+						bg-[var(--bg-subtle)]
+						hover:bg-[var(--bg-muted)]
+						border border-[var(--border)]
+						rounded-[6px]
+						transition-colors
+					"
 				>
-					Git Repositories
-					<span class="text-[var(--text-faint)] font-medium ml-1.5">
-						({stats.gitRepoCount})
-					</span>
-				</h2>
+					{#if allExpanded}
+						<ChevronUp size={14} strokeWidth={2} />
+						<span>Collapse All</span>
+					{:else}
+						<ChevronDown size={14} strokeWidth={2} />
+						<span>Expand All</span>
+					{/if}
+				</button>
+			{/if}
+		</div>
 
-				{#if filteredGrouped.gitRoots.length > 0}
-					<button
-						onclick={toggleExpandAll}
-						class="
-							inline-flex items-center gap-1.5
-							px-3 py-1.5
-							text-xs font-medium
-							text-[var(--text-secondary)]
-							hover:text-[var(--text-primary)]
-							bg-[var(--bg-subtle)]
-							hover:bg-[var(--bg-muted)]
-							border border-[var(--border)]
-							rounded-[6px]
-							transition-colors
-						"
-					>
-						{#if allExpanded}
-							<ChevronUp size={14} strokeWidth={2} />
-							<span>Collapse All</span>
-						{:else}
-							<ChevronDown size={14} strokeWidth={2} />
-							<span>Expand All</span>
-						{/if}
-					</button>
-				{/if}
-			</div>
-
-			<!-- Collapsible Git Root Groups -->
+		<!-- Git -->
+		<TabsContent value="git">
 			{#if filteredGrouped.gitRoots.length > 0}
 				<div class="space-y-3 mb-4">
 					{#each filteredGrouped.gitRoots as group (group.rootPath)}
@@ -494,8 +450,6 @@
 					{/each}
 				</div>
 			{/if}
-
-			<!-- Single Git Projects (Flat Grid) -->
 			{#if filteredGrouped.singleGitProjects.length > 0}
 				<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
 					{#each filteredGrouped.singleGitProjects as project (project.encoded_name)}
@@ -503,28 +457,19 @@
 					{/each}
 				</div>
 			{/if}
-		</div>
-	{/if}
+		</TabsContent>
 
-	<!-- Non-Git Projects Section -->
-	{#if filteredGrouped.otherProjects.length > 0}
-		<div>
-			<h2
-				class="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-4"
-			>
-				Non-Git Projects
-				<span class="text-[var(--text-faint)] font-medium ml-1.5">
-					({filteredGrouped.otherProjects.length})
-				</span>
-			</h2>
-
-			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-				{#each filteredGrouped.otherProjects as project (project.encoded_name)}
-					<ProjectCard {project} variant="default" />
-				{/each}
-			</div>
-		</div>
-	{/if}
+		<!-- Non-Git -->
+		<TabsContent value="non-git">
+			{#if filteredGrouped.otherProjects.length > 0}
+				<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+					{#each filteredGrouped.otherProjects as project (project.encoded_name)}
+						<ProjectCard {project} variant="default" />
+					{/each}
+				</div>
+			{/if}
+		</TabsContent>
+	</Tabs>
 
 	<!-- Empty State -->
 	{#if totalFilteredCount === 0}
@@ -553,7 +498,7 @@
 		const target = e.target as HTMLElement;
 		if (!target.closest('button')) {
 			showSortDropdown = false;
-			showFilterDropdown = false;
 		}
 	}}
 />
+

--- a/frontend/src/routes/projects/+page.svelte
+++ b/frontend/src/routes/projects/+page.svelte
@@ -308,7 +308,6 @@
 			<button
 				onclick={() => {
 					showSortDropdown = !showSortDropdown;
-					showFilterDropdown = false;
 				}}
 				class="inline-flex items-center gap-2 px-3 h-9 text-xs font-medium bg-[var(--bg-base)] border border-[var(--border)] rounded-[6px] hover:bg-[var(--bg-subtle)] hover:border-[var(--border-hover)] transition-all whitespace-nowrap text-[var(--text-secondary)]"
 			>
@@ -480,10 +479,10 @@
 				<FolderOpen size={28} class="text-[var(--text-faint)]" />
 			</div>
 			<h3 class="text-base font-semibold text-[var(--text-primary)] mb-2">
-				{searchQuery || filterType !== 'all' ? 'No matching projects' : 'No projects found'}
+				{searchQuery ? 'No matching projects' : 'No projects found'}
 			</h3>
 			<p class="text-sm font-medium text-[var(--text-muted)]">
-				{searchQuery || filterType !== 'all'
+				{searchQuery
 					? 'Try adjusting your filters'
 					: 'Start using Claude Code to see your projects here'}
 			</p>

--- a/frontend/src/routes/projects/[project_slug]/+page.server.ts
+++ b/frontend/src/routes/projects/[project_slug]/+page.server.ts
@@ -15,7 +15,7 @@ export async function load({ params, fetch, url }) {
 
 	// Extract pagination params
 	const page = parseInt(url.searchParams.get('page') || '1', 10);
-	const perPage = parseInt(url.searchParams.get('per_page') || '50', 10);
+	const perPage = parseInt(url.searchParams.get('per_page') || '500', 10);
 
 	// Build analytics URL with timestamp params
 	const analyticsParams = new URLSearchParams();

--- a/frontend/src/routes/projects/[project_slug]/+page.svelte
+++ b/frontend/src/routes/projects/[project_slug]/+page.svelte
@@ -1100,9 +1100,7 @@
 					<div class="space-y-4">
 						<!-- Header row: title + count + view toggle -->
 						<div class="flex items-center justify-between">
-							<h2 class="text-sm font-semibold text-[var(--text-primary)]">
-								Recent Sessions
-							</h2>
+							<h2 class="sessions-section-title">Recent Sessions</h2>
 							<div class="flex items-center gap-3">
 								<span
 									class="text-xs text-[var(--text-muted)] font-mono tabular-nums flex items-center gap-2"
@@ -1172,7 +1170,7 @@
 									<span>Filters</span>
 									{#if activeFilterCount > 0}
 										<span
-											class="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 bg-[var(--accent)] text-white rounded-full text-[10px] font-bold tabular-nums"
+											class="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 bg-[var(--accent)] text-[var(--bg-base)] rounded-full text-[10px] font-semibold tabular-nums"
 										>
 											{activeFilterCount}
 										</span>
@@ -1492,10 +1490,8 @@
 							class="flex flex-col sm:flex-row sm:items-center justify-between gap-3"
 						>
 							<div>
-								<h2 class="text-lg font-semibold text-[var(--text-primary)]">
-									Project Analytics
-								</h2>
-								<p class="text-sm text-[var(--text-muted)]">
+								<h2 class="tab-section-title">Project Analytics</h2>
+								<p class="tab-section-sub">
 									Insights into your coding patterns and project health
 								</p>
 							</div>
@@ -1548,31 +1544,25 @@
 										<div
 											class="flex items-center gap-2 text-[var(--text-muted)]"
 										>
-											<Clock size={16} />
-											<h3
-												class="text-xs font-semibold uppercase tracking-wider"
-											>
-												Time Investment
-											</h3>
+											<Clock size={14} strokeWidth={1.75} />
+											<h3 class="summary-card-label">Time Investment</h3>
 										</div>
 									</div>
 
 									<div class="mb-4 flex flex-col justify-center">
 										<div class="flex items-center gap-3">
 											<div
-												class="p-2 rounded-full bg-[var(--bg-active)] text-[var(--accent)]"
+												class="inline-flex items-center justify-center w-9 h-9 rounded-[var(--radius-sm)] bg-[var(--accent-subtle)] text-[var(--accent)]"
 											>
-												<PieChart size={24} />
+												<PieChart size={18} strokeWidth={1.75} />
 											</div>
 											<div>
-												<div
-													class="text-2xl font-bold text-[var(--text-primary)]"
-												>
+												<div class="summary-card-value">
 													{formatDuration(
 														analytics.total_duration_seconds
 													)}
 												</div>
-												<div class="text-xs text-[var(--text-muted)]">
+												<div class="text-xs text-[var(--text-muted)] mt-0.5">
 													Total Time
 												</div>
 											</div>
@@ -1605,15 +1595,11 @@
 											<div
 												class="flex items-center gap-2 text-[var(--text-muted)]"
 											>
-												<Briefcase size={16} />
-												<h3
-													class="text-xs font-semibold uppercase tracking-wider"
-												>
-													Work Mode
-												</h3>
+												<Briefcase size={14} strokeWidth={1.75} />
+												<h3 class="summary-card-label">Work Mode</h3>
 											</div>
 											<span
-												class="text-[10px] font-medium px-2 py-0.5 rounded-full bg-[var(--bg-muted)] text-[var(--text-primary)] border border-[var(--border)]"
+												class="font-mono text-[10px] uppercase tracking-widest px-2 py-0.5 rounded-[var(--radius-xs)] bg-[var(--bg-muted)] text-[var(--text-secondary)] border border-[var(--border-subtle)]"
 											>
 												{analytics.work_mode_distribution.primary_mode}
 											</span>
@@ -1625,17 +1611,17 @@
 												class="h-3 w-full flex rounded-full overflow-hidden bg-[var(--bg-muted)]"
 											>
 												<div
-													class="bg-blue-500/80 h-full first:rounded-l-full last:rounded-r-full"
+													class="workmode-bar workmode-explore h-full first:rounded-l-full last:rounded-r-full"
 													style="width: {analytics.work_mode_distribution
 														.exploration_pct}%"
 												></div>
 												<div
-													class="bg-purple-500/80 h-full first:rounded-l-full last:rounded-r-full"
+													class="workmode-bar workmode-build h-full first:rounded-l-full last:rounded-r-full"
 													style="width: {analytics.work_mode_distribution
 														.building_pct}%"
 												></div>
 												<div
-													class="bg-orange-500/80 h-full first:rounded-l-full last:rounded-r-full"
+													class="workmode-bar workmode-test h-full first:rounded-l-full last:rounded-r-full"
 													style="width: {analytics.work_mode_distribution
 														.testing_pct}%"
 												></div>
@@ -1646,7 +1632,7 @@
 											<div class="flex justify-between items-center">
 												<div class="flex items-center gap-2">
 													<div
-														class="w-2 h-2 rounded-full bg-blue-500/80"
+														class="w-2 h-2 rounded-full workmode-bar workmode-explore"
 													></div>
 													<span class="text-[var(--text-secondary)]"
 														>Exploration</span
@@ -1660,7 +1646,7 @@
 											<div class="flex justify-between items-center">
 												<div class="flex items-center gap-2">
 													<div
-														class="w-2 h-2 rounded-full bg-purple-500/80"
+														class="w-2 h-2 rounded-full workmode-bar workmode-build"
 													></div>
 													<span class="text-[var(--text-secondary)]"
 														>Building</span
@@ -1674,7 +1660,7 @@
 											<div class="flex justify-between items-center">
 												<div class="flex items-center gap-2">
 													<div
-														class="w-2 h-2 rounded-full bg-orange-500/80"
+														class="w-2 h-2 rounded-full workmode-bar workmode-test"
 													></div>
 													<span class="text-[var(--text-secondary)]"
 														>Testing</span
@@ -1731,10 +1717,8 @@
 						<div class="space-y-6">
 							<!-- Header -->
 							<div>
-								<h2 class="text-lg font-semibold text-[var(--text-primary)]">
-									Archived Sessions
-								</h2>
-								<p class="text-sm text-[var(--text-muted)]">
+								<h2 class="tab-section-title">Archived Sessions</h2>
+								<p class="tab-section-sub">
 									{archived.total_sessions}
 									{archived.total_sessions === 1 ? 'session' : 'sessions'} with {archived.total_prompts}
 									prompts cleaned up by retention policy
@@ -1756,3 +1740,68 @@
 		{/if}
 	</div>
 {/if}
+
+<style>
+	/* Work-mode distribution — themed ink palette (no more raw Tailwind 500s) */
+	.workmode-bar {
+		height: 100%;
+		transition: width var(--duration-base) var(--ease);
+	}
+	.workmode-explore {
+		background: var(--nav-blue);
+	}
+	.workmode-build {
+		background: var(--nav-purple);
+	}
+	.workmode-test {
+		background: var(--nav-orange);
+	}
+
+	/* Section headings inside tab content — editorial eyebrow style */
+	.tab-section-title {
+		font-family: var(--font-serif);
+		font-style: italic;
+		font-weight: 400;
+		font-size: 26px;
+		line-height: 1;
+		letter-spacing: -0.02em;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.tab-section-sub {
+		margin: 6px 0 0;
+		font-size: 13px;
+		color: var(--text-muted);
+	}
+
+	/* Summary card labels (Time Investment, Work Mode) */
+	.summary-card-label {
+		font-family: var(--font-mono);
+		font-size: 10px;
+		letter-spacing: 0.16em;
+		text-transform: uppercase;
+		font-weight: 500;
+		color: var(--text-muted);
+	}
+
+	/* Big numerical value inside summary cards */
+	.summary-card-value {
+		font-size: 26px;
+		font-weight: 600;
+		letter-spacing: -0.02em;
+		line-height: 1.1;
+		color: var(--text-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	/* Sessions section header */
+	.sessions-section-title {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		font-weight: 500;
+		color: var(--text-primary);
+	}
+</style>

--- a/frontend/src/routes/projects/[project_slug]/+page.svelte
+++ b/frontend/src/routes/projects/[project_slug]/+page.svelte
@@ -28,6 +28,9 @@
 	} from 'lucide-svelte';
 	import { isToday, isYesterday, isThisWeek, isThisMonth } from 'date-fns';
 	import TabsTrigger from '$lib/components/ui/TabsTrigger.svelte';
+	import InnerTabs from '$lib/components/ui/Tabs.svelte';
+	import InnerTabsList from '$lib/components/ui/TabsList.svelte';
+	import InnerTabsContent from '$lib/components/ui/TabsContent.svelte';
 	import { API_BASE } from '$lib/config';
 	import { ProjectDetailSkeleton, SkeletonSessionCard } from '$lib/components/skeleton';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
@@ -997,6 +1000,7 @@
 
 	// Time-based grouping for list view
 	type DateGroup = {
+		key: string;
 		label: string;
 		sessions: SessionSummary[];
 	};
@@ -1025,13 +1029,32 @@
 		}
 
 		const groups: DateGroup[] = [];
-		if (today.length > 0) groups.push({ label: 'Today', sessions: today });
-		if (yesterday.length > 0) groups.push({ label: 'Yesterday', sessions: yesterday });
-		if (thisWeek.length > 0) groups.push({ label: 'This Week', sessions: thisWeek });
-		if (thisMonth.length > 0) groups.push({ label: 'This Month', sessions: thisMonth });
-		if (older.length > 0) groups.push({ label: 'Older', sessions: older });
+		if (today.length > 0) groups.push({ key: 'today', label: 'Today', sessions: today });
+		if (yesterday.length > 0)
+			groups.push({ key: 'yesterday', label: 'Yesterday', sessions: yesterday });
+		if (thisWeek.length > 0)
+			groups.push({ key: 'thisWeek', label: 'This Week', sessions: thisWeek });
+		if (thisMonth.length > 0)
+			groups.push({ key: 'thisMonth', label: 'This Month', sessions: thisMonth });
+		if (older.length > 0) groups.push({ key: 'older', label: 'Older', sessions: older });
 
 		return groups;
+	});
+
+	// Time-based tab state for the Recent Sessions list (mirrors /sessions).
+	let activeDateTab = $state<string>('today');
+	$effect(() => {
+		if (groupedByDate.length === 0) return;
+		const current = groupedByDate.find((g) => g.key === activeDateTab);
+		if (!current) activeDateTab = groupedByDate[0].key;
+	});
+
+	// Per-tab client-side pagination within Recent Sessions.
+	const SESSIONS_TAB_PAGE_SIZE = 30;
+	let sessionsTabPage = $state(1);
+	$effect(() => {
+		void activeDateTab;
+		sessionsTabPage = 1;
 	});
 </script>
 
@@ -1312,82 +1335,68 @@
 						<!-- Session Cards -->
 						{#if filteredSessions.length > 0}
 							{#key resultsAnimationKey}
-								{#if viewMode === 'list'}
-									<!-- List View: Time-Based Grouping -->
-									<div class="space-y-8 animate-results-update">
-										{#each groupedByDate as group (group.label)}
-											<div>
-												<!-- Section Header -->
-												<h2
-													class="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-4"
-												>
-													{group.label}
-													<span
-														class="text-[var(--text-faint)] font-medium ml-1.5"
-													>
-														({group.sessions.length})
-													</span>
-												</h2>
+								<InnerTabs bind:value={activeDateTab} class="animate-results-update">
+									<InnerTabsList class="mb-4">
+										{#each groupedByDate as group (group.key)}
+											<TabsTrigger value={group.key}>
+												<span>{group.label}</span>
+												<span class="tab-count">{group.sessions.length}</span>
+											</TabsTrigger>
+										{/each}
+									</InnerTabsList>
 
-												<!-- Session Cards Grid -->
+									{#each groupedByDate as group (group.key)}
+										<InnerTabsContent value={group.key}>
+											{@const visible = group.sessions.slice(
+												(sessionsTabPage - 1) * SESSIONS_TAB_PAGE_SIZE,
+												sessionsTabPage * SESSIONS_TAB_PAGE_SIZE
+											)}
+											{#if viewMode === 'list'}
 												<div
 													class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3"
 												>
-													{#each group.sessions as session (session.uuid)}
+													{#each visible as session (session.uuid)}
 														<SessionCard
 															{session}
 															projectEncodedName={project.encoded_name}
-															showBranch={selectedBranchFilters.size ===
-																0}
-															liveSession={getLiveSession(
-																session
-															)}
+															showBranch={selectedBranchFilters.size === 0}
+															liveSession={getLiveSession(session)}
 															highlighted={getSessionUrlIdentifier(session, getLiveSession(session)) === lastOpenedSessionId}
 														/>
 													{/each}
 												</div>
-											</div>
-										{/each}
-									</div>
-								{:else}
-									<!-- Grid View: Compact with Time-Based Grouping -->
-									<div class="space-y-6 animate-results-update">
-										{#each groupedByDate as group (group.label)}
-											<div>
-												<!-- Section Header -->
-												<h2
-													class="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-3"
-												>
-													{group.label}
-													<span
-														class="text-[var(--text-faint)] font-medium ml-1.5"
-													>
-														({group.sessions.length})
-													</span>
-												</h2>
-
-												<!-- Session Cards Grid (Compact) -->
+											{:else}
 												<div
 													class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2"
 												>
-													{#each group.sessions as session (session.uuid)}
+													{#each visible as session (session.uuid)}
 														<SessionCard
 															{session}
 															projectEncodedName={project.encoded_name}
-															showBranch={selectedBranchFilters.size ===
-																0}
+															showBranch={selectedBranchFilters.size === 0}
 															compact
-															liveSession={getLiveSession(
-																session
-															)}
+															liveSession={getLiveSession(session)}
 															highlighted={getSessionUrlIdentifier(session, getLiveSession(session)) === lastOpenedSessionId}
 														/>
 													{/each}
 												</div>
-											</div>
-										{/each}
-									</div>
-								{/if}
+											{/if}
+
+											{#if group.sessions.length > SESSIONS_TAB_PAGE_SIZE}
+												<Pagination
+													total={group.sessions.length}
+													page={sessionsTabPage}
+													perPage={SESSIONS_TAB_PAGE_SIZE}
+													totalPages={Math.ceil(
+														group.sessions.length / SESSIONS_TAB_PAGE_SIZE
+													)}
+													onPageChange={(p) => (sessionsTabPage = p)}
+													itemLabel="sessions"
+												/>
+											{/if}
+										</InnerTabsContent>
+									{/each}
+								</InnerTabs>
 							{/key}
 						{:else if isListLoading}
 							<!-- Loading State - Skeleton Cards -->
@@ -1462,23 +1471,6 @@
 							/>
 						{/if}
 
-						<!-- Pagination / Results Info -->
-						{#if !hasClientSideFilters && project && (project.sessions?.length ?? 0) > 0}
-							<Pagination
-								total={totalSessionCount}
-								page={currentPage}
-								perPage={paginationPerPage}
-								{totalPages}
-								onPageChange={goToPage}
-								itemLabel="sessions"
-							/>
-						{:else if hasClientSideFilters && project && (project.sessions?.length ?? 0) > 0}
-							<div class="mt-8 text-xs text-[var(--text-muted)] tabular-nums">
-								Showing <span class="font-medium text-[var(--text-secondary)]"
-									>{filteredSessionsCount.toLocaleString()}</span
-								> filtered sessions
-							</div>
-						{/if}
 					</div>
 				</Tabs.Content>
 

--- a/frontend/src/routes/projects/[project_slug]/[session_slug]/+page.svelte
+++ b/frontend/src/routes/projects/[project_slug]/[session_slug]/+page.svelte
@@ -30,20 +30,25 @@
 	</div>
 {:else if error}
 	<div class="flex flex-col items-center justify-center min-h-[60vh] p-8">
-		<div class="flex flex-col items-center gap-4 max-w-md text-center">
+		<div class="flex flex-col items-center gap-5 max-w-md text-center">
 			<div
-				class="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--error-subtle)]"
+				class="flex h-14 w-14 items-center justify-center rounded-[var(--radius-md)] bg-[var(--error-subtle)] text-[var(--error)]"
 			>
-				<AlertTriangle size={32} class="text-[var(--error)]" />
+				<AlertTriangle size={26} strokeWidth={1.75} />
 			</div>
-			<h1 class="text-xl font-semibold text-[var(--text-primary)]">Failed to Load Session</h1>
-			<p class="text-[var(--text-secondary)]">{error}</p>
+			<h1
+				class="text-3xl italic text-[var(--text-primary)]"
+				style="font-family: var(--font-serif); font-weight: 400; letter-spacing: -0.02em; line-height: 1;"
+			>
+				Failed to load session
+			</h1>
+			<p class="text-sm text-[var(--text-secondary)] max-w-sm">{error}</p>
 			<a
 				href="/projects/{data.project_slug}"
-				class="inline-flex items-center gap-2 mt-4 px-4 py-2 rounded-lg bg-[var(--accent)] text-white hover:opacity-90 transition-opacity"
+				class="inline-flex items-center gap-2 mt-2 px-4 py-2 rounded-[var(--radius-sm)] bg-[var(--accent)] text-[var(--bg-base)] hover:bg-[var(--accent-hover)] transition-colors font-medium text-sm"
 			>
-				<ArrowLeft size={16} />
-				Back to Project
+				<ArrowLeft size={15} strokeWidth={1.75} />
+				Back to project
 			</a>
 		</div>
 	</div>

--- a/frontend/src/routes/sessions/+page.server.ts
+++ b/frontend/src/routes/sessions/+page.server.ts
@@ -14,7 +14,7 @@ export async function load({ fetch, url }) {
 	const branch = url.searchParams.get('branch') || undefined;
 
 	const page = parseInt(url.searchParams.get('page') || '1', 10);
-	const perPage = parseInt(url.searchParams.get('per_page') || '50', 10);
+	const perPage = parseInt(url.searchParams.get('per_page') || '500', 10);
 
 	// Additional filter params (kept in URL for shareability)
 	// Search and scope are forwarded to API; status/date/live filters are applied client-side

--- a/frontend/src/routes/sessions/+page.svelte
+++ b/frontend/src/routes/sessions/+page.svelte
@@ -1057,31 +1057,7 @@
 		return getProjectNameFromEncoded(encodedName) || encodedName;
 	}
 
-	// Check if client-side filters are active (filters applied in browser)
-	// All filters are now client-side: project, branch, search tokens, scope, status
-	// When client-side filters are active, we show filtered count instead of pagination
-	const hasClientSideFilters = $derived(
-		false // All filtering is now server-side
-	);
-
-	// Pagination calculations - use filtered count when client-side filters are active
-	const effectiveTotal = $derived(
-		hasClientSideFilters ? dedupedFilteredSessions.length : contextualTotal
-	);
-	const totalPages = $derived(
-		hasClientSideFilters ? 1 : Math.ceil(contextualTotal / data.filters.perPage)
-	);
-	const currentPage = $derived(data.filters.page);
-	const hasNextPage = $derived(!hasClientSideFilters && currentPage < totalPages);
-	const hasPrevPage = $derived(!hasClientSideFilters && currentPage > 1);
 	const hasActiveFilters = $derived(activeFiltersCount > 0);
-
-	// Navigate to a specific page (only works when no client-side filters)
-	function goToPage(newPage: number) {
-		if (hasClientSideFilters) return;
-		if (newPage < 1 || newPage > totalPages) return;
-		reloadSessions({ page: newPage });
-	}
 
 	// Determine if live sessions should be visible based on date filter
 	// Live sessions are "happening now" so only show when date range includes today
@@ -1520,7 +1496,7 @@
 						/>
 					{/if}
 
-					{#if group.key === 'older' && effectiveTotal > dedupedFilteredSessions.length}
+					{#if group.key === 'older' && contextualTotal > dedupedFilteredSessions.length}
 						<p class="mt-6 text-xs text-[var(--text-muted)] tabular-nums">
 							Showing the {dedupedFilteredSessions.length.toLocaleString()} most recent;
 							older entries not displayed.

--- a/frontend/src/routes/sessions/+page.svelte
+++ b/frontend/src/routes/sessions/+page.svelte
@@ -25,6 +25,10 @@
 	import ActiveFilterChips from '$lib/components/ActiveFilterChips.svelte';
 	import ActiveBranches from '$lib/components/ActiveBranches.svelte';
 	import Pagination from '$lib/components/Pagination.svelte';
+	import Tabs from '$lib/components/ui/Tabs.svelte';
+	import TabsList from '$lib/components/ui/TabsList.svelte';
+	import TabsTrigger from '$lib/components/ui/TabsTrigger.svelte';
+	import TabsContent from '$lib/components/ui/TabsContent.svelte';
 	import { listNavigation } from '$lib/actions/listNavigation';
 	import { keyboardOverrides } from '$lib/stores/keyboardOverrides';
 	import { dropdownNavigation } from '$lib/actions/dropdownNavigation';
@@ -743,6 +747,7 @@
 
 	// Time-based grouping (uses filteredSessions with all client-side filters applied)
 	type DateGroup = {
+		key: string;
 		label: string;
 		sessions: SessionWithContext[];
 	};
@@ -771,14 +776,48 @@
 		}
 
 		const groups: DateGroup[] = [];
-		if (today.length > 0) groups.push({ label: 'Today', sessions: today });
-		if (yesterday.length > 0) groups.push({ label: 'Yesterday', sessions: yesterday });
-		if (thisWeek.length > 0) groups.push({ label: 'This Week', sessions: thisWeek });
-		if (thisMonth.length > 0) groups.push({ label: 'This Month', sessions: thisMonth });
-		if (older.length > 0) groups.push({ label: 'Older', sessions: older });
+		if (today.length > 0) groups.push({ key: 'today', label: 'Today', sessions: today });
+		if (yesterday.length > 0)
+			groups.push({ key: 'yesterday', label: 'Yesterday', sessions: yesterday });
+		if (thisWeek.length > 0)
+			groups.push({ key: 'thisWeek', label: 'This Week', sessions: thisWeek });
+		if (thisMonth.length > 0)
+			groups.push({ key: 'thisMonth', label: 'This Month', sessions: thisMonth });
+		if (older.length > 0) groups.push({ key: 'older', label: 'Older', sessions: older });
 
 		return groups;
 	});
+
+	// Active date tab; defaults to first non-empty bucket, updates when
+	// the current tab becomes empty (e.g., after a search narrows results).
+	let activeDateTab = $state<string>('today');
+
+	$effect(() => {
+		if (groupedByDate.length === 0) return;
+		const current = groupedByDate.find((g) => g.key === activeDateTab);
+		if (!current) {
+			activeDateTab = groupedByDate[0].key;
+		}
+	});
+
+	const activeDateGroup = $derived(
+		groupedByDate.find((g) => g.key === activeDateTab) ?? null
+	);
+
+	// Per-tab client-side pagination. Resets to 1 on tab switch so users
+	// always land on the freshest slice of the new bucket.
+	const TAB_PAGE_SIZE = 30;
+	let activePage = $state(1);
+
+	$effect(() => {
+		// read activeDateTab so the effect re-runs on tab change
+		void activeDateTab;
+		activePage = 1;
+	});
+
+	const activeTotalPages = $derived(
+		activeDateGroup ? Math.ceil(activeDateGroup.sessions.length / TAB_PAGE_SIZE) : 0
+	);
 
 	// Direct API fetch to update session data without goto() + invalidate()
 	// This avoids full SvelteKit page navigation which causes double-rendering
@@ -1423,100 +1462,73 @@
 		</div>
 	{:else if dedupedFilteredSessions.length === 0}
 		<!-- No filtered sessions but have recently ended - don't show message (cards are above) -->
-	{:else if viewMode === 'list'}
-		<!-- List View: Time-Based Grouping -->
-		<div class="space-y-8">
-			{#each groupedByDate as group, index (group.label)}
-				<div>
-					<!-- Section Header -->
-					<div class="flex items-center gap-2 mb-4">
-						<h2
-							class="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)]"
-						>
-							{group.label}
-							<span class="text-[var(--text-faint)] font-medium ml-1.5">
-								({group.sessions.length})
-							</span>
-						</h2>
-						<!-- Session count - shown only on first group if Recently Ended is not visible -->
-						{#if index === 0 && !showRecentlyEnded}
-							<span
-								class="ml-auto text-xs text-[var(--text-muted)] font-mono tabular-nums"
-							>
-								{displayFilteredCount} of {displayTotalCount} sessions
-							</span>
-						{/if}
-					</div>
-
-					<!-- Session Cards Grid -->
-					<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-						{#each group.sessions as session (session.uuid)}
-							<GlobalSessionCard {session} highlighted={session.uuid.slice(0, 8) === lastOpenedSessionId} />
-						{/each}
-					</div>
-				</div>
-			{/each}
-		</div>
 	{:else}
-		<!-- Grid View: Compact with Time-Based Grouping -->
-		<div class="space-y-6">
-			{#each groupedByDate as group, index (group.label)}
-				<div>
-					<!-- Section Header -->
-					<div class="flex items-center gap-2 mb-3">
-						<h2
-							class="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)]"
-						>
-							{group.label}
-							<span class="text-[var(--text-faint)] font-medium ml-1.5">
-								({group.sessions.length})
-							</span>
-						</h2>
-						<!-- Session count - shown only on first group if Recently Ended is not visible -->
-						{#if index === 0 && !showRecentlyEnded}
-							<span
-								class="ml-auto text-xs text-[var(--text-muted)] font-mono tabular-nums"
-							>
-								{displayFilteredCount} of {displayTotalCount} sessions
-							</span>
-						{/if}
-					</div>
+		<!-- Time-based tabs with list/grid view mode inside -->
+		<Tabs bind:value={activeDateTab}>
+			<div class="flex items-center justify-between mb-4 gap-3 flex-wrap">
+				<TabsList>
+					{#each groupedByDate as group (group.key)}
+						<TabsTrigger value={group.key}>
+							<span>{group.label}</span>
+							<span class="tab-count">{group.sessions.length}</span>
+						</TabsTrigger>
+					{/each}
+				</TabsList>
 
-					<!-- Session Cards Grid (Compact) -->
-					<div
-						class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2"
-					>
-						{#each group.sessions as session (session.uuid)}
-							<GlobalSessionCard
-								{session}
-								compact
-								highlighted={session.uuid.slice(0, 8) === lastOpenedSessionId}
-							/>
-						{/each}
-					</div>
-				</div>
+				{#if !showRecentlyEnded}
+					<span class="text-xs text-[var(--text-muted)] font-mono tabular-nums">
+						{displayFilteredCount} of {displayTotalCount} sessions
+					</span>
+				{/if}
+			</div>
+
+			{#each groupedByDate as group (group.key)}
+				<TabsContent value={group.key}>
+					{@const visible = group.sessions.slice(
+						(activePage - 1) * TAB_PAGE_SIZE,
+						activePage * TAB_PAGE_SIZE
+					)}
+					{#if viewMode === 'list'}
+						<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+							{#each visible as session (session.uuid)}
+								<GlobalSessionCard
+									{session}
+									highlighted={session.uuid.slice(0, 8) === lastOpenedSessionId}
+								/>
+							{/each}
+						</div>
+					{:else}
+						<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2">
+							{#each visible as session (session.uuid)}
+								<GlobalSessionCard
+									{session}
+									compact
+									highlighted={session.uuid.slice(0, 8) === lastOpenedSessionId}
+								/>
+							{/each}
+						</div>
+					{/if}
+
+					{#if group.sessions.length > TAB_PAGE_SIZE}
+						<Pagination
+							total={group.sessions.length}
+							page={activePage}
+							perPage={TAB_PAGE_SIZE}
+							totalPages={Math.ceil(group.sessions.length / TAB_PAGE_SIZE)}
+							onPageChange={(p) => (activePage = p)}
+							itemLabel="sessions"
+						/>
+					{/if}
+
+					{#if group.key === 'older' && effectiveTotal > dedupedFilteredSessions.length}
+						<p class="mt-6 text-xs text-[var(--text-muted)] tabular-nums">
+							Showing the {dedupedFilteredSessions.length.toLocaleString()} most recent;
+							older entries not displayed.
+						</p>
+					{/if}
+				</TabsContent>
 			{/each}
-		</div>
-	{/if}
-
-	<!-- Pagination / Results Info -->
-	{#if !hasClientSideFilters && !data.error && !isLoading && dedupedFilteredSessions.length > 0}
-		<div class="mt-8">
-			<Pagination
-				total={effectiveTotal}
-				page={currentPage}
-				perPage={data.filters.perPage}
-				{totalPages}
-				onPageChange={goToPage}
-				itemLabel="sessions"
-			/>
-		</div>
-	{:else if hasClientSideFilters && !data.error && !isLoading && dedupedFilteredSessions.length > 0}
-		<div class="mt-8 text-xs text-[var(--text-muted)] tabular-nums">
-			Showing <span class="font-medium text-[var(--text-secondary)]"
-				>{effectiveTotal.toLocaleString()}</span
-			> filtered sessions
-		</div>
+		</Tabs>
 	{/if}
 </div>
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Start the API and frontend dev servers together.
+# Ctrl-C stops both cleanly.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+API_DIR="$ROOT/api"
+WEB_DIR="$ROOT/frontend"
+API_PORT="${API_PORT:-8000}"
+WEB_PORT="${WEB_PORT:-5173}"
+
+prefix() {
+  local tag="$1"
+  while IFS= read -r line; do
+    printf '[%s] %s\n' "$tag" "$line"
+  done
+}
+
+if [[ ! -d "$API_DIR/venv" ]]; then
+  echo "[setup] Creating Python venv in $API_DIR/venv"
+  python3 -m venv "$API_DIR/venv"
+  "$API_DIR/venv/bin/pip" install --upgrade pip >/dev/null
+  "$API_DIR/venv/bin/pip" install -e "$API_DIR[dev]"
+  "$API_DIR/venv/bin/pip" install -r "$API_DIR/requirements.txt"
+fi
+
+if [[ ! -d "$WEB_DIR/node_modules" ]]; then
+  echo "[setup] Installing frontend deps"
+  (cd "$WEB_DIR" && npm install --engine-strict=false)
+fi
+
+pids=()
+cleanup() {
+  echo ""
+  echo "[dev] stopping..."
+  for pid in "${pids[@]}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  wait 2>/dev/null || true
+  exit 0
+}
+trap cleanup INT TERM
+
+echo "[dev] api  → http://localhost:$API_PORT"
+echo "[dev] web  → http://localhost:$WEB_PORT"
+echo "[dev] Ctrl-C to stop both"
+echo ""
+
+(
+  cd "$API_DIR"
+  exec "$API_DIR/venv/bin/uvicorn" main:app --reload --port "$API_PORT" --host 127.0.0.1
+) 2>&1 | prefix api &
+pids+=($!)
+
+(
+  cd "$WEB_DIR"
+  exec npm run dev -- --port "$WEB_PORT"
+) 2>&1 | prefix web &
+pids+=($!)
+
+wait


### PR DESCRIPTION
## Commits

### 1. `feat: extract titles from custom-title JSONL entries`

Claude Code's `/title` command writes `{"type":"custom-title","customTitle":"..."}` entries to session JSONL, distinct from the auto-generated `{"type":"summary","summary":"..."}` type. User renames via `/title` were invisible to karma's title extractor and to search.

**Changes** (39 lines):

- `api/models/message.py` — new `CustomTitleMessage` class patterned exactly after `SessionTitleMessage`; added to the `Message` union and registered in `_MESSAGE_PARSERS` under the `"custom-title"` key.
- `api/models/compaction_detector.py` — process `CustomTitleMessage` in `CompactionDetector.process()` and append to `session_titles` (so the DB `sessions.session_titles` column populates during indexing).
- `api/services/session_title_cache.py` — extend `_extract_titles_lightweight()` to also capture `custom-title` entries (so the disk title cache populates on scan).

**Testing**

Verified against a real machine with 425 `custom-title` entries across 25 projects. Before the patch: 0 of 21 ticket-renamed sessions appeared in search. After: all 21 surface with correct project attribution. Both the `CompactionDetector`-driven DB column and the disk JSON cache get populated. No change to existing `summary`-type handling.

### 2. `chore: add scripts/dev.sh to launch API and frontend together`

Optional convenience. One-command dev startup that:

- Auto-creates Python venv on first run and installs api deps + requirements
- Auto-installs frontend deps if `node_modules` is missing
- Launches uvicorn and the SvelteKit dev server in parallel with `[api]` / `[web]` prefixed output so both are visible in one terminal
- Cleans up both processes on Ctrl-C
- Honors `API_PORT` / `WEB_PORT` env vars (default `8000` / `5173`)

Replaces the two-terminal flow in SETUP.md for daily iteration. Drop if out of scope for this PR and happy to split into a separate one.

## Notes for review

- Both commits are minimal and surgical. The first is the one that matters; the second is ergonomic convenience.
- Happy to split into two PRs if preferred, or drop commit 2 entirely.
- No test file exists for `_extract_titles_lightweight` or `CompactionDetector` currently — happy to add focused tests for the new handlers if you'd like.