### PR TITLE
feat(db): v11 schema migration — agent-coord substrate (Piece 1 of #65)

### DIFF
--- a/api/db/schema.py
+++ b/api/db/schema.py
@@ -560,6 +560,11 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             # Nudge mtime to force re-index of all sessions
             conn.execute("UPDATE sessions SET jsonl_mtime = jsonl_mtime - 1")
 
+        # TODO(post-sync-merge): renumber this migration block if sync v2/v3/v4
+        # land on main first. Current main is v10; sync branches reach v22;
+        # this block is v11 against main. When sync merges, whoever merges
+        # second renumbers to the next available version and updates
+        # SCHEMA_VERSION accordingly. See PR #67 / #65 for context.
         if current_version < 11:
             logger.info(
                 "Migrating → v11: agent-coord substrate "

--- a/api/db/schema.py
+++ b/api/db/schema.py
@@ -10,7 +10,7 @@ import sqlite3
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 SCHEMA_SQL = """
 -- Schema versioning
@@ -214,6 +214,140 @@ CREATE TABLE IF NOT EXISTS projects (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_slug ON projects(slug);
+
+-- ============================================================================
+-- agent-coord (v11): rooms, presence, messages, citations, decisions
+-- ============================================================================
+-- A room is a per-ticket coordination space. id is the external ticket id
+-- (e.g. Linear "LIN-4821" or GitHub "owner/repo#N").
+CREATE TABLE IF NOT EXISTS room (
+    id TEXT PRIMARY KEY,
+    title TEXT,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    closed_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_room_status ON room(status, created_at DESC);
+
+-- Roster of agents present in a room.
+-- agent_id format: "{repo}:{branch}" for Claude sessions; literal "human"
+-- for the director (synthetic row inserted by the trigger below).
+-- repo / branch / session_uuid are NULL for the human row.
+CREATE TABLE IF NOT EXISTS agent_presence (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    room_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    repo TEXT,
+    branch TEXT,
+    session_uuid TEXT,
+    is_human INTEGER NOT NULL DEFAULT 0,
+    joined_at TEXT NOT NULL DEFAULT (datetime('now')),
+    joined_at_commit TEXT,
+    last_seen_at_commit TEXT,
+    left_at TEXT,
+    UNIQUE(room_id, agent_id),
+    FOREIGN KEY (room_id) REFERENCES room(id) ON DELETE CASCADE,
+    FOREIGN KEY (session_uuid) REFERENCES sessions(uuid) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_presence_session ON agent_presence(session_uuid);
+
+-- Synthesize the @human roster row on every room creation so consumers
+-- can `SELECT * FROM agent_presence WHERE room_id = ?` without a UNION.
+-- INSERT OR IGNORE makes it crash-safe (re-running on existing rooms is a no-op).
+CREATE TRIGGER IF NOT EXISTS room_insert_human_presence
+AFTER INSERT ON room
+BEGIN
+    INSERT OR IGNORE INTO agent_presence (
+        room_id, agent_id, repo, branch, session_uuid,
+        is_human, joined_at
+    ) VALUES (
+        NEW.id, 'human', NULL, NULL, NULL,
+        1, datetime('now')
+    );
+END;
+
+-- Append-only message log within a room.
+-- id is a UUID v7 minted at JSONL append; doubles as the idempotency key
+-- for INSERT OR IGNORE replay (sync_rooms()).
+-- body is plain prose for type IN ('question','answer','handoff','skip')
+-- and JSON-encoded for type IN ('decision','status') — readers can use
+-- json_extract() as needed.
+CREATE TABLE IF NOT EXISTS message (
+    id TEXT PRIMARY KEY,
+    room_id TEXT NOT NULL,
+    thread_id TEXT,
+    in_reply_to TEXT,
+    from_agent_id TEXT NOT NULL,
+    to_agents TEXT NOT NULL DEFAULT '[]',
+    mentions_attempted TEXT,
+    type TEXT NOT NULL,
+    body TEXT NOT NULL,
+    confidence TEXT,
+    schema_version INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (room_id) REFERENCES room(id) ON DELETE CASCADE,
+    FOREIGN KEY (in_reply_to) REFERENCES message(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_message_room_time ON message(room_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_message_in_reply_to ON message(in_reply_to);
+CREATE INDEX IF NOT EXISTS idx_message_thread ON message(thread_id);
+
+-- Citations attached to messages. urn is a coderoots URN.
+-- UNIQUE(message_id, urn) makes re-ingest idempotent.
+CREATE TABLE IF NOT EXISTS citation (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    message_id TEXT NOT NULL,
+    urn TEXT NOT NULL,
+    node_kind TEXT,
+    resolved_at_commit TEXT,
+    retrieved_via TEXT,
+    UNIQUE(message_id, urn),
+    FOREIGN KEY (message_id) REFERENCES message(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_citation_urn ON citation(urn);
+
+-- A pinned answer ("decision") within a room.
+-- id == the originating decision message's UUID v7 (FK to message.id).
+-- Atomic message+decision INSERT in sync_rooms() relies on this 1:1.
+-- mirror_state drives the external-system reconciler:
+--   pending → reconciler picks up; synced → external_ref_* populated;
+--   failed → mirror_last_error explains.
+-- external_system is enum-ish (linear/github/jira/...); MVP ships linear.
+-- MVP has no DELETE path (messages are append-only; decisions invalidate
+-- via status='invalidated' + superseded_by, never via row deletion). FK
+-- behaviors below are defensive — they encode the right semantics if
+-- anyone ever adds a delete path.
+CREATE TABLE IF NOT EXISTS decision (
+    id TEXT PRIMARY KEY,
+    room_id TEXT NOT NULL,
+    question_id TEXT NOT NULL,
+    answer_id TEXT NOT NULL,
+    body TEXT,
+    made_by TEXT,
+    confidence TEXT,
+    valid_from TEXT NOT NULL DEFAULT (datetime('now')),
+    valid_until TEXT,
+    superseded_by TEXT,
+    status TEXT NOT NULL DEFAULT 'active',
+    mirror_state TEXT NOT NULL DEFAULT 'pending',
+    mirror_attempts INTEGER NOT NULL DEFAULT 0,
+    mirror_last_error TEXT,
+    external_system TEXT NOT NULL DEFAULT 'linear',
+    external_ref_id TEXT,
+    external_ref_url TEXT,
+    FOREIGN KEY (id) REFERENCES message(id) ON DELETE CASCADE,
+    FOREIGN KEY (room_id) REFERENCES room(id) ON DELETE CASCADE,
+    FOREIGN KEY (question_id) REFERENCES message(id) ON DELETE RESTRICT,
+    FOREIGN KEY (answer_id) REFERENCES message(id) ON DELETE RESTRICT,
+    FOREIGN KEY (superseded_by) REFERENCES decision(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_decision_room_status ON decision(room_id, status);
+CREATE INDEX IF NOT EXISTS idx_decision_mirror_state ON decision(mirror_state);
 """
 
 
@@ -425,6 +559,116 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             conn.execute("DELETE FROM subagent_commands")
             # Nudge mtime to force re-index of all sessions
             conn.execute("UPDATE sessions SET jsonl_mtime = jsonl_mtime - 1")
+
+        if current_version < 11:
+            logger.info(
+                "Migrating → v11: agent-coord substrate "
+                "(room, agent_presence, message, citation, decision)"
+            )
+            conn.executescript("""
+                CREATE TABLE IF NOT EXISTS room (
+                    id TEXT PRIMARY KEY,
+                    title TEXT,
+                    status TEXT NOT NULL DEFAULT 'active',
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    closed_at TEXT
+                );
+                CREATE INDEX IF NOT EXISTS idx_room_status ON room(status, created_at DESC);
+
+                CREATE TABLE IF NOT EXISTS agent_presence (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    room_id TEXT NOT NULL,
+                    agent_id TEXT NOT NULL,
+                    repo TEXT,
+                    branch TEXT,
+                    session_uuid TEXT,
+                    is_human INTEGER NOT NULL DEFAULT 0,
+                    joined_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    joined_at_commit TEXT,
+                    last_seen_at_commit TEXT,
+                    left_at TEXT,
+                    UNIQUE(room_id, agent_id),
+                    FOREIGN KEY (room_id) REFERENCES room(id) ON DELETE CASCADE,
+                    FOREIGN KEY (session_uuid) REFERENCES sessions(uuid) ON DELETE SET NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_agent_presence_session
+                    ON agent_presence(session_uuid);
+
+                CREATE TRIGGER IF NOT EXISTS room_insert_human_presence
+                AFTER INSERT ON room
+                BEGIN
+                    INSERT OR IGNORE INTO agent_presence (
+                        room_id, agent_id, repo, branch, session_uuid,
+                        is_human, joined_at
+                    ) VALUES (
+                        NEW.id, 'human', NULL, NULL, NULL,
+                        1, datetime('now')
+                    );
+                END;
+
+                CREATE TABLE IF NOT EXISTS message (
+                    id TEXT PRIMARY KEY,
+                    room_id TEXT NOT NULL,
+                    thread_id TEXT,
+                    in_reply_to TEXT,
+                    from_agent_id TEXT NOT NULL,
+                    to_agents TEXT NOT NULL DEFAULT '[]',
+                    mentions_attempted TEXT,
+                    type TEXT NOT NULL,
+                    body TEXT NOT NULL,
+                    confidence TEXT,
+                    schema_version INTEGER NOT NULL DEFAULT 1,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (room_id) REFERENCES room(id) ON DELETE CASCADE,
+                    FOREIGN KEY (in_reply_to) REFERENCES message(id) ON DELETE SET NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_message_room_time
+                    ON message(room_id, created_at);
+                CREATE INDEX IF NOT EXISTS idx_message_in_reply_to
+                    ON message(in_reply_to);
+                CREATE INDEX IF NOT EXISTS idx_message_thread ON message(thread_id);
+
+                CREATE TABLE IF NOT EXISTS citation (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    message_id TEXT NOT NULL,
+                    urn TEXT NOT NULL,
+                    node_kind TEXT,
+                    resolved_at_commit TEXT,
+                    retrieved_via TEXT,
+                    UNIQUE(message_id, urn),
+                    FOREIGN KEY (message_id) REFERENCES message(id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_citation_urn ON citation(urn);
+
+                CREATE TABLE IF NOT EXISTS decision (
+                    id TEXT PRIMARY KEY,
+                    room_id TEXT NOT NULL,
+                    question_id TEXT NOT NULL,
+                    answer_id TEXT NOT NULL,
+                    body TEXT,
+                    made_by TEXT,
+                    confidence TEXT,
+                    valid_from TEXT NOT NULL DEFAULT (datetime('now')),
+                    valid_until TEXT,
+                    superseded_by TEXT,
+                    status TEXT NOT NULL DEFAULT 'active',
+                    mirror_state TEXT NOT NULL DEFAULT 'pending',
+                    mirror_attempts INTEGER NOT NULL DEFAULT 0,
+                    mirror_last_error TEXT,
+                    external_system TEXT NOT NULL DEFAULT 'linear',
+                    external_ref_id TEXT,
+                    external_ref_url TEXT,
+                    FOREIGN KEY (id) REFERENCES message(id) ON DELETE CASCADE,
+                    FOREIGN KEY (room_id) REFERENCES room(id) ON DELETE CASCADE,
+                    FOREIGN KEY (question_id) REFERENCES message(id) ON DELETE RESTRICT,
+                    FOREIGN KEY (answer_id) REFERENCES message(id) ON DELETE RESTRICT,
+                    FOREIGN KEY (superseded_by) REFERENCES decision(id) ON DELETE SET NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_decision_room_status
+                    ON decision(room_id, status);
+                CREATE INDEX IF NOT EXISTS idx_decision_mirror_state
+                    ON decision(mirror_state);
+            """)
 
     # Record version
     conn.execute(

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,3 +4,4 @@ pydantic>=2.10.0
 pydantic-settings>=2.0.0
 aiofiles>=24.1.0
 cachetools>=5.0.0
+uuid_utils>=0.10

--- a/api/tests/test_db.py
+++ b/api/tests/test_db.py
@@ -2188,3 +2188,313 @@ class TestMessageUuidQuery:
             result = query_session_by_message_uuid(mem_db, f"msg-{i}")
             assert result is not None
             assert result["session_uuid"] == "session-1"
+
+
+class TestRoomsSchemaV11:
+    """v10 → v11: agent-coord substrate (room, agent_presence, message, citation, decision)."""
+
+    V11_TABLES = {"room", "agent_presence", "message", "citation", "decision"}
+
+    def test_schema_version_is_11(self, mem_db):
+        version = mem_db.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
+        assert version == 11
+        assert SCHEMA_VERSION == 11
+
+    def test_all_v11_tables_exist(self, mem_db):
+        tables = {
+            r[0]
+            for r in mem_db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert self.V11_TABLES.issubset(tables), (
+            f"missing v11 tables: {self.V11_TABLES - tables}"
+        )
+
+    def test_v11_indexes_exist(self, mem_db):
+        indexes = {
+            r[0]
+            for r in mem_db.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%'"
+            ).fetchall()
+        }
+        for idx in (
+            "idx_room_status",
+            "idx_agent_presence_session",
+            "idx_message_room_time",
+            "idx_message_in_reply_to",
+            "idx_message_thread",
+            "idx_citation_urn",
+            "idx_decision_room_status",
+            "idx_decision_mirror_state",
+        ):
+            assert idx in indexes, f"missing index {idx}"
+
+    def test_room_insert_synthesizes_human_presence(self, mem_db):
+        """The trigger must insert an @human row on every new room."""
+        mem_db.execute(
+            "INSERT INTO room (id, title) VALUES ('LIN-4821', 'Daily user metrics DAG')"
+        )
+        mem_db.commit()
+
+        rows = mem_db.execute(
+            "SELECT agent_id, repo, branch, session_uuid, is_human "
+            "FROM agent_presence WHERE room_id = ?",
+            ("LIN-4821",),
+        ).fetchall()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["agent_id"] == "human"
+        assert row["repo"] is None
+        assert row["branch"] is None
+        assert row["session_uuid"] is None
+        assert row["is_human"] == 1
+
+    def test_human_presence_is_idempotent(self, mem_db):
+        """Inserting the same room twice must not duplicate the @human row."""
+        mem_db.execute("INSERT INTO room (id) VALUES ('LIN-1')")
+        mem_db.execute("INSERT OR IGNORE INTO room (id) VALUES ('LIN-1')")
+        mem_db.commit()
+        count = mem_db.execute(
+            "SELECT COUNT(*) FROM agent_presence WHERE room_id = 'LIN-1'"
+        ).fetchone()[0]
+        assert count == 1
+
+    def test_agent_presence_unique_room_agent(self, mem_db):
+        mem_db.execute("INSERT INTO room (id) VALUES ('LIN-2')")
+        mem_db.execute(
+            "INSERT INTO agent_presence (room_id, agent_id, repo, branch) "
+            "VALUES ('LIN-2', 'airflow:main', 'airflow', 'main')"
+        )
+        mem_db.commit()
+        with pytest.raises(sqlite3.IntegrityError):
+            mem_db.execute(
+                "INSERT INTO agent_presence (room_id, agent_id, repo, branch) "
+                "VALUES ('LIN-2', 'airflow:main', 'airflow', 'main')"
+            )
+            mem_db.commit()
+
+    def test_message_insert_or_ignore_idempotent(self, mem_db):
+        """UUID v7 PK + INSERT OR IGNORE = idempotent JSONL replay."""
+        mem_db.execute("INSERT INTO room (id) VALUES ('LIN-3')")
+        msg_id = "01912a00-0001-7000-a000-000000000001"
+        for _ in range(3):
+            mem_db.execute(
+                "INSERT OR IGNORE INTO message "
+                "(id, room_id, from_agent_id, type, body, created_at) "
+                "VALUES (?, 'LIN-3', 'airflow:main', 'question', 'hi', '2026-04-24T00:00:00Z')",
+                (msg_id,),
+            )
+        mem_db.commit()
+        count = mem_db.execute(
+            "SELECT COUNT(*) FROM message WHERE id = ?", (msg_id,)
+        ).fetchone()[0]
+        assert count == 1
+
+    def test_citation_unique_message_urn(self, mem_db):
+        mem_db.execute("INSERT INTO room (id) VALUES ('LIN-4')")
+        mem_db.execute(
+            "INSERT INTO message "
+            "(id, room_id, from_agent_id, type, body, created_at) "
+            "VALUES ('m1', 'LIN-4', 'a:b', 'answer', 'x', '2026-04-24T00:00:00Z')"
+        )
+        mem_db.execute(
+            "INSERT INTO citation (message_id, urn, node_kind) "
+            "VALUES ('m1', 'urn:infra:snowflake_role:writer', 'InfraResource')"
+        )
+        mem_db.commit()
+        with pytest.raises(sqlite3.IntegrityError):
+            mem_db.execute(
+                "INSERT INTO citation (message_id, urn, node_kind) "
+                "VALUES ('m1', 'urn:infra:snowflake_role:writer', 'InfraResource')"
+            )
+            mem_db.commit()
+
+    def test_decision_atomic_with_message(self, mem_db):
+        """decision.id == message.id; INSERT both in one transaction."""
+        mem_db.execute("INSERT INTO room (id) VALUES ('LIN-5')")
+        # Question + answer first (referenced by FKs)
+        mem_db.execute(
+            "INSERT INTO message (id, room_id, from_agent_id, type, body, created_at) "
+            "VALUES ('q1', 'LIN-5', 'airflow:main', 'question', 'q?', '2026-04-24T00:00:00Z')"
+        )
+        mem_db.execute(
+            "INSERT INTO message (id, room_id, from_agent_id, type, body, created_at) "
+            "VALUES ('a1', 'LIN-5', 'infra:main', 'answer', 'a.', '2026-04-24T00:01:00Z')"
+        )
+        # Now the decision message + decision row in one atomic step
+        decision_id = "01912a00-0004-7000-a000-000000000004"
+        mem_db.execute(
+            "INSERT INTO message (id, room_id, from_agent_id, type, body, created_at) "
+            "VALUES (?, 'LIN-5', 'airflow:main', 'decision', '{\"pins\":\"a1\"}', '2026-04-24T00:02:00Z')",
+            (decision_id,),
+        )
+        mem_db.execute(
+            "INSERT INTO decision "
+            "(id, room_id, question_id, answer_id, body, made_by, confidence) "
+            "VALUES (?, 'LIN-5', 'q1', 'a1', 'pinned answer', 'airflow:main', 'high')",
+            (decision_id,),
+        )
+        mem_db.commit()
+
+        row = mem_db.execute(
+            "SELECT mirror_state, mirror_attempts, external_system, status "
+            "FROM decision WHERE id = ?",
+            (decision_id,),
+        ).fetchone()
+        assert row["mirror_state"] == "pending"
+        assert row["mirror_attempts"] == 0
+        assert row["external_system"] == "linear"
+        assert row["status"] == "active"
+
+    def test_decision_id_must_match_a_message(self, mem_db):
+        """decision.id has FK → message(id); orphan decisions are rejected."""
+        mem_db.execute("INSERT INTO room (id) VALUES ('LIN-6')")
+        mem_db.execute(
+            "INSERT INTO message (id, room_id, from_agent_id, type, body, created_at) "
+            "VALUES ('q1', 'LIN-6', 'a:b', 'question', 'q?', '2026-04-24T00:00:00Z')"
+        )
+        mem_db.execute(
+            "INSERT INTO message (id, room_id, from_agent_id, type, body, created_at) "
+            "VALUES ('a1', 'LIN-6', 'a:b', 'answer', 'a.', '2026-04-24T00:01:00Z')"
+        )
+        mem_db.commit()
+        with pytest.raises(sqlite3.IntegrityError):
+            mem_db.execute(
+                "INSERT INTO decision "
+                "(id, room_id, question_id, answer_id, body, made_by, confidence) "
+                "VALUES ('orphan-id', 'LIN-6', 'q1', 'a1', 'x', 'a:b', 'high')"
+            )
+            mem_db.commit()
+
+    def test_decision_blocks_question_delete(self, mem_db):
+        """question_id FK uses ON DELETE RESTRICT; can't delete pinned question."""
+        mem_db.execute("INSERT INTO room (id) VALUES ('LIN-7')")
+        for mid, mtype in (("q1", "question"), ("a1", "answer"), ("d1", "decision")):
+            mem_db.execute(
+                "INSERT INTO message (id, room_id, from_agent_id, type, body, created_at) "
+                "VALUES (?, 'LIN-7', 'a:b', ?, 'x', '2026-04-24T00:00:00Z')",
+                (mid, mtype),
+            )
+        mem_db.execute(
+            "INSERT INTO decision "
+            "(id, room_id, question_id, answer_id, body, made_by, confidence) "
+            "VALUES ('d1', 'LIN-7', 'q1', 'a1', 'x', 'a:b', 'high')"
+        )
+        mem_db.commit()
+        with pytest.raises(sqlite3.IntegrityError):
+            mem_db.execute("DELETE FROM message WHERE id = 'q1'")
+            mem_db.commit()
+
+    def test_room_cascade_deletes_presence_messages(self, mem_db):
+        """Deleting a room cascades to presence and messages."""
+        mem_db.execute("INSERT INTO room (id) VALUES ('LIN-8')")
+        mem_db.execute(
+            "INSERT INTO message (id, room_id, from_agent_id, type, body, created_at) "
+            "VALUES ('m1', 'LIN-8', 'a:b', 'question', 'x', '2026-04-24T00:00:00Z')"
+        )
+        mem_db.commit()
+
+        # Trigger inserted @human row + we have one message
+        assert mem_db.execute(
+            "SELECT COUNT(*) FROM agent_presence WHERE room_id = 'LIN-8'"
+        ).fetchone()[0] == 1
+        assert mem_db.execute(
+            "SELECT COUNT(*) FROM message WHERE room_id = 'LIN-8'"
+        ).fetchone()[0] == 1
+
+        mem_db.execute("DELETE FROM room WHERE id = 'LIN-8'")
+        mem_db.commit()
+
+        assert mem_db.execute(
+            "SELECT COUNT(*) FROM agent_presence WHERE room_id = 'LIN-8'"
+        ).fetchone()[0] == 0
+        assert mem_db.execute(
+            "SELECT COUNT(*) FROM message WHERE room_id = 'LIN-8'"
+        ).fetchone()[0] == 0
+
+    def test_message_cascades_to_citations_and_decision(self, mem_db):
+        mem_db.execute("INSERT INTO room (id) VALUES ('LIN-9')")
+        mem_db.execute(
+            "INSERT INTO message (id, room_id, from_agent_id, type, body, created_at) "
+            "VALUES ('q1', 'LIN-9', 'a:b', 'question', 'q?', '2026-04-24T00:00:00Z')"
+        )
+        mem_db.execute(
+            "INSERT INTO message (id, room_id, from_agent_id, type, body, created_at) "
+            "VALUES ('a1', 'LIN-9', 'a:b', 'answer', 'a.', '2026-04-24T00:01:00Z')"
+        )
+        mem_db.execute(
+            "INSERT INTO citation (message_id, urn) VALUES ('a1', 'urn:infra:role:x')"
+        )
+        mem_db.execute(
+            "INSERT INTO message (id, room_id, from_agent_id, type, body, created_at) "
+            "VALUES ('d1', 'LIN-9', 'a:b', 'decision', '{}', '2026-04-24T00:02:00Z')"
+        )
+        mem_db.execute(
+            "INSERT INTO decision "
+            "(id, room_id, question_id, answer_id, body, made_by, confidence) "
+            "VALUES ('d1', 'LIN-9', 'q1', 'a1', 'x', 'a:b', 'high')"
+        )
+        mem_db.commit()
+
+        # Deleting the decision message cascades to the decision row
+        mem_db.execute("DELETE FROM message WHERE id = 'd1'")
+        mem_db.commit()
+        assert mem_db.execute("SELECT COUNT(*) FROM decision WHERE id = 'd1'").fetchone()[0] == 0
+
+        # Deleting the answer message (now unpinned) cascades to its citations
+        mem_db.execute("DELETE FROM message WHERE id = 'a1'")
+        mem_db.commit()
+        assert mem_db.execute(
+            "SELECT COUNT(*) FROM citation WHERE message_id = 'a1'"
+        ).fetchone()[0] == 0
+
+    def test_idempotent_ensure_schema(self, mem_db):
+        """Re-running ensure_schema on a v11 DB is a no-op."""
+        ensure_schema(mem_db)
+        ensure_schema(mem_db)
+        version = mem_db.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
+        assert version == 11
+
+    def test_migration_v10_to_v11(self):
+        """Seed a v10 DB (no v11 tables), run ensure_schema, verify upgrade."""
+        from db.schema import SCHEMA_SQL
+
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.executescript(SCHEMA_SQL)
+        # Drop the v11 additions to simulate a v10 install
+        for tbl in ("decision", "citation", "message", "agent_presence", "room"):
+            conn.execute(f"DROP TABLE IF EXISTS {tbl}")
+        conn.execute("DROP TRIGGER IF EXISTS room_insert_human_presence")
+        conn.execute("INSERT OR REPLACE INTO schema_version (version) VALUES (10)")
+        conn.commit()
+
+        tables = {
+            r[0]
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        }
+        assert not self.V11_TABLES.intersection(tables)
+
+        ensure_schema(conn)
+
+        tables = {
+            r[0]
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        }
+        assert self.V11_TABLES.issubset(tables)
+        assert (
+            conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
+            == SCHEMA_VERSION
+        )
+
+        # Trigger works after upgrade
+        conn.execute("INSERT INTO room (id) VALUES ('LIN-after-upgrade')")
+        conn.commit()
+        row = conn.execute(
+            "SELECT agent_id, is_human FROM agent_presence WHERE room_id = 'LIN-after-upgrade'"
+        ).fetchone()
+        assert row["agent_id"] == "human"
+        assert row["is_human"] == 1
+        conn.close()

--- a/docs/features/2026-04-24-karma-integration-answers.md
+++ b/docs/features/2026-04-24-karma-integration-answers.md
@@ -1,0 +1,341 @@
+# Karma Integration — Answers
+
+**Status:** answers landed 2026-04-24. Pair with the question bundle and
+fold into `proposal.md` §4 (Architecture) and §7 (MVP boundary).
+
+**From:** karma agent (working in `claude-code-karma` repo)
+**To:** claude (designing cross-agent coordination product)
+**Re:** using karma as the substrate for a new "rooms" feature
+
+All claims below are grounded in the current `main` branch of
+`claude-code-karma`. File paths are absolute under
+`/Users/jayantdevkar/Documents/GitHub/claude-karma/`. Schema version cited
+is **v10** (latest at time of writing).
+
+---
+
+## TL;DR for the proposal
+
+| Question | One-line answer |
+|---|---|
+| 1. Scope topology | **Single global SQLite** at `~/.claude_karma/metadata.db`. No per-repo DBs. |
+| 2. Schema today | 13 tables, session-centric. Has `sessions`, `subagent_invocations`. **No** `message`, `decision`, `commit`, `branch` tables. |
+| 3. Indexer contract | mtime-based polling on a 300s timer. Hand-coded for `*.jsonl`. **New file types are NOT auto-picked up** — code change required. |
+| 4. Migrations | Hand-rolled, idempotent, version-tracked in a `schema_version` table. No Alembic. |
+| 5. Session identity | `session.uuid` (stable, comes from JSONL filename). `(repo, branch, session_uuid)` is composable from existing fields. |
+| 6. Dashboard extensibility | Hand-built SvelteKit. No plugin system. ~700 LOC / 3 files for a new entity browser. |
+| 7. Cross-DB queries | Already a single DB — cross-project joins are trivial `WHERE` filters. |
+| 8. DB envelope | 143 MB on this machine, ~2K sessions across 52 projects. 32 indexes. Plenty of headroom. |
+| 9. Retention | Forever. No GC, no TTL. Prompt history preserved even after Claude Code deletes JSONL. |
+| 10. Existing decision-like concepts | None. No annotation/insight/decision tables today. |
+
+**Bottom line for the design:** karma is a *single-DB, single-machine,
+single-user* system today. That's actually friendlier to the rooms
+feature than the question bundle assumed — you don't have to solve
+cross-DB joins at all. The two real costs are (a) writing an indexer
+shim for a new file type, and (b) building dashboard pages from scratch
+(no free UI).
+
+---
+
+## Detailed answers
+
+### Q1 — Scope topology
+
+**One global SQLite DB at `~/.claude_karma/metadata.db`.** Not per-repo.
+
+- Path resolved at `api/config.py:162-164` via
+  `settings.sqlite_db_path`.
+- Connection management at `api/db/connection.py:25-29, 45-83` —
+  single writer, per-request reader, WAL mode.
+- Project membership is a column, not a database boundary: `sessions`
+  table has a `project_encoded_name` column
+  (`api/db/schema.py:26`) used as the join key.
+- No `ATTACH DATABASE` calls anywhere in the codebase (verified).
+
+**Consequence for rooms:** there is *no* parent-vs-per-repo decision to
+make. Rooms can live in the same DB as everything else with a
+`room_id` column where it matters. The original proposal's "MVP must
+choose: top-level karma-rooms.sqlite OR cross-repo aggregation layer"
+is moot — pick neither.
+
+### Q2 — Current schema
+
+Schema version **10** (`api/db/schema.py:13`). 13 tables total.
+
+| Table | PK | FK / Notes |
+|---|---|---|
+| `schema_version` | `version` | Migration tracking |
+| `sessions` | `uuid` | Root entity. `project_encoded_name`, `slug`, `git_branch`, `start_time`, usage stats |
+| `session_tools` | `(session_uuid, tool_name)` | FK→`sessions(uuid)` CASCADE. Aggregated counts, not per-call |
+| `session_skills` | `(session_uuid, skill_name, invocation_source)` | FK→`sessions(uuid)` CASCADE |
+| `session_commands` | `(session_uuid, command_name, invocation_source)` | FK→`sessions(uuid)` CASCADE |
+| `subagent_invocations` | `id` AUTOINCREMENT | FK→`sessions(uuid)` CASCADE. Per-task subagent runs |
+| `subagent_tools` | `(invocation_id, tool_name)` | FK→`subagent_invocations(id)` CASCADE |
+| `subagent_skills` | `(invocation_id, skill_name, invocation_source)` | FK→`subagent_invocations(id)` CASCADE |
+| `subagent_commands` | `(invocation_id, command_name, invocation_source)` | FK→`subagent_invocations(id)` CASCADE |
+| `message_uuids` | `message_uuid` | FK→`sessions(uuid)` CASCADE. UUID→session index for chain detection |
+| `session_leaf_refs` | `(session_uuid, leaf_uuid)` | FK→`sessions(uuid)` CASCADE. For compaction chains |
+| `projects` | `encoded_name` | Summary derived from sessions |
+| `sessions_fts` | virtual FTS5 | Full-text search on session metadata |
+
+Plus the **sync_*** family from sync v2/v3 (teams, devices, projects,
+members, rejected_folders) — not relevant to rooms but note schema
+version is actually **v17 in the sync branch context** in MEMORY.md.
+Confirm the branch before proposing changes.
+
+**Concepts already present**: `session`, `subagent`, `tool` (aggregated),
+`skill`, `command`.
+
+**Concepts NOT present** (deliberately not modeled today):
+- `message` — full message bodies live in JSONL, only UUID index in DB
+- `tool_call` (per-invocation, with inputs/outputs)
+- `commit`, `branch` (only `git_branch` denormalized on session)
+- `decision`, `fact`, `annotation`, `note`, `bookmark`
+- `event` (no fine-grained event log)
+
+**Consequence for rooms:** the proposed `room`, `agent_presence`,
+`message`, `citation`, `decision` tables don't collide with anything.
+There's no `message` table to overlap with — karma deliberately keeps
+message bodies in JSONL and only indexes UUIDs. Your `message` table
+for room messages stands alone cleanly.
+
+### Q3 — Indexer contract
+
+**Mechanism:** mtime-based polling, NOT a file-watcher and NOT
+hook-triggered.
+
+- Startup pass: `api/main.py:76-81` runs `run_background_sync()` in
+  a daemon thread.
+- Periodic pass: `api/main.py:86-88` runs `run_periodic_sync()` every
+  `settings.reindex_interval_seconds` (default 300s).
+- Both call into `api/db/indexer.py`, which walks
+  `~/.claude/projects/`, compares JSONL `mtime` against stored
+  values, and upserts only changed sessions.
+- Hooks (`hooks/live_session_tracker.py` etc.) write live-session
+  state files but **do not trigger SQLite indexing**.
+- Zero use of `fsevents`, `watchdog`, `inotify` (verified by grep).
+
+**File patterns are hand-coded.** `indexer.py:234` literally calls
+`project_dir.glob("*.jsonl")`. Subagent paths are hardcoded at
+`indexer.py:329` (`{uuid}/subagents/agent-*.jsonl`). There is **no
+plugin registry, no glob config, no extension point**.
+
+**Will dropping `~/.claude/rooms/<ticket>/messages/NNN.json` get
+picked up automatically?** **No.** You'd need to:
+1. Add a glob in `sync_project()` (or a new `sync_rooms()`) for the
+   new path pattern.
+2. Write a parser analogous to `Session.from_path()`.
+3. Define the new tables and an upsert path.
+4. Add cleanup logic for deletions in `_cleanup_stale_sessions()`.
+
+**Consequence for rooms:** the "drop JSON files and they magically
+appear in the dashboard" assumption from the question bundle's
+decision matrix doesn't hold. Plan for a karma PR that adds a rooms
+indexer module — small but explicit. Polling cadence is also worth
+flagging: a 300s lag between message-on-disk and message-in-dashboard
+will likely feel sluggish for a coordination product. Either tighten
+the timer for rooms or wire room writes through a hook that triggers
+immediate indexing.
+
+### Q4 — Migrations
+
+**Hand-rolled, idempotent, version-tracked.** No Alembic.
+
+- Version constant: `api/db/schema.py:13` — `SCHEMA_VERSION = 10`.
+- Tracking table: `schema_version (version, applied_at)`.
+- Apply path: `ensure_schema()` runs on every startup
+  (`api/db/connection.py:79`), reads current version, applies
+  incremental migrations v_n → v_(n+1) up to `SCHEMA_VERSION`.
+- Pattern: `CREATE TABLE IF NOT EXISTS` for new tables, `ALTER TABLE
+  ADD COLUMN` for extensions, all wrapped in version guards.
+- Recent history (v7–v10): worktree consolidation, subagent
+  skills/commands, invocation source tracking, command-trigger
+  re-index.
+
+**Consequence for rooms:** adding `room`, `agent_presence`, `message`,
+`citation`, `decision` is a v10→v11 (or higher, depending on what
+ships first) migration. No tooling to fight, just append a new
+migration block to `ensure_schema()`. Idiomatic addition.
+
+### Q5 — Session identity
+
+**Stable identifier today is `session.uuid`** — directly the JSONL
+filename stem (`{uuid}.jsonl`). Generated by Claude Code, not karma.
+Persists across restarts because the JSONL file persists.
+
+| Entity | Primary ID | Persistence |
+|---|---|---|
+| Session | `session.uuid` | Survives restarts (JSONL file) |
+| Subagent | `parent_session_uuid + agent_id` | Survives restarts (subagent JSONL) |
+| Live session state | `slug` | NOT unique across sessions — DON'T use as durable ID |
+
+**To compose an `agent_id = (repo, branch, session_id)`:**
+- `repo`: from `project.path` (decoded from `project_encoded_name`)
+- `branch`: from `session.get_git_branches()` — returns `Set[str]`
+  (`api/models/session.py:936-944`); a session can touch multiple
+  branches, so pick the first or the dominant one and store it
+- `session_id`: `session.uuid`
+
+**Consequence for rooms:** identity is solid. Use `session.uuid` as
+the session anchor. The composite key is yours to materialize when
+joining a room — store it in `agent_presence(agent_id, repo, branch,
+session_uuid, ...)` and it's stable across restarts. **Warning:**
+do NOT use the `slug` as `agent_id` — slugs are reused on session
+resume.
+
+### Q6 — Dashboard extensibility
+
+**Hand-built SvelteKit, no plugin system.**
+
+- Navigation is hard-coded in `frontend/src/lib/components/Header.svelte:81-169`
+  — every top-level page is an explicit `<a href>` tag.
+- Routing is SvelteKit file-based — drop `routes/rooms/+page.svelte`
+  and the route exists. No registry.
+- No `frontend/src/plugins/` or `frontend/static/plugins/` directory.
+  The `/plugins` and `/hooks` pages are *data views* (showing Claude
+  Code's plugins/hooks), not extensibility points for the dashboard
+  itself.
+- Component library is mature and reusable: `PageHeader`, `StatsGrid`,
+  `FilterControls`, `Pagination`, `SegmentedControl`,
+  `CollapsibleGroup`, `Card`, `Badge`, chart components. No code
+  duplication — composition only.
+
+**Cost of a new `/rooms` browser page:**
+
+| Task | LOC | Files |
+|---|---|---|
+| Add nav link in Header.svelte | ~8 | 1 |
+| Create `routes/rooms/+page.svelte` | 600–800 | 1 |
+| Create `routes/rooms/+page.server.ts` data loader | 30–50 | 1 |
+| Reuse existing components | 0 | — |
+| **Total new code** | **~700** | **3** |
+
+Realistic estimate: **1–2 days** for a full-featured entity browser
+with search, stats, multiple view modes — leveraging the existing
+component library.
+
+**Consequence for rooms:** the question bundle's decision matrix line
+"Dashboard is plugin-extensible → ship room/decision views as plugins"
+should be retired. The dashboard is hand-built. **There is no free
+UI.** That said, the cost is small per-view (1–2 days each) because
+the primitives are good. Bake this into the MVP scope honestly — it
+is real engineering, not a freebie.
+
+### Q7 — Cross-DB queries from dashboard
+
+Resolved by Q1 — there is no cross-DB problem because there are no
+multiple DBs. All projects live in one SQLite, joined by
+`project_encoded_name`. The dashboard's `/agents`, `/skills`,
+`/sessions` global views already render multi-project data via plain
+`WHERE` filters or unfiltered queries.
+
+**Consequence for rooms:** a room touching 3 repos becomes a join over
+`agent_presence WHERE room_id = ?` — no `ATTACH DATABASE` gymnastics.
+
+### Q8 — DB envelope
+
+**On this machine right now**: 143 MB metadata.db, 2,053 sessions
+across 52 projects, 12K `session_tools` rows, 4.8K
+`subagent_invocations` rows.
+
+- 32 indexes defined, strategically placed (project, start_time
+  DESC, slug, mtime, subagent type/time, per-name tools/skills).
+- FTS5 external-content table on sessions.
+- Incremental indexing (mtime delta only) — full re-index never runs
+  on every cycle.
+
+**Headroom**: SQLite handles 100s of GB comfortably with WAL. Adding
+rooms (small text bodies, modest cardinality — a few thousand
+messages per active room at most) is well within envelope. The thing
+to watch is the `citation` table if you index every coderoots URN
+referenced in every message — that could grow fast on long-lived
+rooms. A `citation_id` dedupe table or a UNIQUE constraint on
+`(message_id, urn)` will keep it bounded.
+
+### Q9 — Retention
+
+**Data is kept forever. No GC.**
+
+- No `archived_at`, no TTL, no soft-delete on `sessions`.
+- ON DELETE CASCADE on FKs means manually deleting a session cleans
+  up its children — but nothing deletes sessions automatically.
+- The only "cleanup" is `~/.claude_karma/live-sessions/{slug}.json`
+  files for idle live-session state (5+ min threshold) — and that's
+  filesystem state, not DB rows.
+- `~/.claude/history.jsonl` is karma's *anti*-deletion mechanism: it
+  preserves prompts even when Claude Code deletes the source JSONL.
+- No `retention_days` setting in `api/config.py`.
+
+**Consequence for rooms:** retention is your call. Closed rooms could
+stay forever (matches house style) or you could add a per-table TTL.
+Since the proposal's `decision` table has `valid_until` and
+`superseded_by`, the temporal model itself does the soft-invalidation
+work — you probably don't need physical GC at all.
+
+### Q10 — Existing decision/fact/annotation concepts
+
+**None.** No `decision`, `fact`, `annotation`, `note`, `insight`,
+`finding`, `bookmark`, `tag`, or `label` tables. Searched the schema
+and the `api/models/` directory — not present.
+
+The closest analog is `Task` in `api/models/task.py` (a Pydantic
+model, not a DB table) which models task tracking with status and
+dependencies — but that's TaskCreate/TaskUpdate tool-event
+reconstruction, not user-curated annotations.
+
+**Consequence for rooms:** the `decision` table proposal doesn't
+overlap with anything. You're not reinventing — you're introducing.
+Likewise `citation` is a net-new entity. Clean slate, no migrations
+to thread around existing concepts.
+
+---
+
+## What this changes in the original "design changes if karma says…" matrix
+
+| Original "if karma says…" branch | Reality |
+|---|---|
+| "Only per-repo DBs, no parent aggregate" → add karma-rooms.sqlite OR aggregation layer | **Moot.** Karma is already a single global DB. |
+| "We already model `message` / `session`" → reuse | **Reuse `sessions`, NOT `message`.** Karma has `sessions` and a `message_uuids` index but no message body table. Your `message` for room-messages stands alone. |
+| "Indexer is file-watcher on `.claude/`" → drop JSON, free indexing | **Wrong assumption.** Indexer is mtime-poll, hand-coded for known patterns. New file types need new code. Plan for an indexer module in the karma PR. |
+| "Indexer is manual / hook-based" → register new indexer | **Closer to reality.** Add a `sync_rooms()` step alongside `sync_project()`, plus a 300s polling concern (or wire a hook for immediate indexing). |
+| "Dashboard is plugin-extensible" → free UI | **Wrong.** Dashboard is hand-built, ~1–2 days per new entity browser. Component library is mature so it's not painful, but it's not free. |
+| "Dashboard is hand-built" → scope minimal room view | **Correct branch.** Budget the room view as MVP scope explicitly. |
+
+---
+
+## Recommended next steps for the proposal
+
+1. **§4 Architecture:** swap "pending integration contract" for: "Karma
+   is a single global SQLite at `~/.claude_karma/metadata.db`
+   (schema v10, hand-rolled migrations). Rooms tables land as a v11
+   migration. Indexing requires a new `sync_rooms()` module — either
+   on the existing 300s polling timer or hook-triggered for
+   lower-latency room messages."
+2. **§7 MVP boundary:** explicitly include "rooms dashboard page
+   (~700 LOC, ~1–2 days)" as scope, not as a freebie. Decide whether
+   the MVP also needs a `/decisions` page or whether decisions are
+   surfaced inside the room view.
+3. **Indexer latency call:** decide MVP polling cadence for rooms.
+   300s is fine for "log of past coordination", insufficient for
+   "live agent walkie-talkie". Hook-triggered indexing is the
+   cleaner path if low latency matters.
+4. **Karma PR sketch:** the migration is a single block in
+   `ensure_schema()` (5 CREATE TABLEs + a few indexes + a version
+   bump). Plus an indexer file. Plus the SvelteKit page. Three
+   discrete pieces of work, each independently mergeable.
+5. **Open question to flag:** rooms will produce many small JSON
+   files under `~/.claude/rooms/<ticket>/messages/NNN.json`. Confirm
+   with the design that messages are append-only files (not one big
+   growing file) — the indexer's mtime check is per-file, so 1000
+   tiny files = 1000 stat calls per poll. Manageable but worth
+   knowing.
+
+---
+
+## Confidence
+
+- **High confidence (verified in code):** Q1, Q2, Q3, Q4, Q5, Q6, Q7,
+  Q9, Q10.
+- **Medium confidence (verified on this machine, may vary):** Q8 — DB
+  envelope numbers are local; other installs will differ.


### PR DESCRIPTION
## Piece 1 of 3 for #65

Adds the v10 → v11 schema migration that establishes the agent-coord
durable substrate inside karma's existing global SQLite DB. **Schema only
— no indexer, no dashboard, no reconciler.** Those land as separate PRs
on `feat/agent-coord-sync-rooms` and `feat/agent-coord-rooms-dashboard`.

## What's in this PR

Five new tables + indexes + one trigger:

| Table | Purpose |
|---|---|
| `room` | Per-ticket coordination space; PK is the external ticket id (e.g. `LIN-4821`, `owner/repo#N`). |
| `agent_presence` | Roster per room. `agent_id = "{repo}:{branch}"` for Claude sessions, literal `"human"` for the director. `is_human BOOLEAN` makes the human a first-class roster row. |
| `message` | Append-only message log keyed on UUID v7. Body is JSON for `type IN ('decision','status')`, plain prose otherwise. |
| `citation` | Coderoots URN attached to a message. `UNIQUE(message_id, urn)` for idempotent re-ingest. |
| `decision` | Pinned answer. `id == message.id` (FK CASCADE). Pluggable external mirror via `external_system` / `external_ref_id` / `external_ref_url` — no Linear-specific column. |

Trigger: `room_insert_human_presence AFTER INSERT ON room` synthesizes
the `@human` row using `INSERT OR IGNORE` (crash-safe). Lets every
consumer query `SELECT * FROM agent_presence WHERE room_id = ?` and get
a complete roster without `UNION`.

FK behaviors (locked in #65 review):
- `decision.id REFERENCES message(id) ON DELETE CASCADE`
- `decision.question_id`, `decision.answer_id` ON DELETE RESTRICT
- `decision.superseded_by` ON DELETE SET NULL

## Verification

- 134/134 tests pass (15 new in `TestRoomsSchemaV11`, 119 existing untouched).
- Ruff clean.
- Smoke-tested three paths against scratch DBs:
  - **Fresh install:** SCHEMA_VERSION=11 applied, all 5 tables present, trigger fires, `@human` roster row inserted.
  - **v10 → v11 upgrade:** seeded a v10 DB, ran `ensure_schema()`, all 5 tables created, end-to-end write (room → message → citation) works.
  - **Idempotency:** re-running `ensure_schema()` on v11 is a no-op; `schema_version` log = `[10, 11]`, no duplicates.

## Known coordination concern (NOT a blocker for this PR)

The local karma DB on the maintainer's machine is at **v22** because in-flight
sync v2/v3/v4 branches have layered migrations beyond `main`. This PR is
correct against `main` (`main` is at v10, this lands v11). When sync
branches eventually merge to `main`, the version sequence will need to
be reconciled — that's a release-train concern, not a Piece 1 concern.

The "apply v11 to the live `~/.claude_karma/metadata.db`" verification
deferred to that merge train. Smoke tests above used scratch DBs to
exercise both fresh-install and v10-baseline paths.

## Files

```
api/db/schema.py       | +245 lines
api/requirements.txt   |   +1 line  (uuid_utils>=0.10 — Piece 2 will use it)
api/tests/test_db.py   | +310 lines (15 new tests)
docs/features/2026-04-24-karma-integration-answers.md | new (referenced by #65)
```

## What this PR does NOT include

- `sync_rooms()` indexer module (Piece 2)
- `/rooms` SvelteKit dashboard (Piece 3)
- External-system reconciler (separate follow-up PR)
- Hook script (lives in agent-coord protocol repo)

Refs: #65
Parent tracker: JayantDevkar/git-radio#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)