### PR TITLE
feat: one-command onboarding via npx claude-code-karma

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,14 @@
 # Dependencies
 node_modules/
 
+# Runtime venv created by bin/start.js
+.karma-venv/
+
 # Build outputs
 dist/
 build/
 out/
+*.tgz
 
 # Vite cache
 .vite/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,16 @@
+# Python build artifacts (within any included directory)
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+**/*.egg-info/
+
+# Venv created by start.js at runtime
+.karma-venv/
+
+# Frontend test files inside frontend/src/
+frontend/src/tests/
+frontend/src/lib/components/**/__tests__/
+
+# Explicitly include pre-built frontend (overrides build/ in .gitignore)
+!frontend/build
+!frontend/build/**

--- a/bin/start.js
+++ b/bin/start.js
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const { spawn, execSync } = require('child_process');
+const { existsSync, writeFileSync } = require('fs');
+const path = require('path');
+const http = require('http');
+const net = require('net');
+
+const ROOT = path.join(__dirname, '..');
+const VENV_DIR = path.join(ROOT, '.karma-venv');
+const VENV_BIN = path.join(VENV_DIR, process.platform === 'win32' ? 'Scripts' : 'bin');
+const STAMP = path.join(VENV_DIR, '.deps-installed');
+
+const args = process.argv.slice(2);
+const NO_OPEN = args.includes('--no-open');
+const PREFERRED_API_PORT = parseInt(flagValue('--api-port') || '8000', 10);
+const PREFERRED_WEB_PORT = parseInt(flagValue('--web-port') || '5173', 10);
+
+function flagValue(name) {
+  const i = args.indexOf(name);
+  return i !== -1 ? args[i + 1] : null;
+}
+
+const dim    = (s) => `\x1b[2m${s}\x1b[0m`;
+const green  = (s) => `\x1b[32m${s}\x1b[0m`;
+const cyan   = (s) => `\x1b[36m${s}\x1b[0m`;
+const red    = (s) => `\x1b[31m${s}\x1b[0m`;
+const bold   = (s) => `\x1b[1m${s}\x1b[0m`;
+
+const API_TAG = cyan('[api]');
+const WEB_TAG = green('[web]');
+
+async function main() {
+  console.log('');
+  console.log(bold('  Claude Code Karma'));
+  console.log('');
+
+  // 1. Find Python 3
+  const python = findPython();
+  if (!python) {
+    console.error(red('  ✗ Python 3 not found.'));
+    console.error('    Install it from https://python.org and try again.');
+    process.exit(1);
+  }
+
+  // 2. Create virtualenv if missing
+  if (!existsSync(VENV_DIR)) {
+    step('Creating Python environment');
+    runSync(`"${python}" -m venv "${VENV_DIR}"`);
+    ok();
+  }
+
+  // 3. Install Python deps (stamp file prevents re-running every time)
+  if (!existsSync(STAMP)) {
+    step('Installing API dependencies');
+    const pip = path.join(VENV_BIN, 'pip');
+    runSync(`"${pip}" install -r "${path.join(ROOT, 'api', 'requirements.txt')}" -q`);
+    runSync(`"${pip}" install -e "${path.join(ROOT, 'api')}" -q`);
+    writeFileSync(STAMP, new Date().toISOString());
+    ok();
+  } else {
+    stepCached('API dependencies');
+  }
+
+  const frontendDir = path.join(ROOT, 'frontend');
+
+  // 4. Resolve free ports
+  const apiPort = await findFreePort(PREFERRED_API_PORT);
+  const webPort = await findFreePort(PREFERRED_WEB_PORT);
+
+  if (apiPort !== PREFERRED_API_PORT)
+    console.log(`  ${dim(`Port ${PREFERRED_API_PORT} in use → API on ${apiPort}`)}`);
+  if (webPort !== PREFERRED_WEB_PORT)
+    console.log(`  ${dim(`Port ${PREFERRED_WEB_PORT} in use → Web on ${webPort}`)}`);
+
+  console.log('');
+
+  // 6. Spawn API and frontend
+  const venvPython = path.join(VENV_BIN, 'python');
+
+  const apiProc = spawn(
+    venvPython,
+    ['-m', 'uvicorn', 'main:app', '--port', String(apiPort)],
+    { cwd: path.join(ROOT, 'api'), stdio: ['ignore', 'pipe', 'pipe'] }
+  );
+
+  const webProc = spawn(
+    process.execPath,
+    [path.join(frontendDir, 'build', 'index.js')],
+    {
+      cwd: frontendDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        PORT: String(webPort),
+        KARMA_API_URL: `http://localhost:${apiPort}`,
+      },
+    }
+  );
+
+  const procs = [apiProc, webProc];
+
+  attachPrefix(apiProc, API_TAG);
+  attachPrefix(webProc, WEB_TAG);
+
+  for (const proc of procs) {
+    proc.on('exit', (code) => {
+      if (code !== 0 && code !== null) {
+        console.error(red(`\n  Process exited unexpectedly (code ${code}). Shutting down.`));
+        cleanup(procs);
+        process.exit(code ?? 1);
+      }
+    });
+  }
+
+  // 7. Wait until both ports respond
+  process.stdout.write('  Waiting for services');
+  try {
+    await Promise.all([waitFor(apiPort), waitFor(webPort)]);
+  } catch (e) {
+    console.error(red('\n  Timed out waiting for services to start.'));
+    cleanup(procs);
+    process.exit(1);
+  }
+  console.log(' ' + green('✓'));
+  console.log('');
+
+  // 8. Open browser
+  const url = `http://localhost:${webPort}`;
+  console.log(`  ${bold('Dashboard')} → ${cyan(url)}`);
+  if (!NO_OPEN) openUrl(url);
+  console.log(`  ${dim('Ctrl+C to stop both services')}`);
+  console.log('');
+
+  process.on('SIGINT', () => { cleanup(procs); process.exit(0); });
+  process.on('SIGTERM', () => { cleanup(procs); process.exit(0); });
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function findPython() {
+  for (const cmd of ['python3', 'python']) {
+    try {
+      const v = execSync(`${cmd} -c "import sys; print(sys.version_info.major)"`, {
+        stdio: 'pipe',
+      }).toString().trim();
+      if (v === '3') return cmd;
+    } catch {}
+  }
+  return null;
+}
+
+function runSync(cmd, opts = {}) {
+  execSync(cmd, { stdio: 'pipe', ...opts });
+}
+
+function step(label) {
+  process.stdout.write(`  ${label}...`);
+}
+function ok() {
+  console.log(' ' + green('done'));
+}
+function stepCached(label) {
+  console.log(`  ${label}... ${dim('cached')}`);
+}
+
+function attachPrefix(proc, tag) {
+  let stdoutBuf = '';
+  let stderrBuf = '';
+
+  const flush = (buf, incoming, stream) => {
+    buf += incoming.toString();
+    const lines = buf.split('\n');
+    const remainder = lines.pop();
+    for (const line of lines) {
+      if (line.trim()) stream.write(`${tag} ${line}\n`);
+    }
+    return remainder;
+  };
+
+  proc.stdout.on('data', (d) => { stdoutBuf = flush(stdoutBuf, d, process.stdout); });
+  proc.stderr.on('data', (d) => { stderrBuf = flush(stderrBuf, d, process.stderr); });
+}
+
+function findFreePort(preferred) {
+  return new Promise((resolve) => {
+    // Use connect (not listen) to detect in-use ports — on macOS, listen(0.0.0.0)
+    // succeeds even when 127.0.0.1 is already bound (dual IPv4/IPv6 stack quirk).
+    const client = net.createConnection({ port: preferred, host: '127.0.0.1' });
+    client.on('connect', () => {
+      client.destroy();
+      const fallback = net.createServer();
+      fallback.listen(0, () => {
+        const { port } = fallback.address();
+        fallback.close(() => resolve(port));
+      });
+    });
+    client.on('error', () => resolve(preferred));
+  });
+}
+
+function waitFor(port, timeoutMs = 60000) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const attempt = () => {
+      if (Date.now() > deadline) { reject(new Error(`port ${port} timeout`)); return; }
+      const req = http.get(`http://localhost:${port}`, () => {
+        process.stdout.write('.');
+        resolve();
+      });
+      req.on('error', () => setTimeout(attempt, 600));
+      req.setTimeout(400, () => { req.destroy(); setTimeout(attempt, 600); });
+    };
+    attempt();
+  });
+}
+
+function openUrl(url) {
+  try {
+    if (process.platform === 'darwin') execSync(`open "${url}"`);
+    else if (process.platform === 'win32') execSync(`start "" "${url}"`);
+    else execSync(`xdg-open "${url}"`);
+  } catch {}
+}
+
+function cleanup(procs) {
+  for (const p of procs) {
+    try { p.kill('SIGTERM'); } catch {}
+  }
+}
+
+main().catch((e) => {
+  console.error(red('\n  Fatal: ') + e.message);
+  process.exit(1);
+});

--- a/frontend/.npmignore
+++ b/frontend/.npmignore
@@ -1,0 +1,4 @@
+# Overrides frontend/.gitignore for npm packaging.
+# build/ is intentionally NOT excluded here — it's the pre-built app needed at runtime.
+node_modules/
+src/

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -144,6 +144,13 @@ export default [
 		}
 	},
 	prettier,
+	// Server-side files and universal modules that use process.env
+	{
+		files: ['**/*.server.ts', 'src/lib/config.ts'],
+		languageOptions: {
+			globals: { process: 'readonly' }
+		}
+	},
 	// Test files: relax strict typing rules for mocks and test helpers
 	{
 		files: ['src/tests/**/*.ts', 'src/**/*.test.ts', 'src/**/*.spec.ts'],

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
 				"@tailwindcss/vite": "^4.1.18",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/svelte": "^5.3.1",
+				"@types/node": "^25.6.0",
 				"@typescript-eslint/eslint-plugin": "^8.52.0",
 				"@typescript-eslint/parser": "^8.52.0",
 				"eslint": "^9.39.2",
@@ -2067,6 +2068,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "*"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.19.0"
 			}
 		},
 		"node_modules/@types/resolve": {
@@ -5441,6 +5452,13 @@
 			"engines": {
 				"node": ">=20.18.1"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"devOptional": true,
+			"license": "MIT"
 		},
 		"node_modules/unist-util-is": {
 			"version": "6.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
 		"@tailwindcss/vite": "^4.1.18",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/svelte": "^5.3.1",
+		"@types/node": "^25.6.0",
 		"@typescript-eslint/eslint-plugin": "^8.52.0",
 		"@typescript-eslint/parser": "^8.52.0",
 		"eslint": "^9.39.2",

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -19,6 +19,7 @@
 				}
 			})();
 		</script>
+		<script>window.__KARMA_API_BASE__ = '%karma_api_base%';</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -1,0 +1,8 @@
+import type { Handle } from '@sveltejs/kit';
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const apiBase = process.env.KARMA_API_URL || 'http://localhost:8000';
+	return resolve(event, {
+		transformPageChunk: ({ html }) => html.replace('%karma_api_base%', apiBase)
+	});
+};

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -18,7 +18,17 @@
  * const response = await fetch(`${API_BASE}/projects`);
  * ```
  */
-export const API_BASE = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000';
+// Server-side (SSR): KARMA_API_URL is injected into process.env by bin/start.js at launch.
+// Client-side: __KARMA_API_BASE__ is injected into HTML by hooks.server.ts at request time.
+// Dev mode fallback: Vite's PUBLIC_API_URL env var or localhost default.
+type KarmaWindow = Window & { __KARMA_API_BASE__?: string };
+export const API_BASE: string =
+	typeof window === 'undefined'
+		? (process.env.KARMA_API_URL ?? 'http://localhost:8000')
+		: (window as KarmaWindow).__KARMA_API_BASE__ &&
+			  (window as KarmaWindow).__KARMA_API_BASE__ !== '%karma_api_base%'
+			? (window as KarmaWindow).__KARMA_API_BASE__!
+			: import.meta.env.PUBLIC_API_URL ?? 'http://localhost:8000';
 
 /**
  * API request timeout in milliseconds (default: 30 seconds)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "claude-code-karma",
+  "version": "0.1.0",
+  "description": "One-command dashboard for your Claude Code sessions",
+  "bin": {
+    "claude-code-karma": "bin/start.js"
+  },
+  "scripts": {
+    "prepack": "cd frontend && npm install && npm run build"
+  },
+  "files": [
+    "bin/",
+    "api/__init__.py",
+    "api/main.py",
+    "api/config.py",
+    "api/schemas.py",
+    "api/utils.py",
+    "api/utils_io.py",
+    "api/collectors.py",
+    "api/parallel.py",
+    "api/http_caching.py",
+    "api/requirements.txt",
+    "api/pyproject.toml",
+    "api/models/",
+    "api/routers/",
+    "api/services/",
+    "api/middleware/",
+    "api/db/",
+    "api/command_helpers/",
+    "frontend/build/",
+    "frontend/static/"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "Apache-2.0",
+  "keywords": ["claude", "claude-code", "dashboard", "analytics", "monitoring"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JayantDevkar/claude-code-karma.git"
+  }
+}


### PR DESCRIPTION
## Summary

This PR packages the entire Claude Code Karma stack as a self-contained npm module, enabling one-command installation and launch for any user — no manual Python virtualenv setup, no port configuration, no separate terminal windows.

```bash
npx claude-code-karma
```

That single command will:
1. Find Python 3 on the system
2. Create an isolated virtualenv (`.karma-venv/`) on first run
3. Install all API dependencies (cached on subsequent runs via a stamp file)
4. Detect whether ports 8000 / 5173 are already in use and auto-select free alternatives
5. Start the FastAPI backend and the pre-built SvelteKit frontend in parallel
6. Wait until both services are responding, then open the dashboard in the browser

---

## What changed

### `bin/start.js` (new)
The CLI entry point. Pure Node.js, no npm dependencies — uses only built-ins (`child_process`, `fs`, `http`, `net`). Key behaviours:

- **Python discovery**: tries `python3` then `python`, exits with a clear message if neither is Python 3
- **Virtualenv management**: creates `.karma-venv/` adjacent to the package root; a `.deps-installed` stamp file prevents pip from re-running on every launch
- **Port conflict resolution**: uses a TCP connect probe (not listen) to detect in-use ports — works correctly on macOS where `listen(0.0.0.0)` can succeed even when `127.0.0.1` is already bound. Falls back to a random free OS-assigned port
- **Process supervision**: prefixes all stdout/stderr from both child processes with `[api]` / `[web]` tags; shuts both down cleanly on `SIGINT` / `SIGTERM` or if either process exits with a non-zero code
- **Startup readiness**: polls both ports over HTTP before printing the dashboard URL, with a 60-second timeout
- **Browser launch**: cross-platform (`open` / `start` / `xdg-open`); can be suppressed with `--no-open`
- **Port overrides**: `--api-port <n>` and `--web-port <n>` flags for users who always want specific ports

### `package.json` (root, new)
Makes the repo publishable as `claude-code-karma` on npm:
- `"bin"` wires `claude-code-karma` → `bin/start.js`
- `"files"` whitelist includes `bin/`, all API source, and `frontend/build/` (the pre-built SvelteKit app)
- `"prepack"` script runs `cd frontend && npm install && npm run build` so the build is always fresh before packing

### `frontend/src/hooks.server.ts` (new)
A SvelteKit server hook that replaces the `%karma_api_base%` placeholder in every SSR HTML response with the actual `KARMA_API_URL` environment variable injected by `bin/start.js` at launch time. This is how the pre-built, static-at-build-time frontend learns which port the API is on at runtime.

### `frontend/src/app.html` (modified)
Adds a single `<script>` tag that seeds `window.__KARMA_API_BASE__` with the placeholder:
```html
<script>window.__KARMA_API_BASE__ = '%karma_api_base%';</script>
```
The placeholder is replaced server-side by `hooks.server.ts` before the page reaches the browser.

### `frontend/src/lib/config.ts` (modified)
Fixes a production bug where all 24 server-side load functions (`+page.server.ts`) would always use the hardcoded `localhost:8000` fallback regardless of what port the API actually started on.

The export now has two branches:
```ts
export const API_BASE: string =
  typeof window === 'undefined'
    // Server-side (SSR): read runtime env var injected by bin/start.js
    ? (process.env.KARMA_API_URL ?? 'http://localhost:8000')
    // Client-side: read window.__KARMA_API_BASE__ injected by hooks.server.ts
    : (window.__KARMA_API_BASE__ && window.__KARMA_API_BASE__ !== '%karma_api_base%'
        ? window.__KARMA_API_BASE__
        : import.meta.env.PUBLIC_API_URL ?? 'http://localhost:8000');
```

The dev-mode behaviour (Vite env var / localhost default) is completely unchanged.

### `.npmignore` (root, new)
Prevents Python build artifacts, the runtime venv, and test files from bloating the npm tarball while explicitly preserving `frontend/build/` (which `.gitignore` normally excludes).

### `frontend/.npmignore` (new)
Overrides `frontend/.gitignore` for npm packaging — keeps `build/`, excludes `src/` and `node_modules/`. Without this file, `npm pack` would use `frontend/.gitignore` and omit the built app entirely.

### `frontend/package.json` + `package-lock.json` (modified)
Adds `@types/node` as a dev dependency. Required for TypeScript to recognise `process.env` in `config.ts` and the pre-existing `hooks.server.ts`. Without it, `npm run check` and `npm run build` both fail with _"Cannot find name 'process'"_.

### `.gitignore` (modified)
- Adds `.karma-venv/` — the runtime virtualenv must not be tracked
- Adds `*.tgz` — prevents accidental commits of `npm pack` output

---

## How the runtime URL injection works end-to-end

```
bin/start.js
  └─ spawns SvelteKit node server with env KARMA_API_URL=http://localhost:<apiPort>

Browser request → SvelteKit node server
  └─ hooks.server.ts reads process.env.KARMA_API_URL
  └─ replaces %karma_api_base% in HTML → window.__KARMA_API_BASE__ = 'http://localhost:<apiPort>'
  └─ +page.server.ts load functions use config.ts → process.env.KARMA_API_URL (SSR path)
  └─ browser JS reads window.__KARMA_API_BASE__ (client path)
```

Both SSR data fetching and client-side API calls always reach the correct port, even when 8000 is occupied.

---

## Test plan

- [ ] `npm run check` passes with 0 errors in `frontend/`
- [ ] With ports 8000 and 5173 free: `npx claude-code-karma` starts both services, opens browser, dashboard loads
- [ ] With port 8000 occupied: startup prints `Port 8000 in use → API on <n>`, dashboard loads and SSR pages return data (not 502)
- [ ] With port 5173 occupied: startup prints `Port 5173 in use → Web on <n>`, dashboard opens on the new port
- [ ] `Ctrl+C` shuts down both services cleanly
- [ ] `npx claude-code-karma --no-open` starts services without opening a browser tab
- [ ] Second run skips pip install (shows `API dependencies... cached`)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)