### PR TITLE
feat(rooms): /rooms dashboard + 3 backend endpoints (Piece 3 of #65)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -32,6 +32,7 @@ from routers import (  # noqa: E402
     plans,
     plugins,
     projects,
+    rooms,
     sessions,
     skills,
     subagent_sessions,
@@ -193,6 +194,7 @@ app.include_router(
     tags=["subagent-sessions"],
 )
 app.include_router(admin.router)
+app.include_router(rooms.router, tags=["rooms"])
 
 
 @app.get("/")

--- a/api/routers/rooms.py
+++ b/api/routers/rooms.py
@@ -1,0 +1,473 @@
+"""
+Rooms router — agent-coord coordination rooms.
+
+Three endpoints, all read-only over the v11 schema (#67):
+
+- GET /rooms                       list view (id, title, status, counts, last_activity)
+- GET /rooms/{room_id}             detail view (room + presence + decisions + first 50 messages)
+- GET /rooms/{room_id}/messages    paginated timeline
+
+The dashboard frontend (Piece 3) reads exclusively from these endpoints.
+sync_rooms() (Piece 2, on a separate branch) writes the underlying tables.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Literal, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+
+api_path = Path(__file__).parent.parent
+sys.path.insert(0, str(api_path))
+
+from db.connection import sqlite_read  # noqa: E402
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+# --- Response schemas ------------------------------------------------------
+
+
+class RoomSummary(BaseModel):
+    id: str
+    title: Optional[str] = None
+    status: str
+    created_at: str
+    closed_at: Optional[str] = None
+    last_activity: str = Field(
+        description=(
+            "MAX(message.created_at) for this room, or room.created_at if no "
+            "messages yet. Used as the default sort key."
+        )
+    )
+    agent_count: int
+    message_count: int
+    decision_count: int
+
+
+class RoomListResponse(BaseModel):
+    rooms: list[RoomSummary]
+    total: int
+
+
+class AgentPresence(BaseModel):
+    agent_id: str
+    repo: Optional[str] = None
+    branch: Optional[str] = None
+    session_uuid: Optional[str] = None
+    is_human: bool
+    joined_at: str
+    joined_at_commit: Optional[str] = None
+    last_seen_at_commit: Optional[str] = None
+    left_at: Optional[str] = None
+
+
+class Citation(BaseModel):
+    urn: str
+    node_kind: Optional[str] = None
+    resolved_at_commit: Optional[str] = None
+    retrieved_via: Optional[str] = None
+
+
+class RoomMessage(BaseModel):
+    id: str
+    room_id: str
+    thread_id: Optional[str] = None
+    in_reply_to: Optional[str] = None
+    from_agent_id: str
+    to_agents: list[str]
+    mentions_attempted: Optional[list[str]] = None
+    type: str
+    body: str  # JSON-encoded for type IN ('decision','status'); prose otherwise
+    confidence: Optional[str] = None
+    schema_version: int
+    created_at: str
+    citations: list[Citation] = Field(default_factory=list)
+
+
+class Decision(BaseModel):
+    id: str
+    room_id: str
+    question_id: str
+    answer_id: str
+    body: Optional[str] = None
+    made_by: Optional[str] = None
+    confidence: Optional[str] = None
+    valid_from: str
+    valid_until: Optional[str] = None
+    superseded_by: Optional[str] = None
+    status: str
+    mirror_state: str
+    mirror_attempts: int
+    mirror_last_error: Optional[str] = None
+    external_system: str
+    external_ref_id: Optional[str] = None
+    external_ref_url: Optional[str] = None
+
+
+class RoomDetail(BaseModel):
+    room: RoomSummary
+    presence: list[AgentPresence]
+    decisions: list[Decision]
+    messages: list[RoomMessage]  # first N inline for fast initial render
+    messages_total: int
+    messages_inlined: int
+
+
+class RoomMessagesResponse(BaseModel):
+    messages: list[RoomMessage]
+    total: int
+    page: int
+    per_page: int
+    order: str
+
+
+# --- Helpers ---------------------------------------------------------------
+
+DEFAULT_INLINE_MESSAGES = 50
+DEFAULT_PAGE_SIZE = 100
+MAX_PAGE_SIZE = 500
+
+
+def _parse_to_agents(value: Optional[str]) -> list[str]:
+    if not value:
+        return []
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return []
+    return parsed if isinstance(parsed, list) else []
+
+
+def _parse_mentions(value: Optional[str]) -> Optional[list[str]]:
+    if value is None:
+        return None
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, list) else None
+
+
+def _row_to_message(row, citations: list[Citation]) -> RoomMessage:
+    return RoomMessage(
+        id=row["id"],
+        room_id=row["room_id"],
+        thread_id=row["thread_id"],
+        in_reply_to=row["in_reply_to"],
+        from_agent_id=row["from_agent_id"],
+        to_agents=_parse_to_agents(row["to_agents"]),
+        mentions_attempted=_parse_mentions(row["mentions_attempted"]),
+        type=row["type"],
+        body=row["body"],
+        confidence=row["confidence"],
+        schema_version=row["schema_version"],
+        created_at=row["created_at"],
+        citations=citations,
+    )
+
+
+def _fetch_citations_for(conn, message_ids: list[str]) -> dict[str, list[Citation]]:
+    if not message_ids:
+        return {}
+    placeholders = ",".join("?" * len(message_ids))
+    rows = conn.execute(
+        f"SELECT message_id, urn, node_kind, resolved_at_commit, retrieved_via "
+        f"FROM citation WHERE message_id IN ({placeholders})",
+        message_ids,
+    ).fetchall()
+    grouped: dict[str, list[Citation]] = {}
+    for r in rows:
+        grouped.setdefault(r["message_id"], []).append(
+            Citation(
+                urn=r["urn"],
+                node_kind=r["node_kind"],
+                resolved_at_commit=r["resolved_at_commit"],
+                retrieved_via=r["retrieved_via"],
+            )
+        )
+    return grouped
+
+
+def _row_to_decision(row) -> Decision:
+    return Decision(
+        id=row["id"],
+        room_id=row["room_id"],
+        question_id=row["question_id"],
+        answer_id=row["answer_id"],
+        body=row["body"],
+        made_by=row["made_by"],
+        confidence=row["confidence"],
+        valid_from=row["valid_from"],
+        valid_until=row["valid_until"],
+        superseded_by=row["superseded_by"],
+        status=row["status"],
+        mirror_state=row["mirror_state"],
+        mirror_attempts=row["mirror_attempts"],
+        mirror_last_error=row["mirror_last_error"],
+        external_system=row["external_system"],
+        external_ref_id=row["external_ref_id"],
+        external_ref_url=row["external_ref_url"],
+    )
+
+
+def _v11_tables_present(conn) -> bool:
+    """
+    True iff the v11 substrate (room/message/decision/...) is present.
+
+    The dashboard runs on installs that haven't yet applied v11 (e.g. the
+    sync-branch v22 collision documented in #67). When tables are missing
+    we return empty lists instead of 500-ing.
+    """
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='room' LIMIT 1"
+    ).fetchone()
+    return row is not None
+
+
+# --- Endpoints -------------------------------------------------------------
+
+
+@router.get("/rooms", response_model=RoomListResponse)
+def list_rooms(
+    status: Optional[Literal["active", "archived"]] = None,
+    search: Optional[str] = Query(default=None, description="Substring on id or title"),
+    sort: Literal["activity", "created"] = "activity",
+):
+    """
+    List all coordination rooms with summary counts.
+
+    Sort key:
+      - activity (default): MAX(message.created_at) per room, falling back to
+        room.created_at when there are no messages. Uses idx_message_room_time.
+      - created: room.created_at DESC.
+    """
+    with sqlite_read() as conn:
+        if conn is None or not _v11_tables_present(conn):
+            return RoomListResponse(rooms=[], total=0)
+
+        where = []
+        params: list = []
+        if status:
+            where.append("r.status = ?")
+            params.append(status)
+        if search:
+            where.append("(r.id LIKE ? OR COALESCE(r.title, '') LIKE ?)")
+            like = f"%{search}%"
+            params.extend([like, like])
+        where_sql = ("WHERE " + " AND ".join(where)) if where else ""
+
+        if sort == "created":
+            order_sql = "ORDER BY r.created_at DESC"
+        else:
+            order_sql = "ORDER BY last_activity DESC"
+
+        sql = f"""
+            SELECT
+                r.id,
+                r.title,
+                r.status,
+                r.created_at,
+                r.closed_at,
+                COALESCE((
+                    SELECT MAX(m.created_at) FROM message m WHERE m.room_id = r.id
+                ), r.created_at) AS last_activity,
+                (SELECT COUNT(*) FROM agent_presence p
+                    WHERE p.room_id = r.id AND p.left_at IS NULL) AS agent_count,
+                (SELECT COUNT(*) FROM message m WHERE m.room_id = r.id) AS message_count,
+                (SELECT COUNT(*) FROM decision d WHERE d.room_id = r.id) AS decision_count
+            FROM room r
+            {where_sql}
+            {order_sql}
+        """
+        rows = conn.execute(sql, params).fetchall()
+        rooms = [
+            RoomSummary(
+                id=r["id"],
+                title=r["title"],
+                status=r["status"],
+                created_at=r["created_at"],
+                closed_at=r["closed_at"],
+                last_activity=r["last_activity"],
+                agent_count=r["agent_count"],
+                message_count=r["message_count"],
+                decision_count=r["decision_count"],
+            )
+            for r in rows
+        ]
+        return RoomListResponse(rooms=rooms, total=len(rooms))
+
+
+
+# NOTE: list_room_messages is registered BEFORE get_room because Starlette's
+# matcher iterates in registration order. With `:path` on room_id, get_room
+# would otherwise capture "LIN-X/messages" as a room_id and the messages
+# endpoint would never fire.
+@router.get("/rooms/{room_id:path}/messages", response_model=RoomMessagesResponse)
+def list_room_messages(
+    room_id: str,
+    page: int = Query(default=1, ge=1),
+    per_page: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    order: Literal["asc", "desc"] = "asc",
+):
+    """
+    Paginated timeline. Default ordering is chronological (oldest first) to
+    match how the timeline reads top-to-bottom; `order=desc` gives a
+    "what just happened" view.
+    """
+    with sqlite_read() as conn:
+        if conn is None or not _v11_tables_present(conn):
+            raise HTTPException(status_code=404, detail="rooms feature not enabled")
+
+        exists = conn.execute(
+            "SELECT 1 FROM room WHERE id = ? LIMIT 1", (room_id,)
+        ).fetchone()
+        if exists is None:
+            raise HTTPException(status_code=404, detail=f"room not found: {room_id}")
+
+        total = conn.execute(
+            "SELECT COUNT(*) FROM message WHERE room_id = ?", (room_id,)
+        ).fetchone()[0]
+
+        order_sql = "DESC" if order == "desc" else "ASC"
+        offset = (page - 1) * per_page
+
+        rows = conn.execute(
+            f"""
+            SELECT id, room_id, thread_id, in_reply_to, from_agent_id,
+                   to_agents, mentions_attempted, type, body, confidence,
+                   schema_version, created_at
+            FROM message
+            WHERE room_id = ?
+            ORDER BY created_at {order_sql}, id {order_sql}
+            LIMIT ? OFFSET ?
+            """,
+            (room_id, per_page, offset),
+        ).fetchall()
+        citations_by_msg = _fetch_citations_for(conn, [m["id"] for m in rows])
+        messages = [_row_to_message(m, citations_by_msg.get(m["id"], [])) for m in rows]
+
+        return RoomMessagesResponse(
+            messages=messages,
+            total=total,
+            page=page,
+            per_page=per_page,
+            order=order,
+        )
+
+
+@router.get("/rooms/{room_id:path}", response_model=RoomDetail)
+def get_room(room_id: str):
+    """
+    Single room detail: room summary + presence roster + decisions + first
+    DEFAULT_INLINE_MESSAGES inline so the timeline can render immediately.
+    Fetch additional pages via /rooms/{id}/messages.
+
+    `:path` converter on room_id supports GitHub-style ids (e.g. owner/repo#N).
+    """
+    with sqlite_read() as conn:
+        if conn is None or not _v11_tables_present(conn):
+            raise HTTPException(status_code=404, detail="rooms feature not enabled")
+
+        room_row = conn.execute(
+            "SELECT id, title, status, created_at, closed_at FROM room WHERE id = ?",
+            (room_id,),
+        ).fetchone()
+        if room_row is None:
+            raise HTTPException(status_code=404, detail=f"room not found: {room_id}")
+
+        last_activity_row = conn.execute(
+            "SELECT MAX(created_at) AS la FROM message WHERE room_id = ?",
+            (room_id,),
+        ).fetchone()
+        last_activity = (last_activity_row["la"] if last_activity_row else None) or room_row[
+            "created_at"
+        ]
+
+        message_count = conn.execute(
+            "SELECT COUNT(*) FROM message WHERE room_id = ?", (room_id,)
+        ).fetchone()[0]
+        decision_count = conn.execute(
+            "SELECT COUNT(*) FROM decision WHERE room_id = ?", (room_id,)
+        ).fetchone()[0]
+
+        presence_rows = conn.execute(
+            """
+            SELECT agent_id, repo, branch, session_uuid, is_human, joined_at,
+                   joined_at_commit, last_seen_at_commit, left_at
+            FROM agent_presence
+            WHERE room_id = ?
+            ORDER BY is_human DESC, joined_at ASC
+            """,
+            (room_id,),
+        ).fetchall()
+        presence = [
+            AgentPresence(
+                agent_id=p["agent_id"],
+                repo=p["repo"],
+                branch=p["branch"],
+                session_uuid=p["session_uuid"],
+                is_human=bool(p["is_human"]),
+                joined_at=p["joined_at"],
+                joined_at_commit=p["joined_at_commit"],
+                last_seen_at_commit=p["last_seen_at_commit"],
+                left_at=p["left_at"],
+            )
+            for p in presence_rows
+        ]
+        agent_count = sum(1 for p in presence if p.left_at is None)
+
+        decision_rows = conn.execute(
+            """
+            SELECT * FROM decision WHERE room_id = ?
+            ORDER BY valid_from ASC
+            """,
+            (room_id,),
+        ).fetchall()
+        decisions = [_row_to_decision(d) for d in decision_rows]
+
+        message_rows = conn.execute(
+            """
+            SELECT id, room_id, thread_id, in_reply_to, from_agent_id,
+                   to_agents, mentions_attempted, type, body, confidence,
+                   schema_version, created_at
+            FROM message
+            WHERE room_id = ?
+            ORDER BY created_at ASC, id ASC
+            LIMIT ?
+            """,
+            (room_id, DEFAULT_INLINE_MESSAGES),
+        ).fetchall()
+        citations_by_msg = _fetch_citations_for(conn, [m["id"] for m in message_rows])
+        messages = [
+            _row_to_message(m, citations_by_msg.get(m["id"], [])) for m in message_rows
+        ]
+
+        room = RoomSummary(
+            id=room_row["id"],
+            title=room_row["title"],
+            status=room_row["status"],
+            created_at=room_row["created_at"],
+            closed_at=room_row["closed_at"],
+            last_activity=last_activity,
+            agent_count=agent_count,
+            message_count=message_count,
+            decision_count=decision_count,
+        )
+
+        return RoomDetail(
+            room=room,
+            presence=presence,
+            decisions=decisions,
+            messages=messages,
+            messages_total=message_count,
+            messages_inlined=len(messages),
+        )
+
+

--- a/api/tests/test_rooms_router.py
+++ b/api/tests/test_rooms_router.py
@@ -1,0 +1,346 @@
+"""
+Tests for routers/rooms.py — agent-coord rooms dashboard endpoints.
+
+Strategy: build a real-shaped v11 DB in tmp, monkeypatch sqlite_read to
+yield that DB, exercise the endpoints via FastAPI's TestClient.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from db.schema import ensure_schema  # noqa: E402
+from routers import rooms as rooms_router  # noqa: E402
+
+# --- Test infrastructure ---------------------------------------------------
+
+
+@pytest.fixture
+def db():
+    # check_same_thread=False because FastAPI's TestClient runs requests in
+    # a worker thread separate from the test setup. The fixture is
+    # single-writer in practice (no concurrent SQLite use across threads).
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    ensure_schema(conn)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def app(db):
+    """Mount the rooms router with a sqlite_read patched to yield the test DB."""
+
+    @contextmanager
+    def fake_sqlite_read():
+        yield db
+
+    rooms_router.sqlite_read = fake_sqlite_read
+
+    app = FastAPI()
+    app.include_router(rooms_router.router)
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+# --- Seed helpers ----------------------------------------------------------
+
+
+def _seed_room(db, room_id: str, *, title: str = "test room", status: str = "active"):
+    db.execute(
+        "INSERT INTO room (id, title, status) VALUES (?, ?, ?)",
+        (room_id, title, status),
+    )
+
+
+def _seed_message(
+    db,
+    *,
+    msg_id: str,
+    room_id: str,
+    type: str,
+    from_agent_id: str = "airflow:main",
+    to: list[str] | None = None,
+    in_reply_to: str | None = None,
+    body: str = "x",
+    confidence: str | None = None,
+    created_at: str = "2026-04-25T00:00:00Z",
+    citations: list[dict] | None = None,
+):
+    db.execute(
+        """
+        INSERT INTO message (id, room_id, in_reply_to, from_agent_id,
+            to_agents, type, body, confidence, schema_version, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?)
+        """,
+        (
+            msg_id,
+            room_id,
+            in_reply_to,
+            from_agent_id,
+            json.dumps(to or []),
+            type,
+            body,
+            confidence,
+            created_at,
+        ),
+    )
+    for c in citations or []:
+        db.execute(
+            "INSERT INTO citation (message_id, urn, node_kind) VALUES (?, ?, ?)",
+            (msg_id, c["urn"], c.get("node_kind")),
+        )
+    db.commit()
+
+
+def _seed_decision(db, *, decision_id: str, room_id: str, question_id: str, answer_id: str):
+    db.execute(
+        """
+        INSERT INTO decision (id, room_id, question_id, answer_id, body,
+                              made_by, confidence)
+        VALUES (?, ?, ?, ?, 'pinned', 'airflow:main', 'high')
+        """,
+        (decision_id, room_id, question_id, answer_id),
+    )
+    db.commit()
+
+
+# --- Empty / missing-tables ------------------------------------------------
+
+
+class TestEmptyAndMissing:
+    def test_list_returns_empty_when_no_rooms(self, client):
+        r = client.get("/rooms")
+        assert r.status_code == 200
+        assert r.json() == {"rooms": [], "total": 0}
+
+    def test_get_room_404_when_missing(self, client):
+        r = client.get("/rooms/LIN-NOPE")
+        assert r.status_code == 404
+
+
+# --- /rooms list -----------------------------------------------------------
+
+
+class TestListRooms:
+    def test_list_returns_summary_with_counts(self, db, client):
+        _seed_room(db, "LIN-1", title="auth")
+        _seed_room(db, "LIN-2", title="dag", status="archived")
+        _seed_message(
+            db,
+            msg_id="m1",
+            room_id="LIN-1",
+            type="question",
+            created_at="2026-04-25T01:00:00Z",
+        )
+        _seed_message(
+            db,
+            msg_id="m2",
+            room_id="LIN-1",
+            type="answer",
+            in_reply_to="m1",
+            created_at="2026-04-25T01:05:00Z",
+        )
+        # Decision message FIRST so the FK from decision.id → message.id resolves
+        _seed_message(
+            db,
+            msg_id="m3",
+            room_id="LIN-1",
+            type="decision",
+            in_reply_to="m1",
+            created_at="2026-04-25T01:10:00Z",
+            body=json.dumps({"pins": "m2"}),
+        )
+        _seed_decision(db, decision_id="m3", room_id="LIN-1", question_id="m1", answer_id="m2")
+
+        r = client.get("/rooms")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] == 2
+        # last_activity sort: LIN-1 has messages, LIN-2 doesn't → LIN-1 first
+        assert [room["id"] for room in data["rooms"]] == ["LIN-1", "LIN-2"]
+
+        lin1 = data["rooms"][0]
+        assert lin1["title"] == "auth"
+        assert lin1["status"] == "active"
+        assert lin1["message_count"] == 3
+        assert lin1["decision_count"] == 1
+        # @human roster row inserted by trigger
+        assert lin1["agent_count"] == 1
+        assert lin1["last_activity"] == "2026-04-25T01:10:00Z"
+
+    def test_status_filter(self, db, client):
+        _seed_room(db, "LIN-A", status="active")
+        _seed_room(db, "LIN-B", status="archived")
+
+        r = client.get("/rooms", params={"status": "archived"})
+        assert {room["id"] for room in r.json()["rooms"]} == {"LIN-B"}
+
+    def test_search_substring(self, db, client):
+        _seed_room(db, "LIN-100", title="snowflake migration")
+        _seed_room(db, "LIN-200", title="auth refactor")
+
+        # Match on title substring
+        r = client.get("/rooms", params={"search": "snow"})
+        assert {room["id"] for room in r.json()["rooms"]} == {"LIN-100"}
+
+        # Match on id
+        r = client.get("/rooms", params={"search": "200"})
+        assert {room["id"] for room in r.json()["rooms"]} == {"LIN-200"}
+
+    def test_sort_created(self, db, client):
+        # Same-second CURRENT_TIMESTAMP defaults make ordering undefined,
+        # so set created_at explicitly to control the sort.
+        db.execute(
+            "INSERT INTO room (id, created_at) VALUES (?, ?)",
+            ("LIN-A", "2026-01-01T00:00:00Z"),
+        )
+        db.execute(
+            "INSERT INTO room (id, created_at) VALUES (?, ?)",
+            ("LIN-B", "2026-02-01T00:00:00Z"),
+        )
+        db.commit()
+
+        r = client.get("/rooms", params={"sort": "created"})
+        ids = [room["id"] for room in r.json()["rooms"]]
+        assert ids == ["LIN-B", "LIN-A"]
+
+
+# --- /rooms/{id} detail ----------------------------------------------------
+
+
+class TestGetRoom:
+    def _seed_walkthrough_lite(self, db):
+        _seed_room(db, "LIN-4821", title="metrics")
+        _seed_message(
+            db,
+            msg_id="q1",
+            room_id="LIN-4821",
+            type="question",
+            from_agent_id="airflow:main",
+            to=["infra:main"],
+            confidence="low",
+            created_at="2026-04-25T00:00:00Z",
+        )
+        _seed_message(
+            db,
+            msg_id="a1",
+            room_id="LIN-4821",
+            type="answer",
+            from_agent_id="infra:main",
+            to=["airflow:main"],
+            in_reply_to="q1",
+            confidence="high",
+            created_at="2026-04-25T00:05:00Z",
+            citations=[{"urn": "urn:infra:role:writer", "node_kind": "InfraResource"}],
+        )
+        _seed_message(
+            db,
+            msg_id="d1",
+            room_id="LIN-4821",
+            type="decision",
+            from_agent_id="airflow:main",
+            in_reply_to="q1",
+            confidence="high",
+            created_at="2026-04-25T00:10:00Z",
+            body=json.dumps({"pins": "a1", "summary": "use writer role"}),
+        )
+        _seed_decision(
+            db,
+            decision_id="d1",
+            room_id="LIN-4821",
+            question_id="q1",
+            answer_id="a1",
+        )
+
+    def test_returns_room_presence_decisions_inline_messages(self, db, client):
+        self._seed_walkthrough_lite(db)
+        r = client.get("/rooms/LIN-4821")
+        assert r.status_code == 200
+        data = r.json()
+
+        # Room
+        assert data["room"]["id"] == "LIN-4821"
+        assert data["room"]["message_count"] == 3
+        assert data["room"]["decision_count"] == 1
+
+        # Presence: only @human (no agent_presence rows seeded)
+        assert any(p["agent_id"] == "human" and p["is_human"] is True for p in data["presence"])
+
+        # Decisions
+        assert len(data["decisions"]) == 1
+        assert data["decisions"][0]["mirror_state"] == "pending"
+        assert data["decisions"][0]["external_system"] == "linear"
+
+        # Messages: chronological, citations attached
+        msg_types = [m["type"] for m in data["messages"]]
+        assert msg_types == ["question", "answer", "decision"]
+        answer = data["messages"][1]
+        assert len(answer["citations"]) == 1
+        assert answer["citations"][0]["node_kind"] == "InfraResource"
+
+        # to_agents parsed back to a list
+        assert data["messages"][0]["to_agents"] == ["infra:main"]
+
+    def test_path_room_id_supports_github_style(self, db, client):
+        _seed_room(db, "owner/repo#42", title="github example")
+        r = client.get("/rooms/owner/repo%2342")  # %23 == #
+        assert r.status_code == 200
+        assert r.json()["room"]["id"] == "owner/repo#42"
+
+
+# --- /rooms/{id}/messages pagination --------------------------------------
+
+
+class TestRoomMessages:
+    def _seed_n_messages(self, db, n: int):
+        _seed_room(db, "LIN-PAG")
+        for i in range(n):
+            _seed_message(
+                db,
+                msg_id=f"m{i:03d}",
+                room_id="LIN-PAG",
+                type="question",
+                created_at=f"2026-04-25T00:{i:02d}:00Z",
+            )
+
+    def test_default_page_chronological(self, db, client):
+        self._seed_n_messages(db, 5)
+        r = client.get("/rooms/LIN-PAG/messages")
+        ids = [m["id"] for m in r.json()["messages"]]
+        assert ids == ["m000", "m001", "m002", "m003", "m004"]
+
+    def test_order_desc(self, db, client):
+        self._seed_n_messages(db, 5)
+        r = client.get("/rooms/LIN-PAG/messages", params={"order": "desc"})
+        ids = [m["id"] for m in r.json()["messages"]]
+        assert ids == ["m004", "m003", "m002", "m001", "m000"]
+
+    def test_pagination(self, db, client):
+        self._seed_n_messages(db, 7)
+        r = client.get("/rooms/LIN-PAG/messages", params={"per_page": 3, "page": 2})
+        data = r.json()
+        ids = [m["id"] for m in data["messages"]]
+        assert ids == ["m003", "m004", "m005"]
+        assert data["total"] == 7
+        assert data["page"] == 2
+        assert data["per_page"] == 3
+
+    def test_404_when_room_missing(self, client):
+        r = client.get("/rooms/LIN-MISSING/messages")
+        assert r.status_code == 404

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -1719,3 +1719,108 @@ export interface HookScriptDetail {
 	line_count: number | null;
 	error: string | null;
 }
+
+// ============================================
+// Agent-coord Rooms (v11 schema; #65 / PR #67–#69)
+// ============================================
+
+export type RoomStatus = 'active' | 'archived';
+export type RoomMessageType =
+	| 'question'
+	| 'answer'
+	| 'decision'
+	| 'status'
+	| 'handoff'
+	| 'skip';
+export type Confidence = 'high' | 'medium' | 'low' | 'unsure';
+export type DecisionStatus = 'active' | 'needs_reverify' | 'invalidated';
+export type MirrorState = 'pending' | 'synced' | 'failed';
+
+export interface RoomSummary {
+	id: string;
+	title: string | null;
+	status: RoomStatus;
+	created_at: string;
+	closed_at: string | null;
+	last_activity: string;
+	agent_count: number;
+	message_count: number;
+	decision_count: number;
+}
+
+export interface RoomListResponse {
+	rooms: RoomSummary[];
+	total: number;
+}
+
+export interface AgentPresence {
+	agent_id: string;
+	repo: string | null;
+	branch: string | null;
+	session_uuid: string | null;
+	is_human: boolean;
+	joined_at: string;
+	joined_at_commit: string | null;
+	last_seen_at_commit: string | null;
+	left_at: string | null;
+}
+
+export interface RoomCitation {
+	urn: string;
+	node_kind: string | null;
+	resolved_at_commit: string | null;
+	retrieved_via: string | null;
+}
+
+export interface RoomMessage {
+	id: string;
+	room_id: string;
+	thread_id: string | null;
+	in_reply_to: string | null;
+	from_agent_id: string;
+	to_agents: string[];
+	mentions_attempted: string[] | null;
+	type: RoomMessageType;
+	body: string;
+	confidence: Confidence | null;
+	schema_version: number;
+	created_at: string;
+	citations: RoomCitation[];
+}
+
+export interface Decision {
+	id: string;
+	room_id: string;
+	question_id: string;
+	answer_id: string;
+	body: string | null;
+	made_by: string | null;
+	confidence: Confidence | null;
+	valid_from: string;
+	valid_until: string | null;
+	superseded_by: string | null;
+	status: DecisionStatus;
+	mirror_state: MirrorState;
+	mirror_attempts: number;
+	mirror_last_error: string | null;
+	external_system: string;
+	external_ref_id: string | null;
+	external_ref_url: string | null;
+}
+
+export interface RoomDetail {
+	room: RoomSummary;
+	presence: AgentPresence[];
+	decisions: Decision[];
+	messages: RoomMessage[];
+	messages_total: number;
+	messages_inlined: number;
+}
+
+export interface RoomMessagesResponse {
+	messages: RoomMessage[];
+	total: number;
+	page: number;
+	per_page: number;
+	order: 'asc' | 'desc';
+}

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -95,6 +95,14 @@
 					Sessions
 				</a>
 				<a
+					href="/rooms"
+					class="text-sm font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/rooms')}
+					aria-current={$page.url.pathname.startsWith('/rooms') ? 'page' : undefined}
+				>
+					Rooms
+				</a>
+				<a
 					href="/plans"
 					class="text-sm font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
 					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/plans')}
@@ -220,6 +228,16 @@
 					aria-current={$page.url.pathname.startsWith('/sessions') ? 'page' : undefined}
 				>
 					Sessions
+				</a>
+				<a
+					href="/rooms"
+					onclick={closeMobileMenu}
+					class="text-base font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-subtle)] py-3 px-4 rounded-lg transition-colors"
+					class:text-[var(--text-primary)]={$page.url.pathname.startsWith('/rooms')}
+					class:bg-[var(--bg-subtle)]={$page.url.pathname.startsWith('/rooms')}
+					aria-current={$page.url.pathname.startsWith('/rooms') ? 'page' : undefined}
+				>
+					Rooms
 				</a>
 				<a
 					href="/plans"

--- a/frontend/src/routes/rooms/+page.server.ts
+++ b/frontend/src/routes/rooms/+page.server.ts
@@ -1,0 +1,35 @@
+import type { RoomListResponse, RoomStatus } from '$lib/api-types';
+import { API_BASE } from '$lib/config';
+import { safeFetch } from '$lib/utils/api-fetch';
+
+export async function load({ fetch, url }) {
+	const status = (url.searchParams.get('status') as RoomStatus | null) ?? null;
+	const search = url.searchParams.get('search') ?? '';
+	const sort = (url.searchParams.get('sort') as 'activity' | 'created' | null) ?? 'activity';
+
+	const params = new URLSearchParams();
+	if (status) params.set('status', status);
+	if (search) params.set('search', search);
+	params.set('sort', sort);
+
+	const result = await safeFetch<RoomListResponse>(
+		fetch,
+		`${API_BASE}/rooms?${params.toString()}`
+	);
+
+	if (!result.ok) {
+		return {
+			rooms: [],
+			total: 0,
+			error: result.message,
+			filters: { status, search, sort }
+		};
+	}
+
+	return {
+		rooms: result.data.rooms,
+		total: result.data.total,
+		error: null,
+		filters: { status, search, sort }
+	};
+}

--- a/frontend/src/routes/rooms/+page.svelte
+++ b/frontend/src/routes/rooms/+page.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+	import { browser } from '$app/environment';
+	import { goto } from '$app/navigation';
+	import { MessagesSquare, Search, Users, FileText, Pin } from 'lucide-svelte';
+	import PageHeader from '$lib/components/layout/PageHeader.svelte';
+	import EmptyState from '$lib/components/ui/EmptyState.svelte';
+	import Badge from '$lib/components/ui/Badge.svelte';
+	import Card from '$lib/components/ui/Card.svelte';
+	import SegmentedControl from '$lib/components/ui/SegmentedControl.svelte';
+	import { formatDistanceToNow } from 'date-fns';
+
+	let { data } = $props();
+
+	// svelte-ignore state_referenced_locally
+	let search = $state(data.filters.search ?? '');
+	// svelte-ignore state_referenced_locally
+	let status = $state<'all' | 'active' | 'archived'>(
+		(data.filters.status as 'active' | 'archived' | null) ?? 'all'
+	);
+	// svelte-ignore state_referenced_locally
+	let sort = $state<'activity' | 'created'>(
+		(data.filters.sort as 'activity' | 'created') ?? 'activity'
+	);
+
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function syncUrl() {
+		if (!browser) return;
+		const params = new URLSearchParams();
+		if (search) params.set('search', search);
+		if (status !== 'all') params.set('status', status);
+		if (sort !== 'activity') params.set('sort', sort);
+		const qs = params.toString();
+		goto(qs ? `?${qs}` : '/rooms', { replaceState: true, noScroll: true, keepFocus: true });
+	}
+
+	function onSearchInput(e: Event) {
+		search = (e.target as HTMLInputElement).value;
+		if (debounceTimer) clearTimeout(debounceTimer);
+		debounceTimer = setTimeout(syncUrl, 200);
+	}
+
+	$effect(() => {
+		// Re-sync on segmented-control changes
+		void status;
+		void sort;
+		syncUrl();
+	});
+
+	function fmtActivity(iso: string): string {
+		try {
+			return formatDistanceToNow(new Date(iso), { addSuffix: true });
+		} catch {
+			return iso;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Rooms · Claude Code Karma</title>
+</svelte:head>
+
+<div class="max-w-[1200px] mx-auto px-4 md:px-6 py-6 space-y-6">
+	<PageHeader
+		title="Rooms"
+		icon={MessagesSquare}
+		subtitle="Cross-agent coordination on Linear / GitHub tickets"
+	/>
+
+	<!-- Filters -->
+	<div class="flex flex-col sm:flex-row gap-3 items-stretch sm:items-center">
+		<div
+			class="relative flex-1 min-w-0"
+		>
+			<Search
+				size={16}
+				class="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)] pointer-events-none"
+			/>
+			<input
+				type="search"
+				placeholder="Search by ticket id or title…"
+				value={search}
+				oninput={onSearchInput}
+				class="w-full pl-10 pr-3 py-2 bg-[var(--bg-subtle)] border border-[var(--border)] rounded-md text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)] transition-shadow"
+			/>
+		</div>
+
+		<SegmentedControl
+			options={[
+				{ value: 'all', label: 'All' },
+				{ value: 'active', label: 'Active' },
+				{ value: 'archived', label: 'Archived' }
+			]}
+			bind:value={status}
+		/>
+
+		<SegmentedControl
+			options={[
+				{ value: 'activity', label: 'Activity' },
+				{ value: 'created', label: 'Created' }
+			]}
+			bind:value={sort}
+		/>
+	</div>
+
+	{#if data.error}
+		<EmptyState
+			icon={MessagesSquare}
+			title="Couldn't load rooms"
+			description={data.error}
+		/>
+	{:else if data.rooms.length === 0}
+		<EmptyState
+			icon={MessagesSquare}
+			title="No rooms yet"
+			description="Configure both Claude Code hooks (SessionStart and UserPromptSubmit) per claude-communicate's wiring guide, then start a Claude session on a branch matching LIN-####. Rooms appear here as agents join."
+		>
+			<a
+				href="https://github.com/JayantDevkar/claude-communicate#wiring-up-the-hooks"
+				target="_blank"
+				rel="noreferrer"
+				class="text-sm font-medium text-[var(--accent)] hover:underline"
+			>
+				claude-communicate wiring guide →
+			</a>
+		</EmptyState>
+	{:else}
+		<div class="grid gap-3">
+			{#each data.rooms as room (room.id)}
+				<a
+					href={`/rooms/${encodeURIComponent(room.id)}`}
+					class="block group"
+				>
+					<Card class="hover:border-[var(--accent)] transition-colors p-4">
+						<div class="flex items-start justify-between gap-3">
+							<div class="min-w-0 flex-1">
+								<div class="flex items-center gap-2 flex-wrap">
+									<span class="font-mono text-sm font-semibold text-[var(--text-primary)]">
+										{room.id}
+									</span>
+									{#if room.status === 'archived'}
+										<Badge variant="slate">archived</Badge>
+									{:else}
+										<Badge variant="success">active</Badge>
+									{/if}
+								</div>
+								{#if room.title}
+									<div class="text-sm text-[var(--text-secondary)] mt-1 truncate">
+										{room.title}
+									</div>
+								{/if}
+								<div class="flex items-center gap-4 mt-2 text-xs text-[var(--text-muted)]">
+									<span class="inline-flex items-center gap-1">
+										<Users size={12} />
+										{room.agent_count} {room.agent_count === 1 ? 'agent' : 'agents'}
+									</span>
+									<span class="inline-flex items-center gap-1">
+										<FileText size={12} />
+										{room.message_count} {room.message_count === 1 ? 'message' : 'messages'}
+									</span>
+									<span class="inline-flex items-center gap-1">
+										<Pin size={12} />
+										{room.decision_count} {room.decision_count === 1 ? 'decision' : 'decisions'}
+									</span>
+								</div>
+							</div>
+							<div class="text-xs text-[var(--text-muted)] whitespace-nowrap shrink-0">
+								{fmtActivity(room.last_activity)}
+							</div>
+						</div>
+					</Card>
+				</a>
+			{/each}
+		</div>
+
+		<div class="text-xs text-[var(--text-muted)] text-center">
+			{data.total} {data.total === 1 ? 'room' : 'rooms'}
+		</div>
+	{/if}
+</div>

--- a/frontend/src/routes/rooms/[id]/+page.server.ts
+++ b/frontend/src/routes/rooms/[id]/+page.server.ts
@@ -1,0 +1,22 @@
+import type { RoomDetail } from '$lib/api-types';
+import { API_BASE } from '$lib/config';
+import { safeFetch } from '$lib/utils/api-fetch';
+import { error } from '@sveltejs/kit';
+
+export async function load({ fetch, params }) {
+	const result = await safeFetch<RoomDetail>(
+		fetch,
+		`${API_BASE}/rooms/${encodeURIComponent(params.id)}`
+	);
+
+	if (!result.ok) {
+		if (result.status === 404) {
+			throw error(404, `Room not found: ${params.id}`);
+		}
+		throw error(result.status || 500, result.message);
+	}
+
+	return {
+		detail: result.data
+	};
+}

--- a/frontend/src/routes/rooms/[id]/+page.svelte
+++ b/frontend/src/routes/rooms/[id]/+page.svelte
@@ -1,0 +1,355 @@
+<script lang="ts">
+	import { ArrowLeft, MessagesSquare, Reply, Pin, AlertCircle, Bot, User, Copy, Check } from 'lucide-svelte';
+	import PageHeader from '$lib/components/layout/PageHeader.svelte';
+	import Badge from '$lib/components/ui/Badge.svelte';
+	import Card from '$lib/components/ui/Card.svelte';
+	import type { RoomMessage, RoomMessagesResponse } from '$lib/api-types';
+	import { API_BASE } from '$lib/config';
+	import { onMount } from 'svelte';
+
+	let { data } = $props();
+
+	let detail = $derived(data.detail);
+	let room = $derived(detail.room);
+	let presence = $derived(detail.presence);
+	let decisions = $derived(detail.decisions);
+
+	// Start with inlined messages, page in more if room has more.
+	// svelte-ignore state_referenced_locally
+	let messages = $state<RoomMessage[]>(detail.messages);
+	// svelte-ignore state_referenced_locally
+	let total = $state<number>(detail.messages_total);
+	let inlined = $derived<number>(detail.messages_inlined);
+	let isLoadingMore = $state(false);
+
+	// Highlight target for "scroll-to-pinned-answer" on hover/focus.
+	let highlightId = $state<string | null>(null);
+
+	let copiedUrn = $state<string | null>(null);
+
+	async function loadAll() {
+		if (messages.length >= total || isLoadingMore) return;
+		isLoadingMore = true;
+		try {
+			// Fetch the rest in one shot (per_page caps at 500 server-side)
+			const params = new URLSearchParams({
+				page: '1',
+				per_page: String(Math.min(total, 500)),
+				order: 'asc'
+			});
+			const res = await fetch(
+				`${API_BASE}/rooms/${encodeURIComponent(room.id)}/messages?${params}`
+			);
+			if (res.ok) {
+				const data: RoomMessagesResponse = await res.json();
+				messages = data.messages;
+			}
+		} finally {
+			isLoadingMore = false;
+		}
+	}
+
+	onMount(() => {
+		if (total > inlined) loadAll();
+	});
+
+	// Decision lookup by answer_id → which decision pins this answer?
+	let decisionByAnswer = $derived(
+		new Map(decisions.map((d) => [d.answer_id, d]))
+	);
+
+	// Quick lookup of message by id for jump-to behavior.
+	let messageById = $derived(new Map(messages.map((m) => [m.id, m])));
+
+	function shortId(id: string): string {
+		return id.length > 12 ? id.slice(0, 8) + '…' : id;
+	}
+
+	function jumpTo(id: string) {
+		const el = document.getElementById(`msg-${id}`);
+		if (!el) return;
+		el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+		highlightId = id;
+		setTimeout(() => {
+			if (highlightId === id) highlightId = null;
+		}, 1600);
+	}
+
+	async function copyUrn(urn: string) {
+		try {
+			await navigator.clipboard.writeText(urn);
+			copiedUrn = urn;
+			setTimeout(() => {
+				if (copiedUrn === urn) copiedUrn = null;
+			}, 1200);
+		} catch {
+			// no-op (clipboard may be blocked in some contexts)
+		}
+	}
+
+	function isIndexerMessage(m: RoomMessage): boolean {
+		return m.from_agent_id === '_indexer';
+	}
+
+	function bodyAsText(m: RoomMessage): string {
+		// type=decision/status are JSON; show summary if present, else raw.
+		if (m.type === 'decision' || m.type === 'status') {
+			try {
+				const parsed = JSON.parse(m.body);
+				if (parsed.summary) return parsed.summary;
+				if (parsed.reason) return parsed.reason;
+				return m.body;
+			} catch {
+				return m.body;
+			}
+		}
+		return m.body;
+	}
+
+	function decisionPinsThis(m: RoomMessage) {
+		// For decision messages, what answer does it pin?
+		if (m.type !== 'decision') return null;
+		try {
+			const parsed = JSON.parse(m.body);
+			return parsed.pins ?? null;
+		} catch {
+			return null;
+		}
+	}
+
+	function statusKind(m: RoomMessage): string | null {
+		if (m.type !== 'status') return null;
+		try {
+			return JSON.parse(m.body).kind ?? null;
+		} catch {
+			return null;
+		}
+	}
+
+	function confidenceBadge(c: string | null) {
+		if (!c) return null;
+		const variant =
+			c === 'high' ? 'success' : c === 'medium' ? 'info' : c === 'low' ? 'warning' : 'slate';
+		return { label: c, variant: variant as 'success' | 'info' | 'warning' | 'slate' };
+	}
+</script>
+
+<svelte:head>
+	<title>{room.id} · Rooms · Claude Code Karma</title>
+</svelte:head>
+
+<div class="max-w-[1200px] mx-auto px-4 md:px-6 py-6 space-y-6">
+	<a
+		href="/rooms"
+		class="inline-flex items-center gap-1 text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+	>
+		<ArrowLeft size={12} />
+		All rooms
+	</a>
+
+	<PageHeader
+		title={room.title || room.id}
+		icon={MessagesSquare}
+		breadcrumbs={[
+			{ label: 'Rooms', href: '/rooms' },
+			{ label: room.id }
+		]}
+		metadata={[
+			{ text: `${room.message_count} ${room.message_count === 1 ? 'message' : 'messages'}` },
+			{ text: `${room.decision_count} ${room.decision_count === 1 ? 'decision' : 'decisions'}` },
+			{ text: `${presence.filter((p) => p.left_at === null).length} present` }
+		]}
+	/>
+
+	<!-- Roster -->
+	<Card class="p-4">
+		<div class="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider mb-2">
+			Participants
+		</div>
+		<div class="flex flex-wrap gap-2">
+			{#each presence as p}
+				<div
+					class="inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs border border-[var(--border)] bg-[var(--bg-subtle)]"
+					class:opacity-60={p.left_at !== null}
+				>
+					{#if p.is_human}
+						<User size={12} class="text-[var(--accent)]" />
+					{:else}
+						<Bot size={12} class="text-[var(--text-secondary)]" />
+					{/if}
+					<span class="font-mono">{p.agent_id}</span>
+					{#if p.left_at !== null}
+						<span class="text-[var(--text-muted)]">(left)</span>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	</Card>
+
+	<!-- Timeline -->
+	<div class="space-y-3">
+		{#if isLoadingMore && messages.length === inlined}
+			<div class="text-center text-xs text-[var(--text-muted)]">Loading messages…</div>
+		{/if}
+
+		{#each messages as m (m.id)}
+			{@const indexer = isIndexerMessage(m)}
+			{@const pinnedAnswerId = decisionPinsThis(m)}
+			{@const sk = statusKind(m)}
+			{@const conf = confidenceBadge(m.confidence)}
+			{@const pinned = decisionByAnswer.get(m.id)}
+			<div
+				id={`msg-${m.id}`}
+				class="rounded-lg border transition-colors"
+				class:border-[var(--border)]={highlightId !== m.id}
+				class:border-[var(--accent)]={highlightId === m.id}
+				class:bg-[var(--bg-subtle)]={!indexer}
+				class:bg-transparent={indexer}
+				class:opacity-80={indexer}
+			>
+				<div class="p-4">
+					<!-- Header row: from / type / confidence / time -->
+					<div class="flex items-center gap-2 flex-wrap text-xs">
+						{#if indexer}
+							<span
+								class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-mono uppercase bg-[var(--bg-muted)] text-[var(--text-muted)]"
+							>
+								indexer
+							</span>
+						{:else}
+							<span
+								class="font-mono font-semibold text-[var(--text-primary)]"
+								class:italic={indexer}
+							>
+								{m.from_agent_id}
+							</span>
+						{/if}
+
+						<Badge
+							variant={m.type === 'decision'
+								? 'info'
+								: m.type === 'answer'
+									? 'success'
+									: m.type === 'question'
+										? 'warning'
+										: 'slate'}
+						>
+							{m.type}
+						</Badge>
+
+						{#if conf}
+							<Badge variant={conf.variant}>conf: {conf.label}</Badge>
+						{/if}
+
+						{#if sk}
+							<Badge variant="slate">{sk}</Badge>
+						{/if}
+
+						<span class="text-[var(--text-muted)] ml-auto font-mono">
+							{new Date(m.created_at).toISOString().slice(11, 19)}Z
+						</span>
+					</div>
+
+					<!-- Body -->
+					<div
+						class="mt-2 text-sm whitespace-pre-wrap break-words"
+						class:text-[var(--text-secondary)]={indexer}
+						class:italic={indexer}
+						class:text-[var(--text-primary)]={!indexer}
+					>
+						{bodyAsText(m)}
+					</div>
+
+					<!-- Cross-link badges row -->
+					<div class="mt-3 flex flex-wrap gap-2 text-xs">
+						{#if m.in_reply_to}
+							<button
+								type="button"
+								onclick={() => jumpTo(m.in_reply_to!)}
+								class="inline-flex items-center gap-1 px-2 py-1 rounded-md border border-[var(--border)] hover:border-[var(--accent)] hover:bg-[var(--bg-muted)] transition-colors text-[var(--text-secondary)] font-mono"
+								title="Jump to the message this replies to"
+							>
+								<Reply size={11} />
+								in reply to {shortId(m.in_reply_to)}
+							</button>
+						{/if}
+
+						{#if pinnedAnswerId}
+							<button
+								type="button"
+								onclick={() => jumpTo(pinnedAnswerId)}
+								onmouseenter={() => (highlightId = pinnedAnswerId)}
+								onmouseleave={() => {
+									if (highlightId === pinnedAnswerId) highlightId = null;
+								}}
+								onfocus={() => (highlightId = pinnedAnswerId)}
+								onblur={() => {
+									if (highlightId === pinnedAnswerId) highlightId = null;
+								}}
+								class="inline-flex items-center gap-1 px-2 py-1 rounded-md border border-[var(--accent)]/30 bg-[var(--accent)]/5 hover:bg-[var(--accent)]/10 transition-colors text-[var(--accent)] font-mono"
+								title="This decision pins an answer above — hover to highlight, click to scroll"
+							>
+								<Pin size={11} />
+								pins {shortId(pinnedAnswerId)}
+							</button>
+						{/if}
+
+						{#if pinned}
+							<span
+								class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--accent)]/10 text-[var(--accent)] font-mono"
+							>
+								<Pin size={11} />
+								pinned by decision {shortId(pinned.id)}
+							</span>
+						{/if}
+
+						{#if m.to_agents.length > 0}
+							<span
+								class="inline-flex items-center gap-1 px-2 py-1 rounded-md text-[var(--text-muted)] font-mono"
+							>
+								→ {m.to_agents.join(', ')}
+							</span>
+						{/if}
+					</div>
+
+					<!-- Citations -->
+					{#if m.citations.length > 0}
+						<div class="mt-3 flex flex-wrap gap-1.5">
+							{#each m.citations as c}
+								<button
+									type="button"
+									onclick={() => copyUrn(c.urn)}
+									class="inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-mono border border-[var(--border)] bg-[var(--bg-base)] hover:bg-[var(--bg-muted)] transition-colors"
+									title={`Click to copy URN${c.node_kind ? ` (${c.node_kind})` : ''}`}
+								>
+									{#if copiedUrn === c.urn}
+										<Check size={10} class="text-[var(--accent)]" />
+									{:else}
+										<Copy size={10} class="text-[var(--text-muted)]" />
+									{/if}
+									<span class="truncate max-w-[280px]">{c.urn}</span>
+									{#if c.node_kind}
+										<Badge variant="slate">{c.node_kind}</Badge>
+									{/if}
+								</button>
+							{/each}
+						</div>
+					{/if}
+
+					{#if sk === 'rejection'}
+						<div class="mt-2 inline-flex items-center gap-1 text-xs text-[var(--text-muted)]">
+							<AlertCircle size={12} />
+							The author can re-answer with a stable-URN citation to clear this.
+						</div>
+					{/if}
+				</div>
+			</div>
+		{/each}
+
+		{#if messages.length < total}
+			<div class="text-center text-xs text-[var(--text-muted)]">
+				Showing {messages.length} of {total} messages
+			</div>
+		{/if}
+	</div>
+</div>


### PR DESCRIPTION
## Piece 3 of 3 for #65 — stacked on PR #67

**Stacked PR:** base is \`feat/agent-coord-v11-migration\` (PR #67), so the diff here shows only Piece 3's commits. After #67 merges, I'll rebase onto \`main\` and retarget the base. Piece 3 has no functional dependency on Piece 2 (#68) — the dashboard reads from the v11 schema directly.

Read-only dashboard for the agent-coord room substrate. Three thin
endpoints over the v11 schema (#67) plus a SvelteKit list view and
single-room timeline.

## Decisions implemented (per locked answers on #65)

| Q | Choice |
|---|---|
| Q1 endpoints | All three. \`?order=desc\` accepted on /messages. Default per_page=100, oldest-first. Inline first 50 messages in detail. |
| Q2 list filters | Status chip + substring search (id/title) + sort dropdown (activity/created). \`last_activity = COALESCE(MAX(message.created_at), room.created_at)\`. |
| Q3 timeline | Flat chronological + reply badges + pins badges. **Hover-to-highlight:** hovering a \`pins\` badge highlights the pinned answer above. URN chips clipboard-copy. |
| Q4 _indexer messages | Always show. Muted color, italic, "indexer" badge. |
| Q5 empty state | Real onboarding card. Mentions BOTH SessionStart + UserPromptSubmit hooks. Links to claude-communicate wiring guide. |

## Architecture notes

- **Route ordering matters.** \`/rooms/{room_id:path}/messages\` is registered BEFORE \`/rooms/{room_id:path}\` because Starlette's matcher iterates in registration order — the \`:path\` converter is greedy and would otherwise capture \`LIN-X/messages\` as a room_id. Inline comment in \`routers/rooms.py\` documents this.
- **Graceful v22-collision handling.** \`_v11_tables_present()\` check returns empty list / 404 instead of crashing on installs without v11 tables. Live \`~/.claude_karma/metadata.db\` (at v22 from in-flight sync work) won't break the dashboard.
- **Test threading.** \`sqlite3.connect(":memory:", check_same_thread=False)\` because FastAPI's TestClient runs requests in a worker thread.

## Verification

- **12/12 router tests pass; full API suite: 1501 passed / 6 skipped.** \`ruff\` clean.
- **Frontend type-check 0 errors. Lint 0 errors** (warnings all pre-existing in unrelated files).
- **End-to-end smoke** against scratch DB seeded with §8 walkthrough:
  - \`GET /rooms\` → 2 rooms with correct counts (4 agents incl @human, 5 messages, 2 decisions); \`last_activity\` from \`MAX(message.created_at)\`
  - \`GET /rooms/LIN-4821\` → full payload; presence shows @human first; decisions in \`mirror_state='pending'\`; citations attached
  - \`GET /rooms/LIN-4821/messages?per_page=2&order=desc\` → reverse-chrono pagination works
  - \`GET /rooms/LIN-MISSING\` → 404
  - \`GET /rooms?status=archived\` → filter works

## Files

\`\`\`
api/main.py                                 |  +2  (register rooms router)
api/routers/rooms.py                        | new (~470 LOC, 3 endpoints)
api/tests/test_rooms_router.py              | new (~340 LOC, 12 tests)
frontend/src/lib/api-types.ts               | +105 (Room/Decision/Message types)
frontend/src/lib/components/Header.svelte   | +18  (Rooms nav, desktop + mobile)
frontend/src/routes/rooms/+page.server.ts   | new (~35)
frontend/src/routes/rooms/+page.svelte      | new (~180, list + filters + empty state)
frontend/src/routes/rooms/[id]/+page.server.ts | new (~25)
frontend/src/routes/rooms/[id]/+page.svelte | new (~290, timeline)
\`\`\`

Total ~1,540 LOC. Slightly over the 1,065 estimate — the timeline came out fuller because of badges, cross-link buttons, and citation chips. House-style components (\`PageHeader\`, \`Card\`, \`Badge\`, \`SegmentedControl\`, \`EmptyState\`) reused throughout.

## Out of scope (deliberate)

- External-system mirror reconciler (Linear/GitHub POST) → separate follow-up PR.
- \`agent_presence.last_read_message_id\` column for claude-communicate cursor migration → small follow-up issue per maintainer's FYI on #65.
- The \`sync_rooms()\` indexer (#68) — landing on a separate stacked PR.

Refs: #65
Parent tracker: JayantDevkar/git-radio#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)