### PR TITLE
feat(memory): add a global memory index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,12 @@ Enable real-time session monitoring by installing Claude Code hooks. See [SETUP.
 |----------|-------------|
 | `GET /cron/system` | Host OS crontab (user crontab, `/etc/crontab`, `/etc/cron.d/*`, run-parts), grouped by origin |
 
+### Memory
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /memory` | Global roll-up of projects that hold memory (note counts); links to each project's Memory tab |
+
 </details>
 
 ## Contributing

--- a/api/main.py
+++ b/api/main.py
@@ -197,7 +197,7 @@ app.include_router(tickets.router)
 app.include_router(background_shells.router)
 app.include_router(cron.router)
 app.include_router(memory.router)
-app.include_router(system_cron.router)  # ADDITIVE: Linux crontab view at /cron/system
+app.include_router(system_cron.router)
 
 
 @app.get("/")

--- a/api/tests/test_memory.py
+++ b/api/tests/test_memory.py
@@ -1,0 +1,78 @@
+"""
+Unit tests for the global memory index router.
+
+The endpoint is deliberately light — it counts memory files per project and
+never parses content — so these tests build a fake projects tree and assert
+on the roll-up shape.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+from routers.memory import _project_label, memory_index
+
+
+def _make_memory(projects_root: Path, encoded: str, notes: list[str], index: bool):
+    mem = projects_root / encoded / "memory"
+    mem.mkdir(parents=True)
+    if index:
+        (mem / "MEMORY.md").write_text("- [x](x.md)\n")
+    for n in notes:
+        (mem / n).write_text(f"# {n}\n")
+
+
+class TestMemoryIndex:
+    def test_counts_and_orders(self, tmp_path, monkeypatch):
+        from config import settings
+
+        monkeypatch.setattr(settings, "claude_base", tmp_path)
+        projects = tmp_path / "projects"
+        projects.mkdir()
+
+        _make_memory(projects, "-home-me-alpha", ["a.md", "b.md"], index=True)
+        _make_memory(projects, "-home-me-beta", ["c.md"], index=False)
+        # a project dir with no memory/ must be ignored
+        (projects / "-home-me-empty").mkdir()
+
+        out = memory_index()
+        assert out["total_projects"] == 2
+        assert out["total_notes"] == 3  # a, b, c (MEMORY.md excluded)
+        # ordered by note_count desc → alpha (2) before beta (1)
+        assert [p["encoded"] for p in out["projects"]] == [
+            "-home-me-alpha",
+            "-home-me-beta",
+        ]
+        assert out["projects"][0]["has_index"] is True
+        assert out["projects"][1]["has_index"] is False
+
+    def test_index_only_project_counts_zero_notes(self, tmp_path, monkeypatch):
+        from config import settings
+
+        monkeypatch.setattr(settings, "claude_base", tmp_path)
+        projects = tmp_path / "projects"
+        projects.mkdir()
+        _make_memory(projects, "-x", [], index=True)
+
+        out = memory_index()
+        assert out["total_projects"] == 1
+        assert out["projects"][0]["note_count"] == 0
+        assert out["projects"][0]["has_index"] is True
+
+    def test_empty_projects_dir(self, tmp_path, monkeypatch):
+        from config import settings
+
+        monkeypatch.setattr(settings, "claude_base", tmp_path)
+        (tmp_path / "projects").mkdir()
+        out = memory_index()
+        assert out == {"projects": [], "total_projects": 0, "total_notes": 0}
+
+
+class TestProjectLabel:
+    def test_falls_back_when_undecodable(self):
+        # A made-up encoded name won't decode to a real path → basename fallback
+        label = _project_label("-home-me-myrepo")
+        assert label  # non-empty
+        assert "/" not in label

--- a/frontend/src/lib/components/memory/MemoryTreeNode.svelte
+++ b/frontend/src/lib/components/memory/MemoryTreeNode.svelte
@@ -1,0 +1,150 @@
+<!--
+  MemoryTreeNode — recursive node for the global memory tree. Folder nodes
+  collapse/expand; a project leaf expands to the upstream MemoryViewer
+  rendered inline (so the content is reused, not re-implemented). Part of the
+  ADDITIVE memory explorer feature.
+-->
+<script lang="ts">
+	import { ChevronRight, Folder, BookOpen, ExternalLink } from 'lucide-svelte';
+	import MemoryViewer from '$lib/components/memory/MemoryViewer.svelte';
+	import Self from '$lib/components/memory/MemoryTreeNode.svelte';
+	import type { MemoryTreeNode } from '$lib/components/memory/memoryTree';
+
+	let {
+		node,
+		depth = 0,
+		forceOpen = false
+	}: { node: MemoryTreeNode; depth?: number; forceOpen?: boolean } = $props();
+
+	const isLeaf = $derived(node.project !== null && node.children.length === 0);
+	let open = $state(false);
+
+	const expanded = $derived(forceOpen || open);
+	const indent = $derived(`padding-left: ${depth * 16 + 12}px;`);
+</script>
+
+<div class="node">
+	<button class="row" style={indent} onclick={() => (open = !open)} aria-expanded={expanded}>
+		<span class="caret" class:open={expanded} aria-hidden="true"
+			><ChevronRight size={13} /></span
+		>
+		<Folder size={14} class="row-ico" />
+		<span class="row-name" class:leaf={isLeaf}
+			>{node.project ? node.project.label : node.name}</span
+		>
+		{#if node.project?.has_index}
+			<span class="badge-index" title="MEMORY.md index"><BookOpen size={11} /></span>
+		{/if}
+		<span class="row-count">{node.noteTotal} note{node.noteTotal === 1 ? '' : 's'}</span>
+	</button>
+
+	{#if expanded}
+		{#if node.project}
+			<div class="viewer" style={`margin-left: ${depth * 16 + 26}px;`}>
+				<a class="open-tab" href="/projects/{node.project.encoded}?tab=memory">
+					Ouvrir l'onglet projet <ExternalLink size={11} />
+				</a>
+				<MemoryViewer projectEncodedName={node.project.encoded} />
+			</div>
+		{/if}
+		{#each node.children as child (child.project?.encoded ?? child.name)}
+			<Self node={child} depth={depth + 1} {forceOpen} />
+		{/each}
+	{/if}
+</div>
+
+<style>
+	.node {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		width: 100%;
+		padding: 8px 12px;
+		background: none;
+		border: none;
+		border-radius: 8px;
+		cursor: pointer;
+		text-align: left;
+		min-width: 0;
+	}
+
+	.row:hover {
+		background: var(--bg-subtle);
+	}
+
+	.caret {
+		color: var(--text-faint);
+		display: flex;
+		align-items: center;
+		transition: transform 0.15s;
+		flex-shrink: 0;
+	}
+
+	.caret.open {
+		transform: rotate(90deg);
+	}
+
+	:global(.row-ico) {
+		color: var(--text-faint);
+		flex-shrink: 0;
+	}
+
+	.row-name {
+		font-size: 13px;
+		color: var(--text-muted);
+		font-family: var(--font-mono);
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.row-name.leaf {
+		color: var(--text-primary);
+		font-weight: 600;
+		font-family: inherit;
+	}
+
+	.badge-index {
+		display: inline-flex;
+		align-items: center;
+		color: var(--accent);
+		flex-shrink: 0;
+	}
+
+	.row-count {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		color: var(--text-faint);
+		background: var(--bg-muted);
+		padding: 1px 8px;
+		border-radius: 99px;
+		flex-shrink: 0;
+		margin-left: auto;
+	}
+
+	.viewer {
+		margin-right: 12px;
+		margin-bottom: 8px;
+		padding-top: 4px;
+	}
+
+	.open-tab {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		font-size: 11.5px;
+		color: var(--accent);
+		margin-bottom: 8px;
+		text-decoration: none;
+	}
+
+	.open-tab:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/frontend/src/lib/components/memory/memoryTree.ts
+++ b/frontend/src/lib/components/memory/memoryTree.ts
@@ -1,0 +1,80 @@
+/**
+ * Build a folder tree from the flat /memory project list. Encoded project
+ * names decode to filesystem paths, so projects naturally nest by their
+ * shared path prefixes. Linear chains are compressed (a/b/c shown as one
+ * node) so the tree stays shallow. Part of the ADDITIVE memory explorer.
+ */
+
+export interface MemoryProjectRow {
+	encoded: string;
+	label: string;
+	path: string;
+	note_count: number;
+	has_index: boolean;
+}
+
+export interface MemoryTreeNode {
+	name: string;
+	children: MemoryTreeNode[];
+	project: MemoryProjectRow | null;
+	noteTotal: number;
+}
+
+function insert(root: MemoryTreeNode, row: MemoryProjectRow): void {
+	const parts = row.path.split('/').filter(Boolean);
+	let node = root;
+	for (const part of parts) {
+		let child = node.children.find((c) => c.name === part && !c.project);
+		if (!child) {
+			child = { name: part, children: [], project: null, noteTotal: 0 };
+			node.children.push(child);
+		}
+		node = child;
+	}
+	node.project = row;
+}
+
+/** Collapse single-child, project-less chains: media → mktotoy → Shared → one node. */
+function compress(node: MemoryTreeNode): MemoryTreeNode {
+	node.children = node.children.map(compress);
+	while (node.children.length === 1 && !node.project) {
+		const only = node.children[0];
+		node = {
+			name: node.name ? `${node.name}/${only.name}` : only.name,
+			children: only.children,
+			project: only.project,
+			noteTotal: 0
+		};
+	}
+	return node;
+}
+
+function tallyNotes(node: MemoryTreeNode): number {
+	const own = node.project?.note_count ?? 0;
+	const sub = node.children.reduce((s, c) => s + tallyNotes(c), 0);
+	node.noteTotal = own + sub;
+	return node.noteTotal;
+}
+
+function sortTree(node: MemoryTreeNode): void {
+	// folders first, then by note total desc, then name
+	node.children.sort((a, b) => {
+		const af = a.project && a.children.length === 0 ? 1 : 0;
+		const bf = b.project && b.children.length === 0 ? 1 : 0;
+		if (af !== bf) return af - bf;
+		if (b.noteTotal !== a.noteTotal) return b.noteTotal - a.noteTotal;
+		return a.name.localeCompare(b.name);
+	});
+	node.children.forEach(sortTree);
+}
+
+/** Build the compressed, sorted top-level nodes from the flat project list. */
+export function buildMemoryTree(rows: MemoryProjectRow[]): MemoryTreeNode[] {
+	const root: MemoryTreeNode = { name: '', children: [], project: null, noteTotal: 0 };
+	for (const r of rows) insert(root, r);
+	const compressed = root.children.map(compress);
+	const top: MemoryTreeNode = { name: '', children: compressed, project: null, noteTotal: 0 };
+	tallyNotes(top);
+	sortTree(top);
+	return top.children;
+}

--- a/frontend/src/routes/memory/+page.server.ts
+++ b/frontend/src/routes/memory/+page.server.ts
@@ -1,0 +1,31 @@
+import { API_BASE } from '$lib/config';
+import { fetchWithFallback } from '$lib/utils/api-fetch';
+
+// Shape mirrors api/routers/memory.py. Kept local to this additive feature so
+// $lib/api-types.ts stays untouched (smaller upstream merge surface).
+interface MemoryProjectRow {
+	encoded: string;
+	label: string;
+	path: string;
+	note_count: number;
+	has_index: boolean;
+}
+interface MemoryIndexResponse {
+	projects: MemoryProjectRow[];
+	total_projects: number;
+	total_notes: number;
+}
+
+export async function load({ fetch }) {
+	const data = await fetchWithFallback<MemoryIndexResponse>(fetch, `${API_BASE}/memory`, {
+		projects: [],
+		total_projects: 0,
+		total_notes: 0
+	});
+
+	return {
+		projects: data?.projects ?? [],
+		totalProjects: data?.total_projects ?? 0,
+		totalNotes: data?.total_notes ?? 0
+	};
+}

--- a/frontend/src/routes/memory/+page.svelte
+++ b/frontend/src/routes/memory/+page.svelte
@@ -1,293 +1,344 @@
 <script lang="ts">
-	import { Brain, FolderOpen, Search, FileText, BookOpen } from 'lucide-svelte';
+	import {
+		Brain,
+		Search,
+		FolderGit2,
+		BookOpen,
+		ArrowRight,
+		LayoutGrid,
+		FolderTree
+	} from 'lucide-svelte';
 	import PageHeader from '$lib/components/layout/PageHeader.svelte';
-
-	interface MemoryProjectRow {
-		encoded: string;
-		label: string;
-		path: string;
-		note_count: number;
-		has_index: boolean;
-	}
+	import StatsGrid from '$lib/components/StatsGrid.svelte';
+	import MemoryTreeNode from '$lib/components/memory/MemoryTreeNode.svelte';
+	import { buildMemoryTree, type MemoryProjectRow } from '$lib/components/memory/memoryTree';
 
 	let { data } = $props();
-	const allProjects = $derived((data.projects ?? []) as MemoryProjectRow[]);
 
 	let query = $state('');
+	let view = $state<'cards' | 'tree'>('cards');
 
-	const filtered = $derived(
-		allProjects.filter((p) => {
-			const q = query.trim().toLowerCase();
-			if (!q) return true;
-			return p.label.toLowerCase().includes(q) || p.path.toLowerCase().includes(q);
-		})
-	);
+	const filtered = $derived.by(() => {
+		const q = query.trim().toLowerCase();
+		const rows = data.projects as MemoryProjectRow[];
+		if (!q) return rows;
+		return rows.filter(
+			(p) => p.label.toLowerCase().includes(q) || p.path.toLowerCase().includes(q)
+		);
+	});
 
-	function memoryHref(p: MemoryProjectRow): string {
-		return `/projects/${p.encoded}?tab=memory`;
-	}
+	const tree = $derived(buildMemoryTree(filtered));
+	const searching = $derived(query.trim().length > 0);
 </script>
 
 <svelte:head>
-	<title>Memory · Claude Code Karma</title>
+	<title>Memory · Claude Karma</title>
 </svelte:head>
 
-<div class="memory-page">
+<div class="page-wrap">
 	<PageHeader
 		title="Memory"
-		iconName="memory"
-		iconColor="--nav-blue"
-		subtitle="Browse each project's persistent memory"
+		subtitle="La mémoire Claude Code de tous tes projets. Vue d'ensemble en cartes, ou arbre par dossier — déplie un projet pour lire son contenu directement."
+		icon={Brain}
+		iconColor="--nav-purple"
+		breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Memory' }]}
 	/>
 
-	{#if allProjects.length > 0}
-		<div class="stats">
-			<div class="stat">
-				<span class="stat-value">{data.totalProjects}</span>
-				<span class="stat-label">projects with memory</span>
-			</div>
-			<div class="stat-divider"></div>
-			<div class="stat">
-				<span class="stat-value">{data.totalNotes}</span>
-				<span class="stat-label">total notes</span>
-			</div>
-		</div>
-	{/if}
+	<div class="stats-wrap">
+		<StatsGrid
+			columns={2}
+			stats={[
+				{
+					title: 'Projets avec mémoire',
+					value: data.totalProjects,
+					icon: FolderGit2,
+					color: 'blue'
+				},
+				{ title: 'Notes mémoire', value: data.totalNotes, icon: Brain, color: 'purple' }
+			]}
+		/>
+	</div>
 
-	{#if allProjects.length === 0}
-		<div class="state">
-			No projects have memory yet (<code>~/.claude/projects/&lt;project&gt;/memory/</code>).
+	<div class="toolbar">
+		<div class="search-wrap">
+			<span class="search-ico"><Search size={14} /></span>
+			<input
+				class="search-input"
+				placeholder="Filtrer par projet ou chemin…"
+				bind:value={query}
+			/>
+		</div>
+
+		<div class="seg" role="tablist" aria-label="Mode d'affichage">
+			<button
+				class="seg-btn"
+				class:on={view === 'cards'}
+				onclick={() => (view = 'cards')}
+				role="tab"
+				aria-selected={view === 'cards'}
+			>
+				<LayoutGrid size={14} /> Cartes
+			</button>
+			<button
+				class="seg-btn"
+				class:on={view === 'tree'}
+				onclick={() => (view = 'tree')}
+				role="tab"
+				aria-selected={view === 'tree'}
+			>
+				<FolderTree size={14} /> Arbre
+			</button>
+		</div>
+	</div>
+
+	{#if filtered.length === 0}
+		<div class="empty">
+			{#if data.totalProjects === 0}
+				Aucun projet n'a encore de mémoire (<code
+					>~/.claude/projects/&lt;projet&gt;/memory/</code
+				>).
+			{:else}
+				Aucun projet ne correspond au filtre.
+			{/if}
+		</div>
+	{:else if view === 'cards'}
+		<div class="grid">
+			{#each filtered as p (p.encoded)}
+				<a class="card" href="/projects/{p.encoded}?tab=memory">
+					<div class="card-top">
+						<span class="card-ico"><FolderGit2 size={16} /></span>
+						<span class="card-label">{p.label}</span>
+					</div>
+					<div class="card-meta">
+						<span class="meta-item">
+							<Brain size={13} />
+							{p.note_count} note{p.note_count === 1 ? '' : 's'}
+						</span>
+						{#if p.has_index}
+							<span class="meta-item index"><BookOpen size={13} /> index</span>
+						{/if}
+					</div>
+					<div class="card-enc">{p.path}</div>
+					<span class="card-go">Voir la mémoire <ArrowRight size={13} /></span>
+				</a>
+			{/each}
 		</div>
 	{:else}
-		<div class="search">
-			<Search size={15} strokeWidth={2} />
-			<input type="text" placeholder="Search projects…" bind:value={query} />
+		<div class="tree">
+			{#each tree as node (node.project?.encoded ?? node.name)}
+				<MemoryTreeNode {node} forceOpen={searching} />
+			{/each}
 		</div>
-
-		{#if filtered.length === 0}
-			<div class="state">No projects match "{query}".</div>
-		{:else}
-			<div class="grid">
-				{#each filtered as project (project.encoded)}
-					<a class="card" href={memoryHref(project)}>
-						<!-- Header -->
-						<div class="card-header">
-							<div class="card-icon">
-								<FolderOpen size={20} strokeWidth={2} />
-							</div>
-							<div class="card-title-wrap">
-								<span class="card-name">{project.label}</span>
-								<span class="card-path">{project.path}</span>
-							</div>
-						</div>
-
-						<!-- Footer -->
-						<div class="card-footer">
-							<span class="footer-stat">
-								<FileText size={13} strokeWidth={2} />
-								{project.note_count} note{project.note_count === 1 ? '' : 's'}
-							</span>
-							{#if project.has_index}
-								<span class="badge-index">
-									<BookOpen size={11} /> index
-								</span>
-							{/if}
-						</div>
-					</a>
-				{/each}
-			</div>
-		{/if}
 	{/if}
 </div>
 
 <style>
-	.memory-page {
-		max-width: 1100px;
+	.page-wrap {
+		max-width: 1120px;
 		margin: 0 auto;
-		padding: 0 16px;
+		padding: 32px 32px 80px;
 	}
 
-	/* Stats */
-	.stats {
+	.stats-wrap {
+		border-radius: 16px;
+		padding: 24px;
+		border: 1px solid var(--border);
+		background: linear-gradient(
+			135deg,
+			rgba(var(--accent-rgb), 0.02) 0%,
+			rgba(var(--accent-rgb), 0.06) 100%
+		);
+		margin-bottom: 22px;
+	}
+
+	.toolbar {
 		display: flex;
 		align-items: center;
-		gap: 20px;
-		padding: 14px 18px;
-		background: var(--bg-subtle);
-		border: 1px solid var(--border);
-		border-radius: 10px;
+		gap: 10px;
 		margin-bottom: 16px;
 	}
 
-	.stat {
-		display: flex;
-		align-items: baseline;
-		gap: 6px;
-	}
-
-	.stat-value {
-		font-size: 18px;
-		font-weight: 700;
-		color: var(--text-primary);
-		font-variant-numeric: tabular-nums;
-	}
-
-	.stat-label {
-		font-size: 12px;
-		color: var(--text-muted);
-	}
-
-	.stat-divider {
-		width: 1px;
-		height: 20px;
-		background: var(--border);
-	}
-
-	/* Search */
-	.state {
-		padding: 32px 16px;
-		text-align: center;
-		color: var(--text-muted);
-		font-size: 14px;
-	}
-
-	.state code {
-		font-family: var(--font-mono);
-		font-size: 12px;
-		background: var(--bg-muted);
-		padding: 1px 5px;
-		border-radius: 4px;
-	}
-
-	.search {
+	.search-wrap {
+		position: relative;
 		display: flex;
 		align-items: center;
-		gap: 8px;
-		padding: 9px 12px;
-		margin-bottom: 16px;
-		background: var(--bg-subtle);
-		border: 1px solid var(--border);
-		border-radius: 8px;
-		color: var(--text-muted);
-	}
-
-	.search input {
 		flex: 1;
-		border: none;
-		background: transparent;
-		outline: none;
-		color: var(--text-primary);
-		font-size: 14px;
-		font-family: var(--font-sans);
 	}
 
-	/* Grid */
+	.search-ico {
+		position: absolute;
+		left: 11px;
+		color: var(--text-faint);
+		pointer-events: none;
+		display: flex;
+	}
+
+	.search-input {
+		width: 100%;
+		height: 36px;
+		border: 1px solid var(--border-hover);
+		border-radius: 8px;
+		background: var(--bg-base);
+		padding: 0 12px 0 34px;
+		font-size: 13px;
+		color: var(--text-primary);
+		outline: none;
+	}
+
+	.search-input:focus {
+		border-color: var(--accent);
+		box-shadow: 0 0 0 3px var(--accent-muted);
+	}
+
+	.seg {
+		display: inline-flex;
+		border: 1px solid var(--border-hover);
+		border-radius: 8px;
+		overflow: hidden;
+		flex-shrink: 0;
+	}
+
+	.seg-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		height: 36px;
+		padding: 0 12px;
+		background: var(--bg-base);
+		border: none;
+		font-size: 12.5px;
+		color: var(--text-muted);
+		cursor: pointer;
+	}
+
+	.seg-btn:hover {
+		background: var(--bg-subtle);
+	}
+
+	.seg-btn.on {
+		background: var(--accent-muted);
+		color: var(--accent);
+		font-weight: 600;
+	}
+
+	.seg-btn + .seg-btn {
+		border-left: 1px solid var(--border-hover);
+	}
+
+	/* ── Cards ─────────────────────────────────────────────────────────────── */
 	.grid {
 		display: grid;
 		grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
 		gap: 12px;
 	}
 
-	/* Card — matches ProjectCard default variant */
 	.card {
 		display: flex;
 		flex-direction: column;
-		gap: 0;
-		background: var(--bg-subtle);
+		gap: 10px;
 		border: 1px solid var(--border);
-		border-left: 3px solid var(--nav-blue);
-		border-radius: 10px;
-		padding: 16px 16px 0;
+		border-radius: 12px;
+		background: var(--bg-base);
+		padding: 16px;
 		text-decoration: none;
 		transition:
-			box-shadow 120ms,
-			border-color 120ms;
+			border-color 0.15s,
+			box-shadow 0.15s;
 	}
 
 	.card:hover {
-		box-shadow: 0 4px 16px -6px rgba(0, 0, 0, 0.12);
+		border-color: var(--border-hover);
+		box-shadow: 0 6px 20px -10px var(--border-subtle);
 	}
 
-	.card:focus-visible {
-		outline: 2px solid var(--accent);
-		outline-offset: 2px;
-	}
-
-	.card-header {
+	.card-top {
 		display: flex;
-		align-items: flex-start;
-		gap: 12px;
-		margin-bottom: 12px;
+		align-items: center;
+		gap: 9px;
+		min-width: 0;
 	}
 
-	.card-icon {
+	.card-ico {
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		width: 40px;
-		height: 40px;
+		width: 30px;
+		height: 30px;
 		border-radius: 8px;
-		background: var(--nav-blue-subtle);
-		color: var(--nav-blue);
+		background: var(--accent-muted);
+		color: var(--accent);
 		flex-shrink: 0;
 	}
 
-	.card-title-wrap {
-		display: flex;
-		flex-direction: column;
-		min-width: 0;
-		flex: 1;
-	}
-
-	.card-name {
-		font-size: 13.5px;
+	.card-label {
+		font-size: 14px;
 		font-weight: 600;
-		font-family: var(--font-mono);
-		color: var(--accent);
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		line-height: 1.3;
-		margin-bottom: 2px;
-	}
-
-	.card-path {
-		font-size: 11px;
-		font-family: var(--font-mono);
-		color: var(--text-muted);
+		color: var(--text-primary);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
 
-	/* Footer */
-	.card-footer {
+	.card-meta {
 		display: flex;
 		align-items: center;
-		justify-content: space-between;
-		gap: 8px;
-		padding: 10px 0;
-		border-top: 1px solid var(--border);
-		margin-top: auto;
+		gap: 12px;
 	}
 
-	.footer-stat {
+	.meta-item {
 		display: inline-flex;
 		align-items: center;
 		gap: 5px;
-		font-size: 12px;
+		font-size: 12.5px;
 		color: var(--text-muted);
 	}
 
-	.badge-index {
+	.meta-item.index {
+		color: var(--accent);
+	}
+
+	.card-enc {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		color: var(--text-faint);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.card-go {
 		display: inline-flex;
 		align-items: center;
-		gap: 3px;
-		font-size: 10.5px;
+		gap: 5px;
+		font-size: 12.5px;
 		font-weight: 500;
 		color: var(--accent);
-		background: var(--accent-muted);
-		padding: 2px 7px;
-		border-radius: 99px;
+		margin-top: 2px;
+	}
+
+	/* ── Tree ──────────────────────────────────────────────────────────────── */
+	.tree {
+		border: 1px solid var(--border);
+		border-radius: 12px;
+		background: var(--bg-base);
+		padding: 8px;
+	}
+
+	.empty {
+		padding: 50px 20px;
+		text-align: center;
+		color: var(--text-muted);
+		border: 1px dashed var(--border);
+		border-radius: 12px;
+		background: var(--bg-subtle);
+		font-size: 13px;
+	}
+
+	.empty code {
+		font-family: var(--font-mono);
+		font-size: 12px;
+		background: var(--bg-muted);
+		padding: 0 5px;
+		border-radius: 4px;
 	}
 </style>


### PR DESCRIPTION
## Summary

Upstream already serves and renders **per-project** memory (the "Memory" tab on each project page, backed by `GET /projects/{encoded}/memory`). What it lacks is a single place to see *all* of it — to review everything you currently open each project one by one.

This adds a `/memory` page with two toggleable views:

- **Cards** (default): a flat, scannable grid — one card per project with its note count and path, linking to the project's Memory tab.
- **Tree**: projects organised into a **folder tree** (encoded names decode to filesystem paths, so they nest by shared prefixes; linear chains are compressed). Expanding a project leaf renders the upstream `MemoryViewer` **inline** — the content is reused, not re-implemented.

## Changes

- New API router `routers/memory.py` → `GET /memory`: a roll-up counting `*.md` files per project's `memory/` dir (no frontmatter parsing, no content dump) and returning the decoded path for tree grouping. Labels/paths via the existing `Project.decode_path`.
- New `/memory` route with a Cards/Tree toggle: the tree builder (`memoryTree.ts`) + recursive `MemoryTreeNode.svelte` embed the existing `MemoryViewer`. Reuses `StatsGrid` / `PageHeader`.
- New nav entry "Memory".
- Additive wiring only: one import + one `include_router` in `main.py`; one icon import + one nav entry in `Header.svelte`.

## Component

- [x] API (FastAPI backend)
- [x] Frontend (SvelteKit dashboard)
- [ ] Captain Hook (hook models)
- [ ] Hook Scripts
- [ ] Documentation
- [ ] CI / Build

## Type

- [x] Feature (new functionality)

## Testing

- [x] API tests pass (`cd api && pytest tests/test_memory.py` → 4 passed: counting/ordering, index-only project, empty dir, label fallback)
- [x] Frontend type-checks (`npm run check` → 0 errors; new files add no warnings)
- [x] Frontend lints clean (`npm run lint` → 0 errors in new files)
- [ ] Captain Hook tests pass — N/A
- [x] Manually tested (`/memory` renders HTTP 200; Cards/Tree toggle works; expanding a tree leaf shows the memory inline via the existing MemoryViewer)

## Screenshots

_Omitted — developed in a headless CLI environment. Happy to attach a screenshot on request._

## Related Issues

_None._
