### PR TITLE
fix(token-cost): fix 6 token/cost calculation bugs

### DIFF
--- a/api/db/indexer.py
+++ b/api/db/indexer.py
@@ -492,7 +492,7 @@ def _index_session(
                         subagent_type,
                         usage.total_input,
                         usage.output_tokens,
-                        usage.calculate_cost(),
+                        usage.calculate_cost(subagent.get_primary_model()),
                         duration,
                         subagent.start_time.isoformat() if subagent.start_time else None,
                     ),

--- a/api/models/agent.py
+++ b/api/models/agent.py
@@ -53,6 +53,7 @@ class AgentCache(BaseCache):
         "tasks",
         "skills_used",
         "commands_used",
+        "models_used",
     )
 
     def __init__(self) -> None:
@@ -64,6 +65,7 @@ class AgentCache(BaseCache):
         self.tasks: Optional[List["Task"]] = None
         self.skills_used: Optional[Dict[tuple, int]] = None  # {(name, source): count}
         self.commands_used: Optional[Dict[tuple, int]] = None  # {(name, source): count}
+        self.models_used: Optional[set] = None
 
     def reset(self) -> None:
         """Reset all cache values to initial state."""
@@ -74,6 +76,7 @@ class AgentCache(BaseCache):
         self.tasks = None
         self.skills_used = None
         self.commands_used = None
+        self.models_used = None
         super().reset()
 
 
@@ -216,6 +219,7 @@ class Agent(BaseModel):
         last_ts: Optional[datetime] = None
         usage = TokenUsage.zero()
         message_count = 0
+        models: set = set()
         # Skills/commands use (name, source) tuple keys for invocation tracking
         skills: Counter = Counter()  # {(name, source): count}
         commands: Counter = Counter()  # {(name, source): count}
@@ -232,6 +236,8 @@ class Agent(BaseModel):
             if isinstance(msg, AssistantMessage):
                 if msg.usage:
                     usage = usage + msg.usage
+                if msg.model:
+                    models.add(msg.model)
 
                 # Extract skills/commands from Skill tool uses
                 for block in msg.content_blocks:
@@ -249,6 +255,7 @@ class Agent(BaseModel):
         cache.end_time = last_ts
         cache.usage_summary = usage
         cache.message_count = message_count
+        cache.models_used = models
         cache.skills_used = dict(skills)
         cache.commands_used = dict(commands)
         cache.mark_loaded(self._get_file_mtime())
@@ -332,6 +339,15 @@ class Agent(BaseModel):
         """
         self._load_metadata()
         return self._get_cache().commands_used or {}
+
+    def get_models_used(self) -> set:
+        """Get set of all models seen in assistant messages (cached)."""
+        self._load_metadata()
+        return self._get_cache().models_used or set()
+
+    def get_primary_model(self) -> Optional[str]:
+        """Return the first model encountered, or None if no messages have a model."""
+        return next(iter(self.get_models_used()), None)
 
     @property
     def start_time(self) -> Optional[datetime]:

--- a/api/models/usage.py
+++ b/api/models/usage.py
@@ -186,6 +186,9 @@ class TokenUsage(BaseModel):
         """
         pricing = _resolve_model(model)
 
+        # Anthropic's long-context surcharge applies to total context length, which includes
+        # cache-read tokens — the model still attends to them. Using total context here is
+        # correct per billing; the high numbers come from legitimate large-context sessions.
         total_input = (
             self.input_tokens + self.cache_creation_input_tokens + self.cache_read_input_tokens
         )

--- a/api/routers/analytics.py
+++ b/api/routers/analytics.py
@@ -30,8 +30,6 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-
-
 def _get_analytics_sqlite(
     project: Optional[str],
     start_dt: Optional[datetime],
@@ -86,7 +84,9 @@ def _get_analytics_sqlite(
 
         return ProjectAnalytics(
             total_sessions=totals["total_sessions"],
-            total_tokens=totals["total_input"] + totals["total_cache_read"] + totals["total_output"],
+            total_tokens=totals["total_input"]
+            + totals["total_cache_read"]
+            + totals["total_output"],
             total_input_tokens=totals["total_input"],
             total_output_tokens=totals["total_output"],
             total_duration_seconds=totals["total_duration"],

--- a/api/routers/analytics.py
+++ b/api/routers/analytics.py
@@ -30,7 +30,6 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-from models.usage import TokenUsage
 
 
 def _get_analytics_sqlite(
@@ -75,10 +74,8 @@ def _get_analytics_sqlite(
         hour_totals.sort(reverse=True)
         peak_hours = [h for _, h in hour_totals[:3] if hour_totals[0][0] > 0]
 
-        # Cache hit rate
-        total_cacheable = (
-            totals["total_input"] + totals["total_cache_creation"] + totals["total_cache_read"]
-        )
+        # Cache hit rate — total_input already includes cache_creation, so don't add it again
+        total_cacheable = totals["total_input"] + totals["total_cache_read"]
         cache_hit_rate = (
             totals["total_cache_read"] / total_cacheable if total_cacheable > 0 else 0.0
         )
@@ -89,7 +86,7 @@ def _get_analytics_sqlite(
 
         return ProjectAnalytics(
             total_sessions=totals["total_sessions"],
-            total_tokens=totals["total_input"] + totals["total_output"],
+            total_tokens=totals["total_input"] + totals["total_cache_read"] + totals["total_output"],
             total_input_tokens=totals["total_input"],
             total_output_tokens=totals["total_output"],
             total_duration_seconds=totals["total_duration"],
@@ -538,20 +535,12 @@ def _calculate_analytics_from_sessions(
 
         # Track models used
         session_models = session.get_models_used()
-        model_count = len(session_models)
-
         for model in session_models:
             models_used[model] += 1
             models_categorized[_categorize_model(model)] += 1
-            # Calculate cost per model (split tokens evenly across models)
-            split_usage = TokenUsage(
-                input_tokens=usage.input_tokens // max(1, model_count),
-                output_tokens=usage.output_tokens // max(1, model_count),
-                cache_creation_input_tokens=usage.cache_creation_input_tokens
-                // max(1, model_count),
-                cache_read_input_tokens=usage.cache_read_input_tokens // max(1, model_count),
-            )
-            total_cost += split_usage.calculate_cost(model)
+
+        # Use per-message cost (already computed with correct model per message)
+        total_cost += session.get_total_cost()
 
         # Track tools used
         session_tools = session.get_tools_used()
@@ -596,7 +585,7 @@ def _calculate_analytics_from_sessions(
 
     return ProjectAnalytics(
         total_sessions=total_sessions,
-        total_tokens=total_input_tokens + total_output_tokens,
+        total_tokens=total_input_tokens + total_cache_read + total_output_tokens,
         total_input_tokens=total_input_tokens,
         total_output_tokens=total_output_tokens,
         total_duration_seconds=total_duration,

--- a/api/routers/plugins.py
+++ b/api/routers/plugins.py
@@ -599,22 +599,17 @@ def _collect_plugin_usage_sync(period: str = "all") -> dict[str, dict]:
                                                 plugin_stats[short]["last_used"] = session_time
                                         break
 
-                # Calculate cost from session token usage
-                if hasattr(session, "total_usage") and session.total_usage:
-                    usage = session.total_usage
-                    # Claude pricing estimates: $3/M input, $15/M output
-                    input_cost = (usage.input_tokens / 1_000_000) * 3.0
-                    output_cost = (usage.output_tokens / 1_000_000) * 15.0
-                    session_cost = input_cost + output_cost
+                # Calculate cost using per-message pricing (correct model + cache tokens)
+                session_cost = session.get_total_cost()
 
-                    # Distribute cost equally among all plugins used in this session
-                    if plugins_in_session:
-                        cost_per_plugin = session_cost / len(plugins_in_session)
-                        for plugin_name in plugins_in_session:
-                            plugin_stats[plugin_name]["cost_usd"] += cost_per_plugin
-                            plugin_stats[plugin_name]["daily_usage"][date_key]["cost_usd"] += (
-                                cost_per_plugin
-                            )
+                # Distribute cost equally among all plugins used in this session
+                if plugins_in_session:
+                    cost_per_plugin = session_cost / len(plugins_in_session)
+                    for plugin_name in plugins_in_session:
+                        plugin_stats[plugin_name]["cost_usd"] += cost_per_plugin
+                        plugin_stats[plugin_name]["daily_usage"][date_key]["cost_usd"] += (
+                            cost_per_plugin
+                        )
         except Exception as e:
             logger.debug(f"Error processing project {project.encoded_name}: {e}")
             continue

--- a/api/tests/api/test_memory.py
+++ b/api/tests/api/test_memory.py
@@ -412,7 +412,7 @@ class TestMemoryFilePathValidation:
         for bad in ("..etc.passwd", "foo..bar.md", "._hidden.md"):
             # Some of these should fail the leading-dot or .. or regex checks.
             with pytest.raises(HTTPException) as exc_info:
-                asyncio.get_event_loop().run_until_complete(
+                asyncio.run(
                     get_project_memory_file(
                         encoded_name=ENCODED_NAME,
                         filename=bad,

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -465,6 +465,7 @@ export interface StatItem {
 	title: string;
 	value: string | number;
 	description?: string;
+	footnote?: string;
 	// Using 'any' for icon to allow Lucide components which have complex signatures
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	icon?: any;

--- a/frontend/src/lib/components/StatsCard.svelte
+++ b/frontend/src/lib/components/StatsCard.svelte
@@ -6,6 +6,7 @@
 		title: string;
 		value: string | number;
 		description?: string;
+		footnote?: string;
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		icon?: any;
 		class?: string;
@@ -19,6 +20,7 @@
 		title,
 		value,
 		description,
+		footnote,
 		icon: Icon,
 		class: className = '',
 		color,
@@ -142,5 +144,9 @@
 				</span>
 			</div>
 		</div>
+	{/if}
+
+	{#if footnote}
+		<p class="mt-2 text-[10px] italic text-[var(--text-muted)] leading-snug">{footnote}</p>
 	{/if}
 </div>

--- a/frontend/src/lib/components/StatsGrid.svelte
+++ b/frontend/src/lib/components/StatsGrid.svelte
@@ -26,6 +26,7 @@
 			title={stat.title}
 			value={stat.value}
 			description={stat.description}
+			footnote={stat.footnote}
 			icon={stat.icon}
 			color={stat.color}
 			tokenIn={stat.tokenIn}

--- a/frontend/src/lib/components/conversation/ConversationView.svelte
+++ b/frontend/src/lib/components/conversation/ConversationView.svelte
@@ -796,6 +796,7 @@
 			{
 				title: 'Total Cost',
 				value: formatCost(entity.total_cost),
+				footnote: 'Pay-as-you-go API rate — not your subscription cost',
 				icon: DollarSign,
 				color: 'purple'
 			},

--- a/frontend/src/routes/analytics/+page.svelte
+++ b/frontend/src/routes/analytics/+page.svelte
@@ -259,6 +259,7 @@
 		{
 			title: 'Total Cost',
 			value: formatCurrency(analytics.estimated_cost_usd),
+			footnote: 'Pay-as-you-go API rate — not your subscription cost',
 			icon: Zap,
 			color: 'green'
 		},

--- a/frontend/src/routes/projects/[project_id]/+page.svelte
+++ b/frontend/src/routes/projects/[project_id]/+page.svelte
@@ -832,6 +832,7 @@
 			{
 				title: 'Estimated Cost',
 				value: formatCost(analytics.estimated_cost_usd),
+				footnote: 'Pay-as-you-go API rate — not your subscription cost',
 				icon: DollarSign,
 				color: 'purple'
 			},
@@ -1584,7 +1585,7 @@
 
 									<div class="pt-4 border-t border-[var(--border)] space-y-2">
 										<div class="flex justify-between items-center text-xs">
-											<span class="text-[var(--text-muted)]">Est. Cost</span>
+											<span class="text-[var(--text-muted)]" title="Pay-as-you-go API rate — not your subscription cost">Est. Cost ⓘ</span>
 											<span class="font-mono text-[var(--text-primary)]"
 												>${analytics.estimated_cost_usd}</span
 											>


### PR DESCRIPTION
Closes #76.

## Summary

- **Bug 3** `analytics.py:79` — Cache hit rate denominator double-counted `cache_creation` tokens (already inside `total_input`). One-liner fix.
- **Bug 2** `indexer.py:495` + `agent.py` — Subagent cost was calculated with the default Sonnet pricing regardless of the actual model. Added `get_models_used()` / `get_primary_model()` to `Agent` and pass the model through to `calculate_cost()`.
- **Bug 4** `analytics.py:546` — Project analytics split tokens evenly across models with integer division, then re-priced each split. Replaced with `session.get_total_cost()` which already sums per-message costs at the correct per-message model.
- **Bug 5** `plugins.py:606` — Plugin cost attribution hardcoded Sonnet prices (`$3/M`, `$15/M`) and ignored cache tokens. Replaced with `session.get_total_cost()`.
- **Bug 1** `usage.py:189` — Documented why the long-context threshold correctly uses total context including cache reads (model attends to all tokens, per Anthropic billing). No behavior change.
- **Bug 6** `analytics.py:92` — "Total Tokens" stat excluded cache-read tokens. Now includes `total_cache_read` in the display total on both DB fast path and full-parse fallback.

## UI disclaimer

Added a `footnote` prop to `StatsCard`/`StatsGrid`/`StatItem` and wired a *"Pay-as-you-go API rate — not your subscription cost"* note onto every cost stat card: session view, project analytics, and global analytics.

## Test plan

- [x] `pytest tests/` — 1587 passed, 6 skipped, 0 failures
- [x] `npm run check` — 0 errors, 10 pre-existing warnings
- [x] Both API (:8000) and frontend (:5173) servers running

🤖 Generated with [Claude Code](https://claude.com/claude-code)