### PR TITLE
feat(ui): session page rail+drawer redesign — all 10 drawer panels

### DIFF
--- a/api/routers/live_sessions.py
+++ b/api/routers/live_sessions.py
@@ -206,6 +206,7 @@ def state_to_summary(
         subagents=subagents_dict,
         active_subagent_count=state.active_subagent_count,
         total_subagent_count=state.total_subagent_count,
+        last_notification_message=state.last_notification_message,
     )
 
 

--- a/api/routers/subagent_sessions.py
+++ b/api/routers/subagent_sessions.py
@@ -134,6 +134,7 @@ def get_subagent_detail(
         working_directories=list(agent_data.working_directories),
         subagent_type=subagent_type,
         initial_prompt=agent_data.initial_prompt,
+        models_used=list(agent.get_models_used()),
     )
 
     # Add cache headers

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1018,6 +1018,9 @@ class LiveSessionSummary(BaseModel):
     total_subagent_count: Optional[int] = Field(
         None, description="Total subagents tracked (running + completed)"
     )
+    last_notification_message: Optional[str] = Field(
+        None, description="Last notification message received in this session"
+    )
     session_ids: List[str] = Field(
         default_factory=list,
         description="All session UUIDs that have been part of this slug's lifecycle (for resumed sessions)",

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -563,6 +563,9 @@ class SubagentSessionDetail(BaseModel):
     initial_prompt: Optional[str] = Field(
         None, description="First user message to subagent (truncated)"
     )
+    models_used: list[str] = Field(
+        default_factory=list, description="Models seen in assistant messages"
+    )
 
 
 # =============================================================================

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -30,6 +30,10 @@
 	/* Missing tokens (referenced but were undefined) */
 	--accent-primary: var(--accent);
 	--border-hover: rgba(0, 0, 0, 0.12);
+
+	/* Rail active button */
+	--rail-active-bg: rgba(0, 0, 0, 0.1);
+	--rail-active-icon: #000000;
 	--radius-xs: 2px;
 	--duration-normal: 300ms;
 
@@ -267,6 +271,10 @@ select:focus {
 	--bg-subtle: #1a1f26;
 	--bg-muted: #242b35;
 
+	/* Rail active button */
+	--rail-active-bg: rgba(255, 255, 255, 0.15);
+	--rail-active-icon: #ffffff;
+
 	/* Text (soft off-white, easier on eyes) */
 	--text-primary: #e2e8f0;
 	--text-secondary: #a1a1aa;
@@ -408,6 +416,8 @@ select:focus {
 		--bg-base: #0f1419;
 		--bg-subtle: #1a1f26;
 		--bg-muted: #242b35;
+		--rail-active-bg: rgba(255, 255, 255, 0.15);
+		--rail-active-icon: #ffffff;
 		--text-primary: #e2e8f0;
 		--text-secondary: #a1a1aa;
 		--text-muted: #71717a;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -545,6 +545,28 @@ body {
 	font-variant-numeric: tabular-nums;
 }
 
+/* Minimal scrollbars */
+::-webkit-scrollbar {
+	width: 4px;
+	height: 4px;
+}
+::-webkit-scrollbar-track {
+	background: transparent;
+}
+::-webkit-scrollbar-thumb {
+	background: rgba(0, 0, 0, 0.12);
+	border-radius: 99px;
+}
+::-webkit-scrollbar-thumb:hover {
+	background: rgba(0, 0, 0, 0.22);
+}
+[data-theme='dark'] ::-webkit-scrollbar-thumb {
+	background: rgba(255, 255, 255, 0.12);
+}
+[data-theme='dark'] ::-webkit-scrollbar-thumb:hover {
+	background: rgba(255, 255, 255, 0.22);
+}
+
 /* Markdown Preview Styles */
 .markdown-preview {
 	@apply leading-relaxed;
@@ -705,6 +727,22 @@ body {
 .markdown-preview li > ol {
 	@apply mt-1 mb-0;
 }
+
+/* ── Compact markdown variant for narrow drawers (350px) ── */
+.markdown-preview--compact h1 { @apply text-sm font-semibold mt-4 mb-2 pb-1; }
+.markdown-preview--compact h2 { @apply text-xs font-semibold mt-3 mb-1.5 uppercase tracking-wide; color: var(--text-muted); }
+.markdown-preview--compact h3 { @apply text-xs font-medium mt-2.5 mb-1; }
+.markdown-preview--compact p  { @apply text-xs mb-2 leading-relaxed; }
+.markdown-preview--compact ul,
+.markdown-preview--compact ol { @apply text-xs mb-2 space-y-0.5; }
+.markdown-preview--compact li { @apply pl-0.5; }
+.markdown-preview--compact code { @apply text-[10px] px-1 py-px; }
+.markdown-preview--compact pre { @apply p-2.5 mb-3 text-[10px]; }
+.markdown-preview--compact blockquote { @apply pl-2 py-0.5 mb-2 text-xs; }
+.markdown-preview--compact hr { @apply my-2; }
+.markdown-preview--compact table { @apply text-[10px]; }
+.markdown-preview--compact th,
+.markdown-preview--compact td { @apply px-2 py-1; }
 
 /* ── Markdown inline copy buttons (injected by markdownCopyButtons action) ── */
 

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -646,6 +646,7 @@ export interface LiveSessionSummary {
 	subagents: Record<string, SubagentState>;
 	active_subagent_count: number;
 	total_subagent_count: number;
+	last_notification_message: string | null;
 }
 
 // ============================================

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -694,6 +694,7 @@ export interface SubagentSessionDetail {
 	// Subagent-specific metadata
 	subagent_type: string | null;
 	initial_prompt: string | null;
+	models_used: string[];
 }
 
 /**

--- a/frontend/src/lib/components/ExpandablePrompt.svelte
+++ b/frontend/src/lib/components/ExpandablePrompt.svelte
@@ -116,147 +116,55 @@
 </script>
 
 {#if isCommandOnly}
-	<!-- Command-only prompt (e.g., /init with no additional text) -->
-	<div
-		class="
-			relative
-			p-4 pl-5
-			bg-[var(--bg-subtle)]
-			border border-[var(--border)]
-			border-l-[3px] border-l-[var(--nav-purple)]
-			rounded-[var(--radius-lg)]
-			{className}
-		"
-	>
-		<div class="flex items-center gap-2">
-			<div class="p-1.5 rounded-md bg-[var(--nav-purple-subtle)]">
-				<Terminal size={14} strokeWidth={2} class="text-[var(--nav-purple)]" />
-			</div>
-			<h3 class="text-sm font-medium text-[var(--text-primary)]">Session Command</h3>
-		</div>
-		<div class="mt-2 flex items-center gap-2">
-			<code
-				class="px-2 py-1 bg-[var(--bg-muted)] rounded font-mono text-sm text-[var(--nav-purple)]"
-			>
-				{commandName}
-			</code>
-			<span class="text-xs text-[var(--text-muted)]">Session started via command</span>
+	<div class="rounded-lg border-l-2 border-l-[var(--nav-purple)] border border-[var(--border)]/60 bg-[var(--bg-base)] px-3 py-2.5 {className}">
+		<div class="flex items-center gap-1.5">
+			<Terminal size={12} strokeWidth={2} class="text-[var(--nav-purple)]" />
+			<span class="text-xs font-medium text-[var(--text-primary)]">Command</span>
+			<code class="ml-1 px-1.5 py-0.5 bg-[var(--bg-muted)] rounded font-mono text-xs text-[var(--nav-purple)]">{commandName}</code>
 		</div>
 	</div>
 {:else}
-	<!-- Regular prompt with user text -->
-	<div
-		class="
-			relative
-			p-4 pl-5
-			bg-[var(--bg-subtle)]
-			border border-[var(--border)]
-			border-l-[3px] border-l-[var(--accent)]
-			rounded-[var(--radius-lg)]
-			{className}
-		"
-	>
-		<!-- Header with title, command badge, and action buttons -->
-		<div class="flex items-center justify-between mb-3">
-			<div class="flex items-center gap-2">
-				<div class="p-1.5 rounded-md bg-[var(--accent-subtle)]">
-					<MessageSquare size={14} strokeWidth={2} class="text-[var(--accent)]" />
-				</div>
-				<h3 class="text-sm font-medium text-[var(--text-primary)]">Initial Prompt</h3>
+	<div class="rounded-lg border-l-2 border-l-[var(--accent)] border border-[var(--border)]/60 bg-[var(--bg-base)] {className}">
+		<!-- Header -->
+		<div class="flex items-center justify-between px-3 pt-2.5 pb-2">
+			<div class="flex items-center gap-1.5">
+				<MessageSquare size={12} strokeWidth={2} class="text-[var(--accent)]" />
+				<span class="text-xs font-medium text-[var(--text-primary)]">Initial Prompt</span>
 				{#if commandName}
-					<code
-						class="px-1.5 py-0.5 bg-[var(--bg-muted)] rounded font-mono text-xs text-[var(--text-muted)]"
-					>
-						{commandName}
-					</code>
+					<code class="px-1 py-0.5 bg-[var(--bg-muted)] rounded font-mono text-[10px] text-[var(--text-muted)]">{commandName}</code>
 				{/if}
 			</div>
-
-			<!-- Action buttons -->
-			<div class="flex items-center gap-1">
+			<div class="flex items-center gap-0.5">
 				{#if showFullViewButton}
-					<button
-						type="button"
-						onclick={() => (modalOpen = true)}
-						class="
-							p-1.5 rounded-md
-							text-[var(--text-muted)]
-							hover:text-[var(--text-primary)]
-							hover:bg-[var(--bg-muted)]
-							transition-colors
-						"
-						title="Full view"
-						aria-label="Open full view"
-					>
-						<Maximize2 size={14} />
-					</button>
+					<button type="button" onclick={() => (modalOpen = true)} class="p-1 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-muted)] transition-colors" title="Full view"><Maximize2 size={12} /></button>
 				{/if}
-				<button
-					type="button"
-					onclick={copyToClipboard}
-					class="
-						p-1.5 rounded-md
-						text-[var(--text-muted)]
-						hover:text-[var(--text-primary)]
-						hover:bg-[var(--bg-muted)]
-						transition-colors
-						{copied ? 'text-green-500' : ''}
-					"
-					title={copied ? 'Copied!' : 'Copy prompt'}
-					aria-label={copied ? 'Copied to clipboard' : 'Copy prompt to clipboard'}
-				>
-					{#if copied}
-						<Check size={14} />
-					{:else}
-						<Copy size={14} />
-					{/if}
+				<button type="button" onclick={copyToClipboard} class="p-1 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-muted)] transition-colors {copied ? 'text-green-500' : ''}" title={copied ? 'Copied!' : 'Copy'}>
+					{#if copied}<Check size={12} />{:else}<Copy size={12} />{/if}
 				</button>
 			</div>
 		</div>
 
-		<!-- Markdown content -->
-		<div class="bg-[var(--bg-muted)] px-3 py-2 rounded-md">
+		<!-- Content -->
+		<div class="px-3 pb-2.5">
 			{#if imageAttachments && imageAttachments.length > 0}
-				<ImageAttachments attachments={imageAttachments} class="mt-1" />
+				<ImageAttachments attachments={imageAttachments} class="mb-2" />
 			{/if}
 			<div
-				class="markdown-preview text-sm prompt-content {!isExpanded && needsExpansion
-					? 'prompt-preview'
-					: ''}"
+				class="markdown-preview text-xs prompt-content {!isExpanded && needsExpansion ? 'prompt-preview' : ''}"
 				use:markdownCopyButtons={renderedContent}
 			>
 				{@html renderedContent}
 			</div>
-		</div>
-
-		<!-- Expand/Collapse button with character count -->
-		{#if needsExpansion}
-			<div class="flex justify-center mt-3">
+			{#if needsExpansion}
 				<button
 					type="button"
 					onclick={() => (isExpanded = !isExpanded)}
-					class="
-						flex items-center gap-1.5 px-3 py-1.5
-						text-xs font-medium
-						text-[var(--accent)]
-						hover:bg-[var(--accent-subtle)]
-						rounded-full
-						transition-colors
-						focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]
-					"
-					aria-expanded={isExpanded}
-					aria-label={isExpanded ? 'Collapse prompt' : 'Expand prompt'}
+					class="mt-1.5 flex items-center gap-1 text-[11px] text-[var(--accent)] hover:underline"
 				>
-					{#if isExpanded}
-						<ChevronUp size={14} strokeWidth={2.5} />
-						<span>Show less</span>
-					{:else}
-						<ChevronDown size={14} strokeWidth={2.5} />
-						<span>Show more ({formatCharCount(charCount)} chars)</span>
-					{/if}
+					{#if isExpanded}<ChevronUp size={11} />Show less{:else}<ChevronDown size={11} />Show more ({formatCharCount(charCount)} chars){/if}
 				</button>
-			</div>
-		{/if}
+			{/if}
+		</div>
 	</div>
 
 	<!-- Full view modal for very long prompts -->

--- a/frontend/src/lib/components/FileActivityTable.svelte
+++ b/frontend/src/lib/components/FileActivityTable.svelte
@@ -6,16 +6,13 @@
 		FileMinusIcon,
 		SearchIcon,
 		BotIcon,
-		UserIcon,
-		ChevronUp,
-		ChevronDown,
 		Copy,
-		ExternalLink
+		ExternalLink,
+		X
 	} from 'lucide-svelte';
 	import type { FileActivity, FileOperation } from '$lib/api-types';
 	import {
 		formatDate,
-		truncate,
 		formatDisplayPath,
 		copyToClipboard,
 		getSubagentColorVars
@@ -24,9 +21,7 @@
 	interface Props {
 		activities: FileActivity[];
 		projectPath?: string | null;
-		/** Current agent ID - when set, activities from this agent won't show subagent badges */
 		currentAgentId?: string | null;
-		/** Map of agent_id to subagent_type for color lookup */
 		subagentTypes?: Record<string, string | null>;
 		class?: string;
 	}
@@ -39,327 +34,171 @@
 		class: className = ''
 	}: Props = $props();
 
-	// Sort state
-	type SortField = 'timestamp' | 'path' | 'operation' | 'actor';
-	type SortOrder = 'asc' | 'desc';
-
-	let sortField = $state<SortField>('timestamp');
-	let sortOrder = $state<SortOrder>('asc');
 	let filterQuery = $state('');
+	let activeOps = $state<Set<FileOperation>>(new Set());
 
-	// Toast state for copy feedback
 	let showToast = $state(false);
-	let toastMessage = $state('');
 
-	// Operation icons and colors
-	const operationConfig: Record<
-		FileOperation,
-		{ icon: typeof FileIcon; color: string; bgColor: string }
-	> = {
-		read: { icon: FileIcon, color: 'text-blue-400', bgColor: 'bg-blue-500/20' },
-		write: { icon: FilePlusIcon, color: 'text-green-400', bgColor: 'bg-green-500/20' },
-		edit: { icon: FilePenIcon, color: 'text-yellow-400', bgColor: 'bg-yellow-500/20' },
-		delete: { icon: FileMinusIcon, color: 'text-red-400', bgColor: 'bg-red-500/20' },
-		search: { icon: SearchIcon, color: 'text-purple-400', bgColor: 'bg-purple-500/20' }
+	const operationConfig: Record<FileOperation, { icon: typeof FileIcon; label: string; color: string; bgColor: string; borderColor: string }> = {
+		read:   { icon: FileIcon,      label: 'Read',   color: 'text-blue-500',   bgColor: 'bg-blue-500/10',   borderColor: 'border-blue-500/30' },
+		write:  { icon: FilePlusIcon,  label: 'Write',  color: 'text-green-500',  bgColor: 'bg-green-500/10',  borderColor: 'border-green-500/30' },
+		edit:   { icon: FilePenIcon,   label: 'Edit',   color: 'text-amber-500',  bgColor: 'bg-amber-500/10',  borderColor: 'border-amber-500/30' },
+		delete: { icon: FileMinusIcon, label: 'Delete', color: 'text-red-500',    bgColor: 'bg-red-500/10',    borderColor: 'border-red-500/30' },
+		search: { icon: SearchIcon,    label: 'Search', color: 'text-purple-500', bgColor: 'bg-purple-500/10', borderColor: 'border-purple-500/30' }
 	};
 
-	// Sorted and filtered activities
-	let sortedActivities = $derived.by(() => {
-		let filtered = activities;
+	// Which op types actually exist in the data
+	const presentOps = $derived(
+		[...new Set(activities.map(a => a.operation))] as FileOperation[]
+	);
 
-		// Apply filter
-		if (filterQuery) {
-			const lowerFilter = filterQuery.toLowerCase();
-			filtered = activities.filter(
-				(a) =>
-					a.path.toLowerCase().includes(lowerFilter) ||
-					a.actor.toLowerCase().includes(lowerFilter) ||
-					a.operation.toLowerCase().includes(lowerFilter) ||
-					a.tool_name.toLowerCase().includes(lowerFilter)
-			);
-		}
+	function toggleOp(op: FileOperation) {
+		const next = new Set(activeOps);
+		if (next.has(op)) next.delete(op);
+		else next.add(op);
+		activeOps = next;
+	}
 
-		// Apply sort
-		return [...filtered].sort((a, b) => {
-			let cmp = 0;
-			switch (sortField) {
-				case 'timestamp':
-					cmp = new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
-					break;
-				case 'path':
-					cmp = a.path.localeCompare(b.path);
-					break;
-				case 'operation':
-					cmp = a.operation.localeCompare(b.operation);
-					break;
-				case 'actor':
-					cmp = a.actor.localeCompare(b.actor);
-					break;
-			}
-			return sortOrder === 'asc' ? cmp : -cmp;
+	const filteredActivities = $derived.by(() => {
+		return activities.filter(a => {
+			const matchesOp = activeOps.size === 0 || activeOps.has(a.operation);
+			const q = filterQuery.toLowerCase();
+			const matchesQuery = !q ||
+				a.path.toLowerCase().includes(q) ||
+				a.operation.toLowerCase().includes(q) ||
+				a.actor.toLowerCase().includes(q);
+			return matchesOp && matchesQuery;
 		});
 	});
-
-	function handleSort(field: SortField) {
-		if (sortField === field) {
-			sortOrder = sortOrder === 'asc' ? 'desc' : 'asc';
-		} else {
-			sortField = field;
-			sortOrder = 'asc';
-		}
-	}
 
 	async function handleCopyPath(path: string) {
 		const success = await copyToClipboard(path);
 		if (success) {
-			toastMessage = 'Path copied to clipboard';
 			showToast = true;
-			setTimeout(() => {
-				showToast = false;
-			}, 2000);
+			setTimeout(() => { showToast = false; }, 2000);
 		}
 	}
 
 	function handleOpenInEditor(path: string) {
-		// Use VS Code protocol to open file
 		window.open(`vscode://file/${path}`, '_blank');
+	}
+
+	// Format just the time portion (HH:MM AM/PM)
+	function formatTime(ts: string): string {
+		return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 	}
 </script>
 
-<div
-	class="
-		rounded-lg border border-[var(--border)]
-		bg-[var(--bg-subtle)]
-		{className}
-	"
->
-	<!-- Header with search -->
-	<div class="border-b border-[var(--border)] p-4">
-		<div class="flex items-center gap-4">
-			<div class="relative flex-1">
-				<SearchIcon
-					class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-muted)]"
-				/>
-				<input
-					type="text"
-					placeholder="Filter by path, actor, or operation..."
-					bind:value={filterQuery}
-					class="
-						w-full rounded-md border border-[var(--border)]
-						bg-[var(--bg-base)]
-						py-2 pl-10 pr-4 text-sm
-						focus:outline-none focus:ring-2 focus:ring-[var(--accent)]
-						placeholder:text-[var(--text-faint)]
-					"
-				/>
-			</div>
-			<span class="text-sm text-[var(--text-muted)]">
-				{sortedActivities.length} operations
-			</span>
-		</div>
+<div class="flex flex-col gap-3 {className}">
+
+	<!-- Search -->
+	<div class="relative">
+		<SearchIcon class="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--text-muted)]" />
+		<input
+			type="text"
+			placeholder="Search files…"
+			bind:value={filterQuery}
+			class="w-full rounded-lg border border-[var(--border)] bg-[var(--bg-base)] py-1.5 pl-8 pr-8 text-xs focus:outline-none focus:ring-1 focus:ring-[var(--accent)] placeholder:text-[var(--text-faint)]"
+		/>
+		{#if filterQuery}
+			<button onclick={() => (filterQuery = '')} class="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-[var(--text-primary)]">
+				<X class="h-3 w-3" />
+			</button>
+		{/if}
 	</div>
 
-	<!-- Table -->
-	<div class="overflow-x-auto">
-		<table class="w-full">
-			<thead>
-				<tr class="border-b border-[var(--border)] bg-[var(--bg-muted)]/30">
-					<th
-						class="cursor-pointer px-4 py-3 text-left text-xs font-medium text-[var(--text-muted)]"
-						onclick={() => handleSort('timestamp')}
-					>
-						<div class="flex items-center gap-1">
-							Time
-							{#if sortField === 'timestamp'}
-								{#if sortOrder === 'asc'}
-									<ChevronUp class="h-4 w-4" />
-								{:else}
-									<ChevronDown class="h-4 w-4" />
-								{/if}
-							{/if}
-						</div>
-					</th>
-					<th
-						class="cursor-pointer px-4 py-3 text-left text-xs font-medium text-[var(--text-muted)]"
-						onclick={() => handleSort('operation')}
-					>
-						<div class="flex items-center gap-1">
-							Operation
-							{#if sortField === 'operation'}
-								{#if sortOrder === 'asc'}
-									<ChevronUp class="h-4 w-4" />
-								{:else}
-									<ChevronDown class="h-4 w-4" />
-								{/if}
-							{/if}
-						</div>
-					</th>
-					<th
-						class="cursor-pointer px-4 py-3 text-left text-xs font-medium text-[var(--text-muted)]"
-						onclick={() => handleSort('path')}
-					>
-						<div class="flex items-center gap-1">
-							Path
-							{#if sortField === 'path'}
-								{#if sortOrder === 'asc'}
-									<ChevronUp class="h-4 w-4" />
-								{:else}
-									<ChevronDown class="h-4 w-4" />
-								{/if}
-							{/if}
-						</div>
-					</th>
-					<th
-						class="cursor-pointer px-4 py-3 text-left text-xs font-medium text-[var(--text-muted)]"
-						onclick={() => handleSort('actor')}
-					>
-						<div class="flex items-center gap-1">
-							Actor
-							{#if sortField === 'actor'}
-								{#if sortOrder === 'asc'}
-									<ChevronUp class="h-4 w-4" />
-								{:else}
-									<ChevronDown class="h-4 w-4" />
-								{/if}
-							{/if}
-						</div>
-					</th>
-					<th class="px-4 py-3 text-left text-xs font-medium text-[var(--text-muted)]">
-						Tool
-					</th>
-					<th class="px-4 py-3 text-left text-xs font-medium text-[var(--text-muted)]">
-						Actions
-					</th>
-				</tr>
-			</thead>
-			<tbody>
-				{#each sortedActivities as activity, i}
-					{@const config = operationConfig[activity.operation] || operationConfig.read}
-					<tr
-						class="border-b border-[var(--border)] last:border-0 hover:bg-[var(--bg-muted)]/20"
-					>
-						<td
-							class="whitespace-nowrap px-4 py-3 text-xs text-[var(--text-muted)] font-mono"
-						>
-							{formatDate(activity.timestamp)}
-						</td>
-						<td class="px-4 py-3">
-							<div class="flex items-center gap-2">
-								<config.icon class="h-4 w-4 {config.color}" />
-								<span
-									class="
-										rounded-full px-2 py-0.5 text-xs capitalize
-										{config.bgColor}
-										{config.color}
-									"
-								>
-									{activity.operation}
-								</span>
-							</div>
-						</td>
-						<td class="px-4 py-3">
-							<code
-								class="
-									inline-block
-									px-2 py-1
-									font-mono text-xs
-									text-[var(--text-primary)]
-									bg-[var(--bg-muted)]
-									border border-[var(--border)]
-									rounded-md
-								"
-								title={activity.path}
-							>
-								{truncate(formatDisplayPath(activity.path, projectPath), 60)}
-							</code>
-						</td>
-						<td class="px-4 py-3">
-							<div class="flex items-center gap-1.5">
-								{#if activity.actor_type === 'subagent' && (!currentAgentId || activity.actor !== currentAgentId)}
-									{@const colorVars = getSubagentColorVars(
-										subagentTypes[activity.actor]
-									)}
-									<!-- Show subagent badge for nested subagents (not the current agent being viewed) -->
-									<BotIcon class="h-3.5 w-3.5" style="color: {colorVars.color}" />
-									<span class="text-xs" style="color: {colorVars.color}"
-										>{activity.actor}</span
-									>
-								{:else}
-									<!-- Show main/session style for current agent or main session activities -->
-									<UserIcon class="h-3.5 w-3.5 text-[var(--text-muted)]" />
-									<span class="text-xs text-[var(--text-muted)]"
-										>{activity.actor}</span
-									>
-								{/if}
-							</div>
-						</td>
-						<td class="px-4 py-3">
-							<span
-								class="rounded bg-[var(--bg-muted)] px-1.5 py-0.5 text-xs font-mono"
-							>
-								{activity.tool_name}
-							</span>
-						</td>
-						<td class="px-4 py-3">
-							<div class="flex items-center gap-1">
-								<button
-									onclick={() => handleCopyPath(activity.path)}
-									class="
-										p-1.5 rounded
-										text-[var(--text-muted)]
-										hover:text-[var(--text-primary)]
-										hover:bg-[var(--bg-muted)]
-										transition-colors
-									"
-									title="Copy path"
-								>
-									<Copy class="h-3.5 w-3.5" />
-								</button>
-								<button
-									onclick={() => handleOpenInEditor(activity.path)}
-									class="
-										p-1.5 rounded
-										text-[var(--text-muted)]
-										hover:text-[var(--text-primary)]
-										hover:bg-[var(--bg-muted)]
-										transition-colors
-									"
-									title="Open in Editor"
-								>
-									<ExternalLink class="h-3.5 w-3.5" />
-								</button>
-							</div>
-						</td>
-					</tr>
+	<!-- Operation filter chips -->
+	{#if presentOps.length > 1}
+		<div class="flex flex-wrap gap-1.5">
+			{#each presentOps as op}
+				{@const cfg = operationConfig[op]}
+				{@const count = activities.filter(a => a.operation === op).length}
+				{@const active = activeOps.has(op)}
+				<button
+					onclick={() => toggleOp(op)}
+					class="inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-all
+						{active
+							? `${cfg.bgColor} ${cfg.borderColor} ${cfg.color}`
+							: 'border-[var(--border)] bg-[var(--bg-base)] text-[var(--text-muted)] hover:border-[var(--border-hover)] hover:text-[var(--text-secondary)]'
+						}"
+				>
+					<cfg.icon class="h-3 w-3" />
+					{cfg.label}
+					<span class="font-mono opacity-60">{count}</span>
+				</button>
+			{/each}
+			{#if activeOps.size > 0}
+				<button
+					onclick={() => (activeOps = new Set())}
+					class="inline-flex items-center gap-1 rounded-full border border-[var(--border)] px-2 py-1 text-[11px] text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+				>
+					<X class="h-3 w-3" /> Clear
+				</button>
+			{/if}
+		</div>
+	{/if}
+
+	<!-- Count -->
+	<div class="flex items-center justify-between px-0.5">
+		<span class="text-[10px] uppercase tracking-wide text-[var(--text-muted)] font-medium">
+			{filteredActivities.length} {filteredActivities.length === 1 ? 'operation' : 'operations'}
+			{#if activeOps.size > 0 || filterQuery} <span class="opacity-50">filtered</span>{/if}
+		</span>
+	</div>
+
+	<!-- File list -->
+	<div class="flex flex-col rounded-lg border border-[var(--border)]/60 overflow-hidden bg-[var(--bg-base)]">
+		{#each filteredActivities as activity, i}
+			{@const cfg = operationConfig[activity.operation] || operationConfig.read}
+			{@const displayPath = formatDisplayPath(activity.path, projectPath)}
+			{@const filename = displayPath.split('/').pop() ?? displayPath}
+			{@const dirPath = displayPath.includes('/') ? displayPath.slice(0, displayPath.lastIndexOf('/')) : ''}
+			{@const isSubagent = activity.actor_type === 'subagent' && (!currentAgentId || activity.actor !== currentAgentId)}
+			{@const colorVars = isSubagent ? getSubagentColorVars(subagentTypes[activity.actor]) : null}
+
+			<div class="group flex items-stretch gap-2.5 px-3 py-2.5 {i > 0 ? 'border-t border-[var(--border)]/40' : ''} hover:bg-[var(--bg-subtle)]">
+				<!-- Op icon -->
+				<div class="mt-0.5 shrink-0 rounded-md p-1.5 self-start {cfg.bgColor}">
+					<cfg.icon class="h-3.5 w-3.5 {cfg.color}" />
+				</div>
+
+				<!-- Info (fills remaining width) -->
+				<div class="flex-1 min-w-0">
+					<span class="text-xs font-medium text-[var(--text-primary)] truncate block">{filename}</span>
+					<div class="mt-0.5 flex items-center gap-1.5 min-w-0">
+						{#if dirPath}
+							<span class="text-[10px] text-[var(--text-muted)] font-mono truncate" title={activity.path}>{dirPath}</span>
+						{/if}
+						<span class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium capitalize {cfg.bgColor} {cfg.color}">{activity.operation}</span>
+						{#if isSubagent && colorVars}
+							<BotIcon class="shrink-0 h-3 w-3" style="color: {colorVars.color}" />
+						{/if}
+					</div>
+				</div>
+
+				<!-- Right column: time top, actions bottom on hover -->
+				<div class="shrink-0 flex flex-col items-end justify-between">
+					<span class="font-mono text-[10px] text-[var(--text-muted)]">{formatTime(activity.timestamp)}</span>
+					<div class="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+						<button onclick={() => handleCopyPath(activity.path)} class="p-1 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-muted)]" title="Copy path"><Copy class="h-3 w-3" /></button>
+						<button onclick={() => handleOpenInEditor(activity.path)} class="p-1 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-muted)]" title="Open in editor"><ExternalLink class="h-3 w-3" /></button>
+					</div>
+				</div>
+			</div>
+		{:else}
+			<div class="px-3 py-10 text-center text-xs text-[var(--text-muted)]">
+				{#if activeOps.size > 0 || filterQuery}
+					No operations match your filter
 				{:else}
-					<tr>
-						<td
-							colspan="6"
-							class="px-4 py-8 text-center text-sm text-[var(--text-muted)]"
-						>
-							No file activity found
-						</td>
-					</tr>
-				{/each}
-			</tbody>
-		</table>
+					No file activity
+				{/if}
+			</div>
+		{/each}
 	</div>
 </div>
 
-<!-- Toast notification -->
 {#if showToast}
-	<div
-		class="
-			fixed bottom-4 left-1/2 -translate-x-1/2
-			px-4 py-2
-			bg-[var(--text-primary)]
-			text-[var(--bg-base)]
-			text-sm font-medium
-			rounded-lg
-			shadow-lg
-			animate-slide-up
-		"
-	>
-		{toastMessage}
+	<div class="fixed bottom-4 left-1/2 -translate-x-1/2 px-4 py-2 bg-[var(--text-primary)] text-[var(--bg-base)] text-xs font-medium rounded-lg shadow-lg">
+		Path copied
 	</div>
 {/if}

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -145,7 +145,10 @@
 								: ''}
 						>
 							{#if grpActive && activeItm}
-								<span class="group-btn-icon">
+								<span
+									class="group-btn-icon"
+									style="background-color: var(--nav-{activeItm.color}-subtle); color: var(--nav-{activeItm.color}); width: 22px; height: 22px; border-radius: 5px; display: flex; align-items: center; justify-content: center; flex-shrink: 0;"
+								>
 									<Icon name={activeItm.icon} size={14} strokeWidth={1.5} />
 								</span>
 								<span class="group-btn-label">{activeItm.label}</span>

--- a/frontend/src/lib/components/ImageAttachments.svelte
+++ b/frontend/src/lib/components/ImageAttachments.svelte
@@ -84,7 +84,7 @@
 					<img
 						src="data:{image.media_type};base64,{image.data}"
 						class="max-h-[70vh] w-auto object-contain rounded-md"
-						alt="Full size image attachment"
+						alt="Full size attachment"
 					/>
 				</div>
 				<div class="mt-3 pt-2 border-t border-[var(--border)]">

--- a/frontend/src/lib/components/charts/StackedAreaChart.svelte
+++ b/frontend/src/lib/components/charts/StackedAreaChart.svelte
@@ -1,0 +1,264 @@
+<script lang="ts">
+	import type { UsageTrendResponse } from '$lib/api-types';
+
+	type TrendRange = '7d' | '30d' | '90d';
+
+	interface GroupInfo { key: string; label: string; color: string; }
+
+	let {
+		trendData = null,
+		loading = false,
+		range = '90d' as TrendRange,
+		onRangeChange,
+		getGroupFor,
+		label = 'Invocations Over Time',
+	}: {
+		trendData: UsageTrendResponse | null;
+		loading: boolean;
+		range: TrendRange;
+		onRangeChange: (r: TrendRange) => void;
+		getGroupFor: (itemName: string) => GroupInfo | null;
+		label?: string;
+	} = $props();
+
+	// ── Bezier helpers ─────────────────────────────────────────────────────────
+	function catmullRom(pts: {x:number;y:number}[]): string {
+		if (pts.length < 2) return '';
+		let d = `M ${pts[0].x.toFixed(1)},${pts[0].y.toFixed(1)}`;
+		for (let i = 0; i < pts.length - 1; i++) {
+			const p0 = pts[Math.max(0, i - 1)];
+			const p1 = pts[i];
+			const p2 = pts[i + 1];
+			const p3 = pts[Math.min(pts.length - 1, i + 2)];
+			const cp1x = p1.x + (p2.x - p0.x) / 6;
+			const cp1y = p1.y + (p2.y - p0.y) / 6;
+			const cp2x = p2.x - (p3.x - p1.x) / 6;
+			const cp2y = p2.y - (p3.y - p1.y) / 6;
+			d += ` C ${cp1x.toFixed(1)},${cp1y.toFixed(1)} ${cp2x.toFixed(1)},${cp2y.toFixed(1)} ${p2.x.toFixed(1)},${p2.y.toFixed(1)}`;
+		}
+		return d;
+	}
+
+	function stackedPaths(topPts: {x:number;y:number}[], botPts: {x:number;y:number}[] | null, baseY: number): { line: string; area: string } {
+		const line = catmullRom(topPts);
+		if (!botPts) {
+			const last = topPts[topPts.length - 1];
+			const first = topPts[0];
+			return { line, area: `${line} L ${last.x.toFixed(1)},${baseY} L ${first.x.toFixed(1)},${baseY} Z` };
+		}
+		const revBot = [...botPts].reverse();
+		const revLine = catmullRom(revBot);
+		const revFirst = revBot[0];
+		return { line, area: `${line} L ${revFirst.x.toFixed(1)},${revFirst.y.toFixed(1)} ${revLine.replace(/^M [^C]*C/, 'C')} Z` };
+	}
+
+	// ── Chart data ─────────────────────────────────────────────────────────────
+	const cX1 = 48, cX2 = 892, cY1 = 8, cY2 = 156;
+	const cW = cX2 - cX1, cH = cY2 - cY1;
+
+	let chartData = $derived.by(() => {
+		if (!trendData?.trend_by_item || !trendData.trend.length) return null;
+		const dates = [...trendData.trend]
+			.sort((a, b) => a.date.localeCompare(b.date))
+			.map(p => p.date);
+
+		// Group items into layers
+		const groupMap = new Map<string, { label: string; color: string; counts: number[] }>();
+		for (const [itemName, pts] of Object.entries(trendData.trend_by_item)) {
+			const g = getGroupFor(itemName);
+			if (!g) continue;
+			if (!groupMap.has(g.key)) groupMap.set(g.key, { label: g.label, color: g.color, counts: new Array(dates.length).fill(0) });
+			const ptMap = new Map(pts.map(p => [p.date, p.count]));
+			const entry = groupMap.get(g.key)!;
+			dates.forEach((d, i) => { entry.counts[i] += ptMap.get(d) ?? 0; });
+		}
+
+		const groups = [...groupMap.values()].sort((a, b) =>
+			b.counts.reduce((s, v) => s + v, 0) - a.counts.reduce((s, v) => s + v, 0)
+		);
+		if (!groups.length) return null;
+
+		const dailyTotals = dates.map((_, i) => groups.reduce((s, g) => s + g.counts[i], 0));
+		const yMax = Math.max(...dailyTotals, 1);
+		const xi = (i: number) => cX1 + (i / Math.max(dates.length - 1, 1)) * cW;
+		const yv = (v: number) => cY2 - (v / yMax) * cH;
+
+		const cumulative = new Array(dates.length).fill(0);
+		const layers = groups.map((g, idx) => {
+			const prevCum = [...cumulative];
+			dates.forEach((_, i) => { cumulative[i] += g.counts[i]; });
+			const topPts = dates.map((_, i) => ({ x: xi(i), y: yv(cumulative[i]) }));
+			const botPts = idx === 0 ? null : dates.map((_, i) => ({ x: xi(i), y: yv(prevCum[i]) }));
+			const { line, area } = stackedPaths(topPts, botPts, cY2);
+			return { ...g, topPts, line, area, gradId: `sc${idx}` };
+		});
+
+		const peakIdx = dailyTotals.reduce((mi, v, i) => v > dailyTotals[mi] ? i : mi, 0);
+		const totalInv = dailyTotals.reduce((s, v) => s + v, 0);
+		const xIdxs = dates.length <= 7 ? dates.map((_, i) => i)
+			: [0, Math.floor(dates.length * 0.25), Math.floor(dates.length * 0.5), Math.floor(dates.length * 0.75), dates.length - 1];
+		const fmt = (d: string) => new Date(d + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+
+		return {
+			layers, groups, dates, dailyTotals,
+			peakX: xi(peakIdx), peakY: yv(dailyTotals[peakIdx]),
+			peakVal: dailyTotals[peakIdx], peakDate: fmt(dates[peakIdx]),
+			totalInv, avgPerDay: (totalInv / dates.length).toFixed(1),
+			yTicks: [1, 0.67, 0.33, 0].map(f => ({ y: cY2 - f * cH, val: Math.round(yMax * f) })),
+			xLabels: xIdxs.map(i => ({
+				x: xi(i), label: fmt(dates[i]),
+				anchor: (i === 0 ? 'start' : i === dates.length - 1 ? 'end' : 'middle') as 'start' | 'end' | 'middle'
+			})),
+			xi
+		};
+	});
+
+	// ── Tooltip state ──────────────────────────────────────────────────────────
+	let hoverIdx = $state<number | null>(null);
+	let svgEl = $state<SVGSVGElement | null>(null);
+
+	function onMouseMove(e: MouseEvent) {
+		if (!chartData || !svgEl) return;
+		const rect = svgEl.getBoundingClientRect();
+		const mx = (e.clientX - rect.left) * (900 / rect.width);
+		if (mx < cX1 - 10 || mx > cX2 + 10) { hoverIdx = null; return; }
+		let best = 0, bestDist = Infinity;
+		chartData.dates.forEach((_, i) => { const d = Math.abs(chartData!.xi(i) - mx); if (d < bestDist) { bestDist = d; best = i; } });
+		hoverIdx = best;
+	}
+
+	let tooltip = $derived.by(() => {
+		if (hoverIdx === null || !chartData) return null;
+		const i = hoverIdx;
+		const date = new Date(chartData.dates[i] + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+		const rows = chartData.layers.filter(l => l.counts[i] > 0).map(l => ({ label: l.label, count: l.counts[i], color: l.color })).sort((a, b) => b.count - a.count);
+		return { date, total: chartData.dailyTotals[i], rows, svgX: chartData.xi(i) };
+	});
+</script>
+
+<!-- Chart card -->
+<div class="rounded-lg" style="padding: 16px 18px; background: var(--bg-base); border: 1px solid var(--border);">
+	<!-- Header -->
+	<div class="flex items-start justify-between" style="margin-bottom: 12px;">
+		<div>
+			<div style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace; margin-bottom: 5px;">{label}</div>
+			{#if chartData}
+				<div class="flex items-center gap-4">
+					<span style="font-size: 11px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace;"><span style="font-weight: 700; color: var(--text-primary);">{chartData.totalInv}</span> total</span>
+					<span style="font-size: 11px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace;"><span style="font-weight: 700; color: var(--text-primary);">{chartData.avgPerDay}</span>/day avg</span>
+					<span style="font-size: 11px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace;">peak <span style="font-weight: 700; color: var(--text-primary);">{chartData.peakVal}</span> on {chartData.peakDate}</span>
+				</div>
+			{/if}
+		</div>
+		<div class="flex items-center gap-3">
+			{#if chartData}
+				<div class="flex items-center gap-2">
+					{#each chartData.groups.slice(0, 4) as g}
+						<div class="flex items-center gap-1.5">
+							<div style="width: 8px; height: 8px; border-radius: 2px; background: {g.color}; flex-shrink: 0;"></div>
+							<span style="font-size: 10px; color: var(--text-faint);">{g.label.length > 12 ? g.label.slice(0, 11) + '…' : g.label}</span>
+						</div>
+					{/each}
+					{#if chartData.groups.length > 4}
+						<span style="font-size: 10px; color: var(--text-faint);">+{chartData.groups.length - 4} more</span>
+					{/if}
+				</div>
+			{/if}
+			<div class="flex overflow-hidden rounded" style="border: 1px solid var(--border);">
+				{#each (['7d', '30d', '90d'] as const) as r}
+					<button
+						onclick={() => onRangeChange(r)}
+						style="padding: 4px 10px; font-size: 11px; font-weight: {range === r ? '700' : '500'}; font-family: 'JetBrains Mono', monospace; background: {range === r ? 'var(--accent-muted)' : 'var(--bg-subtle)'}; color: {range === r ? 'var(--accent)' : 'var(--text-faint)'}; {r !== '90d' ? 'border-right: 1px solid var(--border);' : ''}"
+					>{r}</button>
+				{/each}
+			</div>
+		</div>
+	</div>
+
+	<!-- SVG -->
+	{#if loading && !trendData}
+		<div style="height: 188px; display: flex; align-items: center; justify-content: center;">
+			<div style="width: 18px; height: 18px; border: 2px solid var(--accent); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
+		</div>
+	{:else if !chartData}
+		<div style="height: 188px; display: flex; align-items: center; justify-content: center; color: var(--text-faint); font-size: 13px;">No data for this period</div>
+	{:else}
+		<div style="position: relative;">
+			<svg
+				bind:this={svgEl}
+				viewBox="0 0 900 188"
+				style="width: 100%; height: 188px; display: block; overflow: visible; cursor: crosshair;"
+				onmousemove={onMouseMove}
+				onmouseleave={() => hoverIdx = null}
+			>
+				<defs>
+					{#each chartData.layers as layer}
+						<linearGradient id={layer.gradId} x1="0" y1="0" x2="0" y2="1">
+							<stop offset="0%" stop-color={layer.color} stop-opacity="0.22" />
+							<stop offset="100%" stop-color={layer.color} stop-opacity="0.03" />
+						</linearGradient>
+					{/each}
+				</defs>
+
+				{#each chartData.yTicks as tick}
+					<line x1={cX1} y1={tick.y} x2={cX2} y2={tick.y} stroke="var(--border)" stroke-width="0.5" />
+					<text x={cX1 - 5} y={tick.y + 3} text-anchor="end" font-size="9" fill="var(--text-faint)" font-family="JetBrains Mono, monospace">{tick.val}</text>
+				{/each}
+				<line x1={cX1} y1={cY2} x2={cX2} y2={cY2} stroke="var(--border)" stroke-width="1" />
+
+				{#each chartData.layers as layer}
+					<path d={layer.area} fill="url(#{layer.gradId})" />
+				{/each}
+				{#each chartData.layers as layer, i}
+					<path d={layer.line} fill="none" stroke={layer.color}
+						stroke-width={i === chartData.layers.length - 1 ? 2 : 1.5}
+						stroke-opacity={i === 0 ? 0.5 : 0.8}
+						stroke-dasharray={i === 0 ? '3 3' : 'none'}
+					/>
+				{/each}
+
+				{#if hoverIdx !== null}
+					{@const hx = chartData.xi(hoverIdx)}
+					<line x1={hx} y1={cY1} x2={hx} y2={cY2} stroke="var(--text-faint)" stroke-width="1" stroke-dasharray="3 2" opacity="0.6" />
+					{#each chartData.layers as layer}
+						{#if layer.counts[hoverIdx] > 0}
+							<circle cx={hx} cy={layer.topPts[hoverIdx].y} r="3.5" fill={layer.color} stroke="var(--bg-base)" stroke-width="1.5" />
+						{/if}
+					{/each}
+				{/if}
+
+				<circle cx={chartData.peakX} cy={chartData.peakY} r="4" fill="var(--accent)" stroke="var(--bg-base)" stroke-width="2" />
+				<text x={chartData.peakX} y={chartData.peakY - 10} text-anchor="middle" font-size="10" fill="var(--accent)" font-family="JetBrains Mono, monospace" font-weight="bold">peak · {chartData.peakVal}</text>
+
+				{#each chartData.xLabels as xl}
+					<text x={xl.x} y="184" text-anchor={xl.anchor} font-size="9" fill="var(--text-faint)" font-family="JetBrains Mono, monospace">{xl.label}</text>
+				{/each}
+			</svg>
+
+			{#if tooltip && hoverIdx !== null}
+				{@const svgWidth = svgEl?.getBoundingClientRect().width ?? 900}
+				{@const tipX = (tooltip.svgX / 900) * svgWidth}
+				{@const flip = tipX > svgWidth * 0.65}
+				<div style="position: absolute; top: 0; left: {tipX}px; transform: translate({flip ? 'calc(-100% - 10px)' : '10px'}, 4px); pointer-events: none; z-index: 20; background: var(--bg-base); border: 1px solid var(--border); border-radius: 8px; padding: 9px 12px; min-width: 150px; box-shadow: 0 4px 16px rgba(0,0,0,0.18);">
+					<div class="flex items-baseline justify-between gap-4" style="margin-bottom: 7px;">
+						<span style="font-size: 11px; font-weight: 700; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;">{tooltip.date}</span>
+						<span style="font-size: 11px; font-weight: 700; color: var(--accent); font-family: 'JetBrains Mono', monospace;">{tooltip.total}</span>
+					</div>
+					{#if tooltip.rows.length > 0}
+						<div style="border-top: 1px solid var(--border-subtle); padding-top: 6px; display: flex; flex-direction: column; gap: 4px;">
+							{#each tooltip.rows as row}
+								<div class="flex items-center justify-between gap-3">
+									<div class="flex items-center gap-1.5 min-w-0">
+										<div style="width: 7px; height: 7px; border-radius: 2px; background: {row.color}; flex-shrink: 0;"></div>
+										<span class="truncate" style="font-size: 10px; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace;" title={row.label}>{row.label.length > 16 ? row.label.slice(0, 15) + '…' : row.label}</span>
+									</div>
+									<span style="font-size: 10px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace; flex-shrink: 0;">{row.count}</span>
+								</div>
+							{/each}
+						</div>
+					{/if}
+				</div>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/commands/CommandsPanel.svelte
+++ b/frontend/src/lib/components/commands/CommandsPanel.svelte
@@ -158,65 +158,40 @@
 	}
 </script>
 
-<div class="space-y-4">
-	<div>
-		<h2 class="text-lg font-semibold text-[var(--text-primary)]">
-			Commands ({commands.length})
-		</h2>
-		<p class="text-sm text-[var(--text-muted)]">Slash commands invoked during this session</p>
-	</div>
+<div class="flex flex-col gap-2">
+	<span class="text-[10px] uppercase tracking-wide font-medium text-[var(--text-muted)]">
+		{sortedCommands.length} command{sortedCommands.length !== 1 ? 's' : ''}
+	</span>
 
 	{#if sortedCommands.length > 0}
-		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-			{#each sortedCommands as command (command.name)}
+		<div class="flex flex-col rounded-lg border border-[var(--border)]/60 overflow-hidden bg-[var(--bg-base)]">
+			{#each sortedCommands as command, i (command.name)}
 				{@const cmdColors = getCommandColors(command)}
 				{@const Icon = isPluginCommand(command) ? Zap : TerminalSquare}
 				{@const isClickable = !isBuiltinCommand(command)}
+				{@const displayName = isPluginCommand(command) ? cleanSkillName(command.name, true) : command.name}
 
 				<button
 					onclick={() => openCommand(command)}
 					disabled={!isClickable}
-					class="group flex items-start gap-4 p-4 bg-[var(--bg-base)] border border-[var(--border)] rounded-xl transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 text-left {isClickable
-						? 'cursor-pointer hover:border-[var(--accent)]/50 hover:shadow-sm'
-						: 'cursor-default opacity-75'}"
+					class="group flex items-center gap-2.5 px-3 py-2.5 text-left hover:bg-[var(--bg-subtle)] transition-colors {i > 0 ? 'border-t border-[var(--border)]/40' : ''} {isClickable ? 'cursor-pointer' : 'cursor-default'}"
 				>
-					<div
-						class="p-2.5 rounded-lg shrink-0 transition-colors"
-						style="background-color: {cmdColors.subtle}; color: {cmdColors.color};"
+					<span
+						class="shrink-0 flex items-center justify-center w-6 h-6 rounded-md"
+						style="background: {cmdColors.subtle}; color: {cmdColors.color};"
 					>
-						<Icon size={20} />
-					</div>
+						<Icon size={13} strokeWidth={2} />
+					</span>
 
-					<div class="min-w-0 flex-1">
-						<div class="flex items-center gap-2">
-							<span
-								class="font-medium text-[var(--text-primary)] truncate"
-								title={command.name}
-							>
-								/{isPluginCommand(command)
-									? cleanSkillName(command.name, true)
-									: command.name}
-							</span>
-						</div>
-						<div class="flex items-center gap-2 text-xs text-[var(--text-muted)] mt-1">
-							<span
-								class="px-1.5 py-0.5 rounded text-[10px] uppercase font-medium"
-								style="background-color: {cmdColors.subtle}; color: {cmdColors.color};"
-							>
-								{getBadgeLabel(command)}
-							</span>
-							{#if command.plugin}
-								<span class="text-[var(--text-faint)]">{command.plugin}</span>
-							{/if}
+					<div class="flex-1 min-w-0">
+						<span class="text-xs font-medium text-[var(--text-primary)] truncate block" title={command.name}>/{displayName}</span>
+						<div class="flex items-center gap-1 mt-0.5">
+							<span class="text-[10px] font-medium px-1 py-px rounded" style="background: {cmdColors.subtle}; color: {cmdColors.color};">{getBadgeLabel(command)}</span>
+							{#if command.plugin}<span class="text-[10px] text-[var(--text-faint)] truncate">{command.plugin}</span>{/if}
 						</div>
 					</div>
 
-					<div
-						class="shrink-0 px-2.5 py-1 rounded-full text-xs font-medium"
-						style="background-color: {cmdColors.subtle}; color: {cmdColors.color};"
-					>
-						{command.count}x
-					</div>
+					<span class="shrink-0 font-mono text-[11px] font-semibold" style="color: {cmdColors.color};">{command.count}×</span>
 				</button>
 			{/each}
 		</div>

--- a/frontend/src/lib/components/conversation/ConversationOverview.svelte
+++ b/frontend/src/lib/components/conversation/ConversationOverview.svelte
@@ -84,8 +84,20 @@
 	});
 </script>
 
-<div class="space-y-6 animate-fade-in">
-	<!-- Initial Prompt -->
+<div class="flex flex-col gap-3 animate-fade-in">
+
+	<!-- Branch (Messages/Duration/Model removed — already in session hero) -->
+	{#if entity.git_branches?.length}
+		<div class="flex items-center gap-2.5 rounded-lg px-3 py-2.5 bg-[var(--bg-base)] border border-[var(--border)]/60">
+			<GitBranch size={14} strokeWidth={2} class="text-violet-400 shrink-0" />
+			<div class="min-w-0 overflow-hidden">
+				<div class="text-[10px] uppercase tracking-wide text-[var(--text-muted)] leading-none mb-0.5">Branch</div>
+				<div class="text-xs font-medium text-[var(--text-primary)] truncate">{entity.git_branches[0]}</div>
+			</div>
+		</div>
+	{/if}
+
+	<!-- ── Initial Prompt ── -->
 	{#if entity.initial_prompt}
 		<ExpandablePrompt
 			prompt={entity.initial_prompt}
@@ -93,406 +105,117 @@
 		/>
 	{/if}
 
-	<!-- Continuation Session Indicator (sessions only) -->
+	<!-- ── Continuation marker ── -->
 	{#if isMainSession(entity) && entity.is_continuation_marker}
-		<div
-			class="
-				p-4 pl-5
-				bg-[var(--nav-gray-subtle)]
-				border border-[var(--nav-gray)]/30
-				border-l-[3px] border-l-[var(--nav-gray)]
-				rounded-lg
-			"
-		>
-			<div class="flex items-center gap-3">
-				<div class="p-2 rounded-lg bg-[var(--nav-gray)]/10">
-					<Activity size={20} strokeWidth={2} class="text-[var(--nav-gray)]" />
-				</div>
-				<div>
-					<h3 class="text-sm font-medium text-[var(--text-primary)]">
-						Session Continuation Marker
-					</h3>
-					<p class="text-xs text-[var(--text-muted)] mt-0.5">
-						This session was continued in a new session. This file contains {entity.file_snapshot_count ||
-							0} file backup checkpoints tracking file changes for undo/redo functionality.
-					</p>
-				</div>
+		<div class="rounded-lg border-l-2 border-l-[var(--nav-gray)] border border-[var(--nav-gray)]/20 bg-[var(--nav-gray-subtle)] px-3 py-2.5">
+			<div class="flex items-center gap-2 mb-1">
+				<Activity size={13} strokeWidth={2} class="text-[var(--nav-gray)]" />
+				<span class="text-xs font-medium text-[var(--text-primary)]">Continuation Marker</span>
 			</div>
-			{#if entity.message_type_breakdown}
-				<div class="mt-3 flex items-center gap-4 text-xs text-[var(--text-muted)]">
-					<span
-						>Snapshots: <span class="font-mono text-[var(--text-secondary)]"
-							>{entity.message_type_breakdown.file_history_snapshot || 0}</span
-						></span
-					>
-					<span
-						>Summaries: <span class="font-mono text-[var(--text-secondary)]"
-							>{entity.message_type_breakdown.summary || 0}</span
-						></span
-					>
-				</div>
-			{/if}
-
-			<!-- View Continuation Link -->
-			{#if continuationLoading}
-				<div class="mt-3 text-xs text-[var(--text-muted)]">
-					Loading continuation session...
-				</div>
-			{:else if continuationSession}
-				<!-- Always use UUID for continuation links - they share slugs with parent session -->
+			<p class="text-xs text-[var(--text-muted)]">{entity.file_snapshot_count || 0} file checkpoints</p>
+			{#if continuationSession}
 				<a
-					href={projectHrefFromSession(
-						continuationSession,
-						`/${continuationSession.session_uuid.slice(0, 8)}`
-					)}
-					class="
-						mt-3 inline-flex items-center gap-1.5
-						px-3 py-1.5
-						text-xs font-medium
-						rounded-md border
-						bg-[var(--accent-subtle)] border-[var(--accent)]/40 text-[var(--accent)]
-						hover:bg-[var(--accent)]/20 hover:border-[var(--accent)]/60
-						transition-colors
-					"
+					href={projectHrefFromSession(continuationSession, `/${continuationSession.session_uuid.slice(0, 8)}`)}
+					class="mt-2 inline-flex items-center gap-1 text-xs font-medium text-[var(--accent)] hover:underline"
 				>
-					<ExternalLink size={14} strokeWidth={2} />
-					View Continuation Session
+					<ExternalLink size={12} strokeWidth={2} /> View continuation
 				</a>
-			{:else if continuationError}
-				<div class="mt-3 text-xs text-[var(--text-muted)] italic">
-					Could not find the continuation session
-				</div>
 			{/if}
 		</div>
 	{/if}
 
-	<!-- Project Context (sessions only - summaries from PREVIOUS sessions) -->
+	<!-- ── Project Context ── -->
 	{#if isMainSession(entity) && entity.project_context_summaries && entity.project_context_summaries.length > 0}
 		{@const needsExpansion = entity.project_context_summaries.length > MAX_CONTEXT_PREVIEW}
-		{@const displayedSummaries = isContextExpanded
-			? entity.project_context_summaries
-			: entity.project_context_summaries.slice(0, MAX_CONTEXT_PREVIEW)}
-		<div
-			class="
-				p-4 pl-5
-				bg-[var(--bg-subtle)]
-				border border-[var(--border)]
-				border-l-[3px] border-l-[var(--accent)]
-				rounded-lg
-			"
-		>
+		{@const displayedSummaries = isContextExpanded ? entity.project_context_summaries : entity.project_context_summaries.slice(0, MAX_CONTEXT_PREVIEW)}
+		<div class="rounded-lg border-l-2 border-l-[var(--accent)] border border-[var(--border)]/60 bg-[var(--bg-base)] px-3 py-2.5">
 			<div class="flex items-center gap-2 mb-2">
-				<div class="p-1.5 rounded-md bg-[var(--accent)]/10">
-					<Sparkles size={14} strokeWidth={2} class="text-[var(--accent)]" />
-				</div>
-				<h3 class="text-sm font-medium text-[var(--text-primary)]">Project Context</h3>
-				<span class="text-xs text-[var(--text-muted)]"> (from previous sessions) </span>
-				{#if needsExpansion}
-					<span class="text-xs text-[var(--text-muted)]">
-						&middot; {entity.project_context_summaries.length} summaries
-					</span>
-				{/if}
+				<Sparkles size={13} strokeWidth={2} class="text-[var(--accent)]" />
+				<span class="text-xs font-medium text-[var(--text-primary)]">Project Context</span>
+				<span class="text-[10px] text-[var(--text-muted)] ml-auto">{entity.project_context_summaries.length} summaries</span>
 			</div>
-
-			<Collapsible.Root open={isContextExpanded}>
-				<div class="space-y-1.5">
-					{#each displayedSummaries as summary, i}
-						<p
-							class="text-sm text-[var(--text-secondary)] leading-relaxed {i === 0
-								? ''
-								: 'border-t border-[var(--border)]/50 pt-1.5'}"
-						>
-							{summary}
-						</p>
-					{/each}
-				</div>
-			</Collapsible.Root>
-
+			<div class="space-y-1.5">
+				{#each displayedSummaries as summary, i}
+					<p class="text-xs text-[var(--text-secondary)] leading-relaxed {i > 0 ? 'border-t border-[var(--border)]/40 pt-1.5' : ''}">{summary}</p>
+				{/each}
+			</div>
 			{#if needsExpansion}
-				<div class="flex justify-center mt-3">
-					<button
-						onclick={() => (isContextExpanded = !isContextExpanded)}
-						class="
-							p-1.5
-							text-[var(--accent)]
-							hover:bg-[var(--accent-subtle)]
-							rounded-full
-							transition-colors
-							focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)]
-						"
-						aria-expanded={isContextExpanded}
-						aria-label={isContextExpanded ? 'Collapse context' : 'Expand context'}
-					>
-						{#if isContextExpanded}
-							<ChevronUp size={18} strokeWidth={2.5} />
-						{:else}
-							<ChevronDown size={18} strokeWidth={2.5} />
-						{/if}
-					</button>
-				</div>
+				<button onclick={() => (isContextExpanded = !isContextExpanded)} class="mt-2 text-xs text-[var(--accent)] hover:underline flex items-center gap-1">
+					{#if isContextExpanded}<ChevronUp size={12} /> Less{:else}<ChevronDown size={12} /> {entity.project_context_summaries.length - MAX_CONTEXT_PREVIEW} more{/if}
+				</button>
 			{/if}
 		</div>
 	{/if}
 
-	<!-- Additional Session Titles (only show if there are multiple titles beyond the header) -->
-	{#if isMainSession(entity) && entity.session_titles && entity.session_titles.length > 1}
-		<div
-			class="
-				p-4 pl-5
-				bg-[var(--nav-teal-subtle)]
-				border border-[var(--nav-teal)]/30
-				border-l-[3px] border-l-[var(--nav-teal)]
-				rounded-lg
-			"
-		>
-			<div class="flex items-center gap-2 mb-2">
-				<div class="p-1.5 rounded-md bg-[var(--nav-teal)]/10">
-					<Tag size={14} strokeWidth={2} class="text-[var(--nav-teal)]" />
-				</div>
-				<h3 class="text-sm font-medium text-[var(--text-primary)]">
-					Additional Titles ({entity.session_titles.length - 1})
-				</h3>
+	<!-- ── Compaction ── -->
+	{#if isMainSession(entity) && entity.was_compacted}
+		{@const compactionEvents = entity.compaction_summaries || []}
+		<div class="rounded-lg border-l-2 border-l-[var(--nav-orange)] border border-[var(--nav-orange)]/20 bg-[var(--nav-orange-subtle)] px-3 py-2.5">
+			<div class="flex items-center gap-2 mb-1.5">
+				<Zap size={13} strokeWidth={2} class="text-[var(--nav-orange)]" />
+				<span class="text-xs font-medium text-[var(--text-primary)]">Context Compacted</span>
+				<span class="text-[10px] text-[var(--text-muted)] ml-auto">{entity.compaction_summary_count || 1}×</span>
 			</div>
-			<div class="space-y-1.5">
-				{#each entity.session_titles.slice(1) as title}
-					<p class="text-sm text-[var(--text-secondary)] leading-relaxed">
-						{title}
+			{#each compactionEvents as event, i}
+				<div class="{i > 0 ? 'border-t border-[var(--nav-orange)]/20 pt-2 mt-2' : ''}">
+					{#if typeof event === 'object' && event.pre_tokens}
+						<span class="text-[10px] text-[var(--text-muted)]">{formatTokens(event.pre_tokens)} tokens</span>
+					{/if}
+					<p class="text-xs text-[var(--text-secondary)] leading-relaxed mt-0.5">
+						{typeof event === 'string' ? event : event.summary || ''}
 					</p>
+				</div>
+			{/each}
+		</div>
+	{/if}
+
+	<!-- ── Additional Titles ── -->
+	{#if isMainSession(entity) && entity.session_titles && entity.session_titles.length > 1}
+		<div class="rounded-lg border-l-2 border-l-[var(--nav-teal)] border border-[var(--nav-teal)]/20 bg-[var(--nav-teal-subtle)] px-3 py-2.5">
+			<div class="flex items-center gap-2 mb-1.5">
+				<Tag size={13} strokeWidth={2} class="text-[var(--nav-teal)]" />
+				<span class="text-xs font-medium text-[var(--text-primary)]">Titles ({entity.session_titles.length - 1})</span>
+			</div>
+			<div class="space-y-1">
+				{#each entity.session_titles.slice(1) as title}
+					<p class="text-xs text-[var(--text-secondary)]">{title}</p>
 				{/each}
 			</div>
 		</div>
 	{/if}
 
-	<!-- Session Compaction Indicator (sessions only - TRUE compaction events) -->
-	{#if isMainSession(entity) && entity.was_compacted}
-		{@const compactionEvents = entity.compaction_summaries || []}
-		{@const hasEvents = compactionEvents.length > 0}
-		<div
-			class="
-				p-4 pl-5
-				bg-[var(--nav-orange-subtle)]
-				border border-[var(--nav-orange)]/30
-				border-l-[3px] border-l-[var(--nav-orange)]
-				rounded-lg
-			"
-		>
-			<div class="flex items-center gap-2 mb-2">
-				<div class="p-1.5 rounded-md bg-[var(--nav-orange)]/10">
-					<Zap size={14} strokeWidth={2} class="text-[var(--nav-orange)]" />
-				</div>
-				<h3 class="text-sm font-medium text-[var(--text-primary)]">Context Compacted</h3>
-				<span class="text-xs text-[var(--text-muted)]">
-					({entity.compaction_summary_count || 1} time{(entity.compaction_summary_count ||
-						1) > 1
-						? 's'
-						: ''})
-				</span>
-			</div>
-
-			{#if hasEvents}
-				<div class="space-y-3">
-					{#each compactionEvents as event, i}
-						<div
-							class="flex flex-col gap-1.5 {i > 0
-								? 'border-t border-[var(--nav-orange)]/20 pt-3'
-								: ''}"
-						>
-							<!-- Compaction metadata -->
-							<div class="flex items-center gap-3 text-xs">
-								<span class="text-[var(--nav-orange)]/60 shrink-0">#{i + 1}</span>
-								{#if typeof event === 'object' && event.trigger}
-									<span
-										class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-[var(--nav-orange)]/10 text-[var(--nav-orange)]"
-									>
-										{#if event.trigger === 'auto'}
-											<Zap size={10} />
-											Auto
-										{:else}
-											Manual
-										{/if}
-									</span>
-								{/if}
-								{#if typeof event === 'object' && event.pre_tokens}
-									<span class="text-[var(--text-muted)]">
-										{formatTokens(event.pre_tokens)} tokens before
-									</span>
-								{/if}
-							</div>
-							<!-- Summary text -->
-							{#if typeof event === 'string'}
-								<p class="text-sm text-[var(--text-secondary)] leading-relaxed">
-									{event}
-								</p>
-							{:else if event.summary}
-								<p class="text-sm text-[var(--text-secondary)] leading-relaxed">
-									{event.summary}
-								</p>
-							{/if}
-						</div>
-					{/each}
-				</div>
-			{:else}
-				<p class="text-sm text-[var(--text-muted)] italic">
-					Context was compacted to manage conversation length
-				</p>
-			{/if}
-		</div>
-	{/if}
-
-	<!-- Session Chain View (shows related sessions) -->
+	<!-- ── Session Chain ── -->
 	{#if sessionChain && sessionChain.total_sessions > 1}
 		<SessionChainView chain={sessionChain} {projectEncoded} />
 	{/if}
 
-	<!-- Info Cards Grid -->
-	<div class="grid grid-cols-2 md:grid-cols-4 gap-3">
-		<!-- Messages Card -->
-		<StatsCard
-			title="Messages"
-			value={entity.message_count}
-			icon={MessageSquare}
-			color="blue"
-		/>
-
-		<!-- Duration Card -->
-		<StatsCard
-			title="Duration"
-			value={formatDuration(entity.duration_seconds)}
-			icon={Clock}
-			color="orange"
-		/>
-
-		<!-- Session: Model Card / Agent: Tool Calls Card -->
-		{#if isMainSession(entity)}
-			<div
-				class="p-4 bg-[var(--bg-subtle)] border border-[var(--border)] rounded-lg hover-lift"
-			>
-				<div class="text-[11px] uppercase tracking-wide text-[var(--text-muted)] mb-2">
-					Model
-				</div>
-				<div class="flex items-center gap-2 flex-wrap">
-					{#if entity.models_used?.length}
-						{#each entity.models_used as model}
-							<ModelBadge modelName={model} />
-						{/each}
-					{:else}
-						<span class="text-sm text-[var(--text-muted)]">-</span>
-					{/if}
-					{#if entity.session_source === 'desktop'}
-						<div
-							class="flex items-center gap-1 px-2 py-0.5 rounded-full border bg-[var(--bg-muted)] text-[var(--text-secondary)] border-[var(--border)] text-xs"
-							title="Claude Desktop session"
-						>
-							<Monitor size={12} strokeWidth={2} />
-							<span class="font-medium">Desktop</span>
-						</div>
-					{/if}
-				</div>
-			</div>
-		{:else}
-			<StatsCard title="Tool Calls" value={totalToolCalls} icon={Wrench} color="green" />
-		{/if}
-
-		<!-- Git Branch Card -->
-		<div class="p-4 bg-[var(--bg-subtle)] border border-[var(--border)] rounded-lg hover-lift">
-			<div class="text-[11px] uppercase tracking-wide text-[var(--text-muted)] mb-2">
-				Git Branch
-			</div>
-			<div class="flex items-center gap-2 flex-wrap">
-				{#if entity.git_branches?.length}
-					{#each entity.git_branches as branch}
-						<span
-							class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md border bg-[var(--nav-purple-subtle)] text-[var(--nav-purple)] border-[var(--nav-purple)]/40"
-						>
-							<GitBranch size={14} />
-							{branch}
-						</span>
-					{/each}
-				{:else}
-					<span class="text-sm text-[var(--text-muted)]">-</span>
-				{/if}
-			</div>
-		</div>
-	</div>
-
-	<!-- Working Directories -->
+	<!-- ── Working Directories ── -->
 	{#if entity.working_directories?.length}
-		<div
-			class="
-				p-4 pl-5
-				bg-[var(--bg-subtle)]
-				border border-[var(--border)]
-				border-l-[3px] border-l-[var(--nav-teal)]
-				rounded-lg
-				w-full
-			"
-		>
-			<div class="flex items-center gap-2 mb-3">
-				<div class="p-1.5 rounded-md bg-[var(--nav-teal-subtle)]">
-					<Folder size={14} strokeWidth={2} class="text-[var(--nav-teal)]" />
-				</div>
-				<h3 class="text-sm font-medium text-[var(--text-primary)]">Working Directories</h3>
+		<div class="rounded-lg border border-[var(--border)]/60 bg-[var(--bg-base)] px-3 py-2.5">
+			<div class="flex items-center gap-2 mb-2">
+				<Folder size={13} strokeWidth={2} class="text-[var(--nav-teal)]" />
+				<span class="text-xs font-medium text-[var(--text-primary)]">Working Directories</span>
 			</div>
-			<div class="space-y-1.5">
+			<div class="space-y-1">
 				{#each entity.working_directories as dir}
-					<div
-						class="
-							flex items-center gap-2
-							px-2.5 py-1.5
-							bg-[var(--bg-muted)]
-							rounded-md
-							group
-						"
-					>
-						<span class="text-[var(--nav-teal)]/60 text-xs">></span>
-						<p
-							class="font-mono text-xs text-[var(--text-secondary)] group-hover:text-[var(--text-primary)] transition-colors break-all"
-							title={dir}
-						>
-							{dir}
-						</p>
-					</div>
+					<p class="font-mono text-[11px] text-[var(--text-secondary)] break-all leading-relaxed" title={dir}>{dir}</p>
 				{/each}
 			</div>
 		</div>
 	{/if}
 
-	<!-- Tools Summary -->
+	<!-- ── Tools Summary ── -->
 	{#if toolsArray.length > 0}
-		<div
-			class="
-				p-4 pl-5
-				bg-[var(--bg-subtle)]
-				border border-[var(--border)]
-				border-l-[3px] border-l-[var(--nav-green)]
-				rounded-lg
-			"
-		>
-			<div class="flex items-center gap-2 mb-3">
-				<div class="p-1.5 rounded-md bg-[var(--nav-green-subtle)]">
-					<Wrench size={14} strokeWidth={2} class="text-[var(--nav-green)]" />
-				</div>
-				<h3 class="text-sm font-medium text-[var(--text-primary)]">
-					Tools Used
-					<span class="ml-1.5 text-xs font-normal text-[var(--text-muted)]">
-						({totalToolCalls} calls)
-					</span>
-				</h3>
+		<div class="rounded-lg border border-[var(--border)]/60 bg-[var(--bg-base)] px-3 py-2.5">
+			<div class="flex items-center gap-2 mb-2">
+				<Wrench size={13} strokeWidth={2} class="text-[var(--nav-green)]" />
+				<span class="text-xs font-medium text-[var(--text-primary)]">Tools Used</span>
+				<span class="text-[10px] text-[var(--text-muted)] ml-auto">{totalToolCalls} calls</span>
 			</div>
-			<div class="flex flex-wrap gap-2">
+			<div class="flex flex-wrap gap-1.5">
 				{#each toolsArray.toSorted((a, b) => b.count - a.count) as tool}
-					<span
-						class="
-							inline-flex items-center gap-1.5
-							px-2.5 py-1.5 text-xs font-medium
-							rounded-md border
-							bg-[var(--bg-muted)] border-[var(--border)]
-							hover:border-[var(--nav-green)]/40 hover:bg-[var(--nav-green-subtle)]
-							transition-colors
-						"
-					>
-						<span class="text-[var(--text-primary)]">{tool.tool_name}</span>
-						<span class="text-[var(--nav-green)] font-semibold">x{tool.count}</span>
+					<span class="inline-flex items-center gap-1 px-2 py-1 text-[11px] font-medium rounded-md border bg-[var(--bg-subtle)] border-[var(--border)]/60 text-[var(--text-primary)]">
+						{tool.tool_name}<span class="text-[var(--nav-green)] font-semibold">×{tool.count}</span>
 					</span>
 				{/each}
 			</div>

--- a/frontend/src/lib/components/conversation/ConversationView.svelte
+++ b/frontend/src/lib/components/conversation/ConversationView.svelte
@@ -92,6 +92,7 @@
 		getSubagentColorVars,
 		cleanAgentIdForDisplay,
 		calculateSubagentDuration,
+		getEffectiveSubagentType,
 		truncate
 	} from '$lib/utils';
 
@@ -1513,118 +1514,339 @@
 	</div>
 
 <!-- ═══════════════════════════════════════════════════════════════════
-     SUBAGENT SESSION — keep original tab layout
+     SUBAGENT SESSION — new timeline-first layout with rail + drawer
      ═══════════════════════════════════════════════════════════════════ -->
 {:else if entity && isSubagentSession(entity)}
-	<div class="space-y-6">
-		<ConversationHeader
-			{entity}
-			{encodedName}
-			{sessionSlug}
-			{projectPath}
-			{parentSessionSlug}
-			{liveStatus}
-			{isRefreshing}
-		/>
+	{@const agentEntity = entity}
+	{@const agentType = getEffectiveSubagentType(agentEntity.subagent_type, agentEntity.agent_id)}
+	{@const agentColorVars = getSubagentColorVars(agentType)}
+	{@const displayId = cleanAgentIdForDisplay(agentEntity.agent_id)}
+	{@const agentShortId = agentEntity.agent_id.slice(-8)}
+	{@const agentTypeLabel = getSubagentTypeDisplayName(agentType)}
+	{@const agentLiveInfo = liveStatus?.subagents?.[agentEntity.agent_id] ?? null}
 
-		{#if tabsReady}
-			<Tabs.Root bind:value={activeTab} class="space-y-6">
-				<Tabs.List class="flex items-center gap-1 p-1 bg-[var(--bg-subtle)] rounded-lg w-fit mx-auto border border-[var(--border)]">
-					<TabsTrigger value="overview" icon={Info}>Overview</TabsTrigger>
-					<TabsTrigger value="timeline" icon={Clock}>Timeline</TabsTrigger>
-					<TabsTrigger value="tasks" icon={ListTodo}>
-						Tasks
-						{#if tasksArray.length > 0}
-							<span class="text-xs font-mono text-[var(--text-muted)]">{tasksArray.filter((t) => t.status === 'completed').length}/{tasksArray.length}</span>
+	<!-- Full-viewport column: negate the layout's px-6 py-8 padding -->
+	<div
+		class="-mx-6 -my-8 flex flex-col overflow-hidden"
+		style="height: calc(100vh - 56px);"
+	>
+		<!-- ── Agent Header ──────────────────────────────────────────────── -->
+		<div
+			class="flex-shrink-0 bg-[var(--bg-base)]"
+			style="padding: 13px 24px 14px;"
+		>
+			<!-- Breadcrumb row -->
+			<div class="flex items-center gap-1 mb-2" style="font-size: 11px; color: var(--text-faint);">
+				<a href="/" class="hover:text-[var(--text-muted)] transition-colors" style="color: var(--text-faint);">Dashboard</a>
+				<span style="color: var(--border);">/</span>
+				<a href="/projects" class="hover:text-[var(--text-muted)] transition-colors" style="color: var(--text-faint);">Projects</a>
+				<span style="color: var(--border);">/</span>
+				<a href="/projects/{encodedName}" class="hover:text-[var(--text-muted)] transition-colors" style="color: var(--text-faint);">{getProjectName(projectPath || '')}</a>
+				<span style="color: var(--border);">/</span>
+				<a href="/projects/{encodedName}/{parentSessionSlug || sessionSlug}" class="hover:text-[var(--text-muted)] transition-colors" style="color: var(--text-faint);">{parentSessionSlug || sessionSlug}</a>
+				<span style="color: var(--border);">/</span>
+				<span style="color: var(--text-muted); font-family: 'JetBrains Mono', monospace;">{displayId}</span>
+			</div>
+
+			<!-- Title row -->
+			<div class="flex items-start justify-between gap-4">
+				<div class="min-w-0 flex-1">
+					<!-- Agent title: type name -->
+					<h1
+						class="leading-[1.3] text-[var(--text-primary)]"
+						style="font-size: 17px; font-weight: 700; letter-spacing: -0.02em;"
+					>
+						{agentTypeLabel}
+					</h1>
+
+					<!-- Metadata chips row -->
+					<div class="flex items-center flex-wrap mt-2" style="gap: 6px;">
+						<!-- Agent ID chip -->
+						<span
+							class="inline-flex items-center"
+							style="font-size: 10.5px; background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 4px; padding: 2px 7px; color: var(--text-muted); font-family: 'JetBrains Mono', monospace;"
+						>#{agentShortId}</span>
+
+						<!-- Date -->
+						{#if agentEntity.start_time}
+							<span class="inline-flex items-center gap-1" style="font-size: 11px; color: var(--text-muted);">
+								<Calendar size={11} color="var(--text-faint)" />
+								{formatDateFull(agentEntity.start_time)}
+							</span>
 						{/if}
-					</TabsTrigger>
-					<TabsTrigger value="files" icon={FileText}>Files</TabsTrigger>
-					<TabsTrigger value="analytics" icon={BarChart3}>Analytics</TabsTrigger>
-				</Tabs.List>
 
-				<Tabs.Content value="overview">
-					<ConversationOverview
-						{entity}
-						{toolsArray}
-						{totalToolCalls}
-						projectEncoded={encodedName}
-						{continuationSession}
-						{continuationLoading}
-						{continuationError}
-					/>
-				</Tabs.Content>
+						<!-- Duration -->
+						{#if agentEntity.duration_seconds}
+							<span class="inline-flex items-center gap-1" style="font-size: 11px; color: var(--text-muted);">
+								<Clock size={11} color="var(--text-faint)" />
+								{formatDuration(agentEntity.duration_seconds)}
+							</span>
+						{/if}
 
-				<Tabs.Content value="timeline" class="animate-fade-in">
-					<div class="space-y-4">
-						<div class="flex items-start justify-between gap-4">
-							<div>
-								<h2 class="text-lg font-semibold text-[var(--text-primary)]">Timeline</h2>
-								<p class="text-sm text-[var(--text-muted)]">
-									{#if isTailing && timelineEvents.length > TAIL_COUNT}
-										Showing {TAIL_COUNT} of {timelineEvents.length} events
-									{:else}
-										Chronological sequence of events in this agent
-									{/if}
-								</p>
+						<!-- Model chip -->
+						{#if agentEntity.models_used?.[0]}
+							<span
+								class="inline-flex items-center gap-1"
+								style="font-size: 10.5px; font-weight: 500; color: var(--nav-purple); background: var(--nav-purple-subtle); border: 1px solid color-mix(in srgb, var(--nav-purple) 25%, transparent); border-radius: 4px; padding: 2px 7px;"
+							>
+								<Sparkles size={10} color="var(--nav-purple)" />
+								{agentEntity.models_used[0]}
+							</span>
+						{/if}
+
+						<!-- Cost -->
+						{#if agentEntity.total_cost}
+							<span style="font-size: 11px; color: var(--text-muted);">{formatCost(agentEntity.total_cost)}</span>
+						{/if}
+
+						<!-- Subagent live status -->
+						{#if agentLiveInfo}
+							{@const liveColor = agentLiveInfo.status === 'running' ? '#16a34a' : agentLiveInfo.status === 'error' ? '#dc2626' : '#94a3b8'}
+							<span
+								class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full"
+								style="background: color-mix(in srgb, {liveColor} 10%, transparent); border: 1px solid color-mix(in srgb, {liveColor} 30%, transparent);"
+							>
+								<span
+									class="w-1.5 h-1.5 rounded-full"
+									class:animate-pulse={agentLiveInfo.status === 'running'}
+									style="background: {liveColor};"
+								></span>
+								<span style="font-size: 10.5px; font-weight: 500; color: {liveColor};">{agentLiveInfo.status}</span>
+							</span>
+						{/if}
+
+						<!-- Syncing indicator -->
+						{#if isRefreshing}
+							<span class="inline-flex items-center gap-1" style="font-size: 10.5px; color: var(--nav-teal);">
+								<RefreshCw size={10} class="animate-spin" color="var(--nav-teal)" />
+								Syncing
+							</span>
+						{/if}
+					</div>
+				</div>
+
+				<!-- Right: tail toggle (live only) + Back to Session -->
+				<div class="flex items-center gap-2 flex-shrink-0">
+					{#if isCurrentlyLive && timelineEvents.length > 0}
+						<button
+							onclick={toggleTailing}
+							aria-pressed={isTailing}
+							title={isTailing ? 'Stop tailing — show all events' : 'Tail live events'}
+							class="inline-flex items-center gap-1 transition-all"
+							style="
+								padding: 5px 10px;
+								border-radius: 7px;
+								border: 1px solid {isTailing ? 'color-mix(in srgb, var(--nav-green) 30%, transparent)' : 'var(--border)'};
+								background: {isTailing ? 'var(--nav-green-subtle)' : 'var(--bg-base)'};
+								font-size: 11px;
+								font-weight: 500;
+								color: {isTailing ? 'var(--nav-green)' : 'var(--text-muted)'};
+								box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+							"
+						>
+							<ArrowDown size={11} strokeWidth={2} class={isTailing ? 'animate-pulse' : ''} />
+							Tail
+						</button>
+					{/if}
+
+					<a
+						href="/projects/{encodedName}/{parentSessionSlug || sessionSlug}"
+						class="inline-flex items-center gap-1.5 transition-all"
+						style="
+							padding: 7px 14px;
+							border: 1px solid var(--border);
+							border-radius: 7px;
+							background: var(--bg-base);
+							font-size: 12px;
+							font-weight: 500;
+							color: var(--text-primary);
+							box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+							white-space: nowrap;
+							text-decoration: none;
+						"
+					>
+						<ArrowLeft size={12} />
+						Original Session
+					</a>
+				</div>
+			</div>
+		</div>
+
+		<!-- ── Main content row ─────────────────────────────────────────── -->
+		<div class="flex flex-1 min-h-0" style="gap: 10px; padding: 8px 0 8px; overflow: hidden; align-items: stretch;">
+
+			<!-- ── Timeline column ──────────────────────────────────────── -->
+			<div class="flex-1 flex flex-col overflow-hidden min-w-0" style="background: var(--bg-base);">
+				{#if timelineEvents.length > 0}
+					<div class="flex-1 overflow-y-auto" style="scrollbar-width: none;">
+						<TimelineRail
+							events={timelineEvents}
+							isLive={isCurrentlyLive}
+							{isTailing}
+							onToggleTailing={toggleTailing}
+							{currentAgentId}
+							{projectPath}
+							projectEncoded={encodedName}
+							{sessionSlug}
+							searchQuery={showConversationSearch ? conversationSearchQuery : ''}
+							onSearchMatchCount={(count) => { searchMatchCount = count; }}
+							onCurrentMatchChange={(idx) => { currentSearchMatch = idx; }}
+							contained={true}
+						/>
+					</div>
+				{:else}
+					<div class="flex-1 flex items-center justify-center">
+						<EmptyState icon={Clock} title="No timeline events yet" description="Events will appear here as the agent progresses" />
+					</div>
+				{/if}
+			</div>
+
+			<!-- ── Right group: drawer + rail, no gap between them ──────── -->
+			<div class="flex flex-shrink-0 overflow-hidden" style="border-radius: 12px; background: var(--bg-subtle);">
+
+				<!-- ── Drawer ─────────────────────────────────────────────── -->
+				{#if drawerOpen && activeDrawer !== null}
+					<div
+						class="flex flex-col overflow-hidden flex-shrink-0"
+						style="width: 350px; border-right: 1px solid var(--border);"
+					>
+						<!-- Drawer header -->
+						<div class="flex items-center justify-between flex-shrink-0" style="height: 44px; padding: 0 16px; border-bottom: 1px solid var(--border);">
+							<span style="font-size: 13px; font-weight: 600; color: var(--text-primary); letter-spacing: -0.01em;">{drawerTitle}</span>
+							<div class="flex items-center" style="gap: 2px;">
+								<button onclick={() => cycleDrawer(-1)} disabled={activeDrawerIdx <= 0} style="width: 26px; height: 26px; border: none; background: none; color: var(--text-muted); opacity: {activeDrawerIdx <= 0 ? 0.25 : 1}; cursor: {activeDrawerIdx <= 0 ? 'default' : 'pointer'}; display: flex; align-items: center; justify-content: center; border-radius: 4px;" aria-label="Previous drawer"><ChevronLeft size={15} /></button>
+								<button onclick={() => cycleDrawer(1)} disabled={activeDrawerIdx >= enabledRailItems.length - 1} style="width: 26px; height: 26px; border: none; background: none; color: var(--text-muted); opacity: {activeDrawerIdx >= enabledRailItems.length - 1 ? 0.25 : 1}; cursor: {activeDrawerIdx >= enabledRailItems.length - 1 ? 'default' : 'pointer'}; display: flex; align-items: center; justify-content: center; border-radius: 4px;" aria-label="Next drawer"><ChevronRight size={15} /></button>
+								<button onclick={() => (drawerOpen = false)} style="width: 26px; height: 26px; border: none; background: none; color: var(--text-muted); cursor: pointer; display: flex; align-items: center; justify-content: center; border-radius: 4px;" aria-label="Close drawer"><X size={15} /></button>
 							</div>
-							{#if isCurrentlyLive && timelineEvents.length > 0}
-								<button
-									onclick={toggleTailing}
-									class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border transition-all duration-150 shrink-0 {isTailing ? 'bg-[var(--success-subtle)] border-[var(--success)]/50 text-[var(--success)]' : 'bg-[var(--bg-base)] border-[var(--border)] text-[var(--text-muted)]'}"
-									aria-pressed={isTailing}
-								>
-									<ArrowDown size={14} strokeWidth={2} class={isTailing ? 'animate-pulse' : ''} />
-									Tail Events
-								</button>
+						</div>
+						<!-- Drawer body -->
+						<div class="flex-1 overflow-y-auto" style="padding: 20px 20px 24px; scrollbar-width: none;">
+							{#if activeDrawer === 'overview'}
+								<ConversationOverview entity={agentEntity} {toolsArray} {totalToolCalls} projectEncoded={encodedName} {continuationSession} {continuationLoading} {continuationError} />
+							{:else if activeDrawer === 'files'}
+								{#if fileActivities.length > 0}
+									<FileActivityTable activities={fileActivities} {projectPath} {currentAgentId} {subagentTypes} />
+								{:else}
+									<EmptyState icon={FileText} title="No file activity" description="File operations will appear here" />
+								{/if}
+							{:else if activeDrawer === 'analytics'}
+								{@const totalTokens = (agentEntity.total_input_tokens || 0) + (agentEntity.total_output_tokens || 0)}
+								{@const inPct = totalTokens > 0 ? ((agentEntity.total_input_tokens || 0) / totalTokens) * 100 : 50}
+								{@const outPct = totalTokens > 0 ? ((agentEntity.total_output_tokens || 0) / totalTokens) * 100 : 50}
+								{@const maxToolCount = toolsArray.length > 0 ? Math.max(...toolsArray.map(t => t.count)) : 1}
+								{@const sortedTools = [...toolsArray].sort((a, b) => b.count - a.count)}
+								<div class="flex flex-col gap-4">
+
+									<!-- Key metrics: 2-col grid -->
+									<div class="grid grid-cols-2 gap-2">
+										<div class="rounded-lg border border-[var(--border)]/60 bg-[var(--bg-base)] px-3 py-2.5">
+											<p class="text-[10px] uppercase tracking-wide text-[var(--text-muted)] mb-1">Cost</p>
+											<p class="text-base font-bold text-[var(--text-primary)]">{formatCost(agentEntity.total_cost)}</p>
+											<p class="text-[10px] text-[var(--text-muted)] mt-0.5 leading-tight">API rate</p>
+										</div>
+										<div class="rounded-lg border border-[var(--border)]/60 bg-[var(--bg-base)] px-3 py-2.5">
+											<p class="text-[10px] uppercase tracking-wide text-[var(--text-muted)] mb-1">Duration</p>
+											<p class="text-base font-bold text-[var(--text-primary)]">{formatDuration(agentEntity.duration_seconds)}</p>
+										</div>
+										<div class="rounded-lg border border-[var(--border)]/60 bg-[var(--bg-base)] px-3 py-2.5">
+											<p class="text-[10px] uppercase tracking-wide text-[var(--text-muted)] mb-1">Cache hits</p>
+											<p class="text-base font-bold text-[var(--text-primary)]">{((agentEntity.cache_hit_rate || 0) * 100).toFixed(1)}%</p>
+										</div>
+										<div class="rounded-lg border border-[var(--border)]/60 bg-[var(--bg-base)] px-3 py-2.5">
+											<p class="text-[10px] uppercase tracking-wide text-[var(--text-muted)] mb-1">Tools used</p>
+											<p class="text-base font-bold text-[var(--text-primary)]">{toolsArray.length}</p>
+											<p class="text-[10px] text-[var(--text-muted)] mt-0.5">{totalToolCalls} calls</p>
+										</div>
+									</div>
+
+									<!-- Token breakdown -->
+									<div class="rounded-lg border border-[var(--border)]/60 bg-[var(--bg-base)] px-3 py-2.5">
+										<div class="flex items-baseline justify-between mb-2">
+											<p class="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">Tokens</p>
+											<p class="text-xs font-bold text-[var(--text-primary)] font-mono">{formatTokens(totalTokens)}</p>
+										</div>
+										<div class="flex h-2 rounded-full overflow-hidden bg-[var(--bg-muted)]">
+											<div class="bg-[var(--accent)] transition-all" style="width: {inPct}%" title="Input"></div>
+											<div class="bg-[var(--nav-teal)] transition-all" style="width: {outPct}%" title="Output"></div>
+										</div>
+										<div class="flex justify-between mt-1.5">
+											<span class="flex items-center gap-1 text-[10px] text-[var(--text-muted)]">
+												<span class="w-1.5 h-1.5 rounded-full bg-[var(--accent)]"></span>
+												In · {formatTokens(agentEntity.total_input_tokens)}
+											</span>
+											<span class="flex items-center gap-1 text-[10px] text-[var(--text-muted)]">
+												Out · {formatTokens(agentEntity.total_output_tokens)}
+												<span class="w-1.5 h-1.5 rounded-full bg-[var(--nav-teal)]"></span>
+											</span>
+										</div>
+									</div>
+
+									<!-- Tool usage -->
+									{#if sortedTools.length > 0}
+										<div class="flex flex-col gap-1">
+											<p class="text-[10px] uppercase tracking-wide text-[var(--text-muted)] font-medium mb-1">Tool usage</p>
+											{#each sortedTools as tool}
+												{@const pct = (tool.count / maxToolCount) * 100}
+												<div class="flex items-center gap-2 group">
+													<span class="w-28 shrink-0 text-[11px] font-mono text-[var(--text-secondary)] truncate" title={tool.tool_name}>{tool.tool_name}</span>
+													<div class="flex-1 h-1.5 rounded-full bg-[var(--bg-muted)] overflow-hidden">
+														<div class="h-full rounded-full transition-all" style="width: {pct}%; background: {agentColorVars.color};"></div>
+													</div>
+													<span class="shrink-0 w-6 text-right font-mono text-[10px] text-[var(--text-muted)]">{tool.count}</span>
+												</div>
+											{/each}
+										</div>
+									{/if}
+
+								</div>
+							{:else if activeDrawer === 'tasks'}
+								<TasksTab tasks={tasksArray} />
 							{/if}
 						</div>
-						{#if timelineEvents.length > 0}
-							<TimelineRail
-								events={timelineEvents}
-								isLive={isCurrentlyLive}
-								{isTailing}
-								onToggleTailing={toggleTailing}
-								{currentAgentId}
-								{projectPath}
-								projectEncoded={encodedName}
-								{sessionSlug}
-								searchQuery={showConversationSearch ? conversationSearchQuery : ''}
-								onSearchMatchCount={(count) => { searchMatchCount = count; }}
-								onCurrentMatchChange={(idx) => { currentSearchMatch = idx; }}
-							/>
-						{:else}
-							<EmptyState icon={Clock} title="No timeline events available" description="Timeline events will appear here as they occur" />
-						{/if}
-					</div>
-				</Tabs.Content>
-
-				<Tabs.Content value="tasks" class="animate-fade-in">
-					<TasksTab tasks={tasksArray} />
-				</Tabs.Content>
-
-				<Tabs.Content value="files" class="animate-fade-in">
-					{#if fileActivities.length > 0}
-						<FileActivityTable activities={fileActivities} {projectPath} {currentAgentId} {subagentTypes} />
-					{:else}
-						<EmptyState icon={FileText} title="No file activity recorded" description="File operations will appear here when files are accessed" />
-					{/if}
-				</Tabs.Content>
-
-				<Tabs.Content value="analytics" class="animate-fade-in">
-					<div class="space-y-6">
-						<StatsGrid stats={analyticsStats} columns={5} />
-						{#if toolsArray.length > 0}
-							<div class="grid gap-6 lg:grid-cols-2">
-								<ToolUsageTable tools={toolsArray} totalCalls={totalToolCalls} />
-								<ToolsChart toolsUsed={toolsUsedRecord} />
+						<!-- Drawer footer legends -->
+						{#if activeDrawer === 'tasks'}
+							<div class="flex-shrink-0 flex items-center justify-center gap-4 flex-wrap" style="padding: 10px 20px; border-top: 1px solid var(--border);">
+								<span class="flex items-center gap-1.5 text-[10px] text-[var(--text-faint)]"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/></svg>Pending</span>
+								<span class="flex items-center gap-1.5 text-[10px]" style="color: var(--nav-blue);"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>In Progress</span>
+								<span class="flex items-center gap-1.5 text-[10px]" style="color: var(--success);"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>Completed</span>
 							</div>
-						{:else}
-							<EmptyState icon={BarChart3} title="No tools used" description="Tool usage statistics will appear here" />
 						{/if}
 					</div>
-				</Tabs.Content>
-			</Tabs.Root>
-		{/if}
+				{/if}
+
+				<!-- ── Rail: always at the right edge ──────────────────────── -->
+				<div
+					class="flex flex-col items-center flex-shrink-0 overflow-y-auto"
+					style="width: 68px; padding: 14px 0; gap: 6px; scrollbar-width: none;"
+				>
+					{#each railItems as item (item.key)}
+						{@const isSelected = activeDrawer === item.key}
+						{@const isOpen = isSelected && drawerOpen}
+						{@const IconComponent = item.icon}
+						{@const iconColor = isSelected ? 'var(--rail-active-icon)' : item.disabled ? 'var(--text-faint)' : 'var(--text-primary)'}
+						<span
+							title={item.disabled ? item.disabledTip : item.label}
+							style="display: flex; align-items: center; justify-content: center; width: 52px; height: 52px;"
+						>
+							<button
+								onclick={() => toggleDrawer(item.key)}
+								aria-pressed={isOpen}
+								aria-disabled={item.disabled}
+								class="relative flex items-center justify-center flex-shrink-0 transition-all duration-150"
+								style="width: 52px; height: 52px; border-radius: 12px; border: none; cursor: {item.disabled ? 'default' : 'pointer'}; background: {isOpen ? 'var(--rail-active-bg)' : 'transparent'}; opacity: {isSelected ? 1 : item.disabled ? 0.3 : 0.85}; pointer-events: {item.disabled ? 'none' : 'auto'};"
+							>
+								{#if item.iconName}
+									<CustomIcon name={item.iconName} size={22} strokeWidth={2} color={iconColor} />
+								{:else if IconComponent}
+									<IconComponent size={22} color={iconColor} strokeWidth={2.5} />
+								{/if}
+							</button>
+						</span>
+					{/each}
+				</div>
+
+			</div><!-- end right group -->
+		</div>
 	</div>
 
 <!-- ═══════════════════════════════════════════════════════════════════

--- a/frontend/src/lib/components/conversation/ConversationView.svelte
+++ b/frontend/src/lib/components/conversation/ConversationView.svelte
@@ -25,7 +25,21 @@
 		Ticket as TicketIcon,
 		Search,
 		Activity,
-		AlarmClock
+		AlarmClock,
+		BarChart2,
+		CheckSquare,
+		Tag,
+		Layers,
+		Play,
+		Calendar,
+		GitBranch,
+		Link2,
+		Sparkles,
+		ChevronRight,
+		ChevronLeft,
+		Copy,
+		Check,
+		Terminal
 	} from 'lucide-svelte';
 	import TabsTrigger from '$lib/components/ui/TabsTrigger.svelte';
 	import { SessionDetailSkeleton } from '$lib/components/skeleton';
@@ -46,6 +60,7 @@
 	import SessionShellsSection from '$lib/components/shells/SessionShellsSection.svelte';
 	import SessionCronSection from '$lib/components/cron/SessionCronSection.svelte';
 	import ConversationHeader from './ConversationHeader.svelte';
+	import CustomIcon from '$lib/components/icons/Icon.svelte';
 	import ConversationOverview from './ConversationOverview.svelte';
 	import type {
 		StatItem,
@@ -70,8 +85,14 @@
 		formatDuration,
 		formatTokens,
 		formatCost,
+		formatDateFull,
 		getProjectName,
-		getSubagentTypeDisplayName
+		getSubagentTypeDisplayName,
+		getSessionDisplayName,
+		getSubagentColorVars,
+		cleanAgentIdForDisplay,
+		calculateSubagentDuration,
+		truncate
 	} from '$lib/utils';
 
 	interface Props {
@@ -874,65 +895,614 @@
 		if (!subagents) return {};
 		return Object.fromEntries(subagents.map((a) => [a.agent_id, a.subagent_type]));
 	});
+
+	// ── Rail + Drawer state (main sessions only) ────────────────────────────────
+	type DrawerKey =
+		| 'overview'
+		| 'files'
+		| 'analytics'
+		| 'tasks'
+		| 'agents'
+		| 'plan'
+		| 'skills'
+		| 'commands'
+		| 'shells'
+		| 'tickets'
+		| 'cron';
+
+	let activeDrawer = $state<DrawerKey | null>(null);
+	let drawerWidth = $state(296);
+	let resumeCopied = $state(false);
+	let expandedAgentIds = $state<Set<string>>(new Set());
+
+	// null = unknown (show icon by default), 0 = confirmed empty (hide icon), >0 = has shells
+	let shellCount = $state<number | null>(null);
+	let cronCount = $state<number | null>(null);
+
+	$effect(() => {
+		if (!browser || !sessionUuid || !entity || !isMainSession(entity)) return;
+		const uuid = sessionUuid;
+		fetch(`${API_BASE}/sessions/${uuid}/cron`)
+			.then((r) => r.ok ? r.json() : null)
+			.then((data) => { if (data) cronCount = (data.jobs ?? []).length; })
+			.catch(() => {});
+	});
+
+	// Pre-fetch shell count so the rail item only appears for sessions that actually have shells.
+	// Only hide the icon when we get a confirmed empty response — not on 404/error (e.g. live sessions
+	// not yet in the DB will 404, but they may well have shells).
+	$effect(() => {
+		if (!browser || !sessionUuid || !entity || !isMainSession(entity)) return;
+		const uuid = sessionUuid;
+		fetch(`${API_BASE}/sessions/${uuid}/shells?include_polls=false`)
+			.then((r) => {
+				if (!r.ok) return; // Don't hide on 404 or other errors
+				return r.json();
+			})
+			.then((data) => {
+				if (data) shellCount = (data.shells ?? []).length;
+			})
+			.catch(() => {});
+	});
+	let resumeCopyTimeout: ReturnType<typeof setTimeout> | null = null;
+
+	function toggleDrawer(key: DrawerKey) {
+		activeDrawer = activeDrawer === key ? null : key;
+	}
+
+	type RailItem = { key: DrawerKey; icon: typeof Info | null; iconName?: string; label: string; disabled: boolean; disabledTip: string };
+
+	const railItems = $derived.by<RailItem[]>(() => {
+		const isMain = entity ? isMainSession(entity) : false;
+		const items: RailItem[] = [
+			{ key: 'overview',  icon: Info,        label: 'Overview',  disabled: false, disabledTip: '' },
+			{ key: 'files',     icon: FileText,    label: 'Files',     disabled: fileActivities.length === 0, disabledTip: 'No file activity in this session' },
+			{ key: 'analytics', icon: BarChart2,   label: 'Analytics', disabled: false, disabledTip: '' },
+			{ key: 'tasks',     icon: CheckSquare, label: 'Tasks',     disabled: tasksArray.length === 0, disabledTip: 'No tasks in this session' },
+		];
+		if (isMain) {
+			const agentCount = (entity as { subagents?: unknown[] }).subagents?.length ?? 0;
+			items.push({ key: 'agents',   icon: null, iconName: 'agents',  label: 'Agents',   disabled: agentCount === 0,          disabledTip: 'No agents in this session' });
+			items.push({ key: 'plan',     icon: null, iconName: 'plans',   label: 'Plan',     disabled: !plan,                     disabledTip: 'No plan in this session' });
+			items.push({ key: 'skills',   icon: Zap,                       label: 'Skills',   disabled: skillsArray.length === 0,  disabledTip: 'No skills in this session' });
+			items.push({ key: 'commands', icon: Terminal,                  label: 'Commands', disabled: commandsArray.length === 0, disabledTip: 'No commands in this session' });
+			items.push({ key: 'shells',   icon: null, iconName: 'shells',  label: 'Shells',   disabled: shellCount === 0,           disabledTip: 'No background shells in this session' });
+			items.push({ key: 'cron',     icon: null, iconName: 'cron',    label: 'Cron',     disabled: cronCount === 0,            disabledTip: 'No cron jobs in this session' });
+			items.push({ key: 'tickets',  icon: null, iconName: 'tickets', label: 'Tickets',  disabled: tickets.length === 0,      disabledTip: 'No tickets in this session' });
+		}
+		return items;
+	});
+
+	const enabledRailItems = $derived(railItems.filter((i) => !i.disabled));
+	const drawerTitle = $derived(railItems.find((i) => i.key === activeDrawer)?.label ?? '');
+	const activeDrawerIdx = $derived(enabledRailItems.findIndex((i) => i.key === activeDrawer));
+
+	function cycleDrawer(dir: 1 | -1) {
+		if (activeDrawer === null) return;
+		const next = (activeDrawerIdx + dir + enabledRailItems.length) % enabledRailItems.length;
+		activeDrawer = enabledRailItems[next].key;
+	}
+
+	async function handleResumeCopy() {
+		if (!entity || isSubagentSession(entity) || !entity.uuid) return;
+		try {
+			await navigator.clipboard.writeText(`claude --resume ${entity.uuid}`);
+		} catch {
+			// fallback: do nothing
+		}
+		resumeCopied = true;
+		if (resumeCopyTimeout) clearTimeout(resumeCopyTimeout);
+		resumeCopyTimeout = setTimeout(() => {
+			resumeCopied = false;
+		}, 1500);
+	}
 </script>
 
-<div class="space-y-6">
-	{#if isStarting && liveSession}
-		<!-- Starting Session Placeholder -->
+<!-- ═══════════════════════════════════════════════════════════════════
+     MAIN SESSION — new timeline-first layout with rail + drawer
+     ═══════════════════════════════════════════════════════════════════ -->
+{#if !isStarting && entity && isMainSession(entity)}
+	{@const sessionEntity = entity}
+	{@const sessionTitle = getSessionDisplayName(
+		sessionEntity.session_titles,
+		sessionEntity.slug,
+		sessionEntity.uuid,
+		sessionEntity.chain_title
+	)}
+	{@const shortId = sessionEntity.uuid?.slice(0, 8) ?? ''}
+	{@const primaryModel = sessionEntity.models_used?.[0] ?? null}
+	{@const primaryBranch = sessionEntity.git_branches?.[0] ?? null}
+
+	<!-- Full-viewport column: negate the layout's px-6 py-8 padding -->
+	<div
+		class="-mx-6 -my-8 flex flex-col overflow-hidden"
+		style="height: calc(100vh - 56px);"
+	>
+		<!-- ── Session Header ─────────────────────────────────────────────── -->
+		<div
+			class="flex-shrink-0 bg-white"
+			style="padding: 13px 24px 14px;"
+		>
+			<!-- Breadcrumb row -->
+			<div class="flex items-center gap-1 mb-2" style="font-size: 11px; color: #94a3b8;">
+				<a href="/" class="hover:text-[#64748b] transition-colors" style="color: #94a3b8;">Dashboard</a>
+				<span style="color: #d1d5db;">/</span>
+				<a href="/projects" class="hover:text-[#64748b] transition-colors" style="color: #94a3b8;">Projects</a>
+				<span style="color: #d1d5db;">/</span>
+				<a href="/projects/{encodedName}" class="hover:text-[#64748b] transition-colors" style="color: #94a3b8;">{getProjectName(projectPath || '')}</a>
+				<span style="color: #d1d5db;">/</span>
+				<span style="color: #64748b; font-family: 'JetBrains Mono', monospace;">{shortId}</span>
+			</div>
+
+			<!-- Title row -->
+			<div class="flex items-start justify-between gap-4">
+				<div class="min-w-0 flex-1">
+					<!-- Session title -->
+					<h1
+						class="leading-[1.3] text-[#0f172a]"
+						style="font-size: 17px; font-weight: 700; letter-spacing: -0.02em; text-wrap: pretty;"
+					>
+						{sessionTitle}
+					</h1>
+
+					<!-- Metadata chips row -->
+					<div class="flex items-center flex-wrap mt-2" style="gap: 6px;">
+						<!-- Session ID chip -->
+						<span
+							class="inline-flex items-center"
+							style="font-size: 10.5px; background: #f1f5f9; border: 1px solid #e2e8f0; border-radius: 4px; padding: 2px 7px; color: #64748b; font-family: 'JetBrains Mono', monospace;"
+						>#{shortId}</span>
+
+						<!-- Date -->
+						{#if sessionEntity.start_time}
+							<span class="inline-flex items-center gap-1" style="font-size: 11px; color: #64748b;">
+								<Calendar size={11} color="#94a3b8" />
+								{formatDateFull(sessionEntity.start_time)}
+							</span>
+						{/if}
+
+						<!-- Duration -->
+						{#if sessionEntity.duration_seconds}
+							<span class="inline-flex items-center gap-1" style="font-size: 11px; color: #64748b;">
+								<Clock size={11} color="#94a3b8" />
+								{formatDuration(sessionEntity.duration_seconds)}
+							</span>
+						{/if}
+
+						<!-- Model chip -->
+						{#if primaryModel}
+							<span
+								class="inline-flex items-center gap-1"
+								style="font-size: 10.5px; font-weight: 500; color: #7c3aed; background: #faf5ff; border: 1px solid #e9d5ff; border-radius: 4px; padding: 2px 7px;"
+							>
+								<Sparkles size={10} color="#7c3aed" />
+								{primaryModel}
+							</span>
+						{/if}
+
+						<!-- Git branch chip -->
+						{#if primaryBranch}
+							<span
+								class="inline-flex items-center gap-1"
+								style="font-size: 10.5px; font-weight: 500; color: #0891b2; background: #f0f9ff; border: 1px solid #bae6fd; border-radius: 4px; padding: 2px 7px;"
+							>
+								<GitBranch size={10} color="#0891b2" />
+								{primaryBranch}
+							</span>
+						{/if}
+
+						<!-- Chain position chip -->
+						{#if sessionEntity.chain_info}
+							{@const ci = sessionEntity.chain_info}
+							<span
+								class="inline-flex items-center gap-1"
+								style="font-size: 10.5px; color: #64748b; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 4px; padding: 2px 7px;"
+							>
+								<Link2 size={10} color="#94a3b8" />
+								Session {ci.position + 1} of {ci.total}
+							</span>
+						{/if}
+
+						<!-- Cost -->
+						{#if sessionEntity.total_cost}
+							<span style="font-size: 11px; color: #64748b;">{formatCost(sessionEntity.total_cost)}</span>
+						{/if}
+
+						<!-- Live status -->
+						{#if liveStatus && liveStatus.status !== 'ended'}
+							{@const liveColors: Record<string, string> = {
+								starting: '#7c3aed', active: '#16a34a', idle: '#d97706',
+								waiting: '#0891b2', stopped: '#94a3b8', stale: '#dc2626', ended: '#cbd5e1'
+							}}
+							{@const liveColor = liveColors[liveStatus.status] ?? '#94a3b8'}
+							<span
+								class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full"
+								style="background: color-mix(in srgb, {liveColor} 10%, transparent); border: 1px solid color-mix(in srgb, {liveColor} 30%, transparent);"
+							>
+								<span
+									class="w-1.5 h-1.5 rounded-full"
+									class:animate-pulse={['starting','active'].includes(liveStatus.status)}
+									style="background: {liveColor};"
+								></span>
+								<span style="font-size: 10.5px; font-weight: 500; color: {liveColor};">{liveStatus.status}</span>
+							</span>
+						{/if}
+
+						<!-- Syncing indicator -->
+						{#if isRefreshing}
+							<span class="inline-flex items-center gap-1" style="font-size: 10.5px; color: #0891b2;">
+								<RefreshCw size={10} class="animate-spin" color="#0891b2" />
+								Syncing
+							</span>
+						{/if}
+					</div>
+				</div>
+
+				<!-- Right: tail toggle (live only) + Resume button -->
+				<div class="flex items-center gap-2 flex-shrink-0">
+					{#if isCurrentlyLive && timelineEvents.length > 0}
+						<button
+							onclick={toggleTailing}
+							aria-pressed={isTailing}
+							title={isTailing ? 'Stop tailing — show all events' : 'Tail live events'}
+							class="inline-flex items-center gap-1 transition-all"
+							style="
+								padding: 5px 10px;
+								border-radius: 7px;
+								border: 1px solid {isTailing ? '#bbf7d0' : '#e2e8f0'};
+								background: {isTailing ? '#f0fdf4' : '#fff'};
+								font-size: 11px;
+								font-weight: 500;
+								color: {isTailing ? '#16a34a' : '#64748b'};
+								box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+							"
+						>
+							<ArrowDown size={11} strokeWidth={2} class={isTailing ? 'animate-pulse' : ''} />
+							Tail
+						</button>
+					{/if}
+
+					<!-- Resume button -->
+					<button
+						onclick={handleResumeCopy}
+						class="inline-flex items-center gap-1.5 transition-all"
+						style="
+							padding: 7px 14px;
+							border: 1px solid #e2e8f0;
+							border-radius: 7px;
+							background: #fff;
+							font-size: 12px;
+							font-weight: 500;
+							color: {resumeCopied ? '#16a34a' : '#374151'};
+							box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+							white-space: nowrap;
+						"
+						title="Copy: claude --resume {sessionEntity.uuid}"
+					>
+						{#if resumeCopied}
+							<Check size={12} color="#16a34a" />
+							Copied!
+						{:else}
+							<Play size={12} />
+							Resume
+						{/if}
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<!-- ── Main content row ───────────────────────────────────────────── -->
+		<div class="flex flex-1 min-h-0" style="gap: 10px; padding: 8px 0 8px; overflow: hidden; align-items: stretch;">
+
+			<!-- ── Timeline column ─────────────────────────────────────────── -->
+			<div class="flex-1 flex flex-col overflow-hidden min-w-0" style="background: #fff;">
+				{#if timelineEvents.length > 0}
+					<div class="flex-1 overflow-y-auto" style="scrollbar-width: none;">
+						<TimelineRail
+							events={timelineEvents}
+							isLive={isCurrentlyLive}
+							{isTailing}
+							onToggleTailing={toggleTailing}
+							{currentAgentId}
+							{projectPath}
+							projectEncoded={encodedName}
+							{sessionSlug}
+							searchQuery={showConversationSearch ? conversationSearchQuery : ''}
+							onSearchMatchCount={(count) => { searchMatchCount = count; }}
+							onCurrentMatchChange={(idx) => { currentSearchMatch = idx; }}
+							contained={true}
+						/>
+					</div>
+				{:else}
+					<div class="flex-1 flex items-center justify-center">
+						<EmptyState icon={Clock} title="No timeline events yet" description="Events will appear here as the session progresses" />
+					</div>
+				{/if}
+			</div>
+
+			<!-- ── Right group: drawer + rail, no gap between them ──────────── -->
+			<div class="flex flex-shrink-0 overflow-hidden" style="border-radius: 12px; background: #f1f5f9;">
+
+			<!-- ── Drawer ────────────────────────────────────────────────────── -->
+			{#if activeDrawer !== null}
+				<div
+					class="flex flex-col overflow-hidden flex-shrink-0"
+					style="width: 350px; border-right: 1px solid #e2e8f0;"
+				>
+					<!-- Drawer header -->
+					<div class="flex items-center justify-between flex-shrink-0" style="height: 44px; padding: 0 16px; border-bottom: 1px solid #e2e8f0;">
+						<span style="font-size: 13px; font-weight: 600; color: #0f172a; letter-spacing: -0.01em;">{drawerTitle}</span>
+						<div class="flex items-center" style="gap: 2px;">
+							<button onclick={() => cycleDrawer(-1)} disabled={activeDrawerIdx <= 0} style="width: 26px; height: 26px; border: none; background: none; color: #64748b; opacity: {activeDrawerIdx <= 0 ? 0.25 : 1}; cursor: {activeDrawerIdx <= 0 ? 'default' : 'pointer'}; display: flex; align-items: center; justify-content: center; border-radius: 4px;" aria-label="Previous drawer"><ChevronLeft size={15} /></button>
+							<button onclick={() => cycleDrawer(1)} disabled={activeDrawerIdx >= enabledRailItems.length - 1} style="width: 26px; height: 26px; border: none; background: none; color: #64748b; opacity: {activeDrawerIdx >= enabledRailItems.length - 1 ? 0.25 : 1}; cursor: {activeDrawerIdx >= railItems.length - 1 ? 'default' : 'pointer'}; display: flex; align-items: center; justify-content: center; border-radius: 4px;" aria-label="Next drawer"><ChevronRight size={15} /></button>
+							<button onclick={() => (activeDrawer = null)} style="width: 26px; height: 26px; border: none; background: none; color: #64748b; cursor: pointer; display: flex; align-items: center; justify-content: center; border-radius: 4px;" aria-label="Close drawer"><X size={15} /></button>
+						</div>
+					</div>
+					<!-- Drawer body -->
+					<div class="flex-1 overflow-y-auto" style="padding: 20px 20px 24px; scrollbar-width: none;">
+						{#if activeDrawer === 'overview'}
+							<ConversationOverview entity={sessionEntity} {toolsArray} {totalToolCalls} projectEncoded={encodedName} {continuationSession} {continuationLoading} {continuationError} />
+						{:else if activeDrawer === 'files'}
+							{#if fileActivities.length > 0}
+								<FileActivityTable activities={fileActivities} {projectPath} {currentAgentId} {subagentTypes} />
+							{:else}
+								<EmptyState icon={FileText} title="No file activity" description="File operations will appear here" />
+							{/if}
+						{:else if activeDrawer === 'analytics'}
+							{@const totalTokens = (entity?.total_input_tokens || 0) + (entity?.total_output_tokens || 0)}
+							{@const inPct = totalTokens > 0 ? ((entity?.total_input_tokens || 0) / totalTokens) * 100 : 50}
+							{@const outPct = totalTokens > 0 ? ((entity?.total_output_tokens || 0) / totalTokens) * 100 : 50}
+							{@const maxToolCount = toolsArray.length > 0 ? Math.max(...toolsArray.map(t => t.count)) : 1}
+							{@const sortedTools = [...toolsArray].sort((a, b) => b.count - a.count)}
+							<div class="flex flex-col gap-4">
+
+								<!-- Key metrics: 2-col grid -->
+								<div class="grid grid-cols-2 gap-2">
+									<div class="rounded-lg border border-[var(--border)]/60 bg-[var(--bg-base)] px-3 py-2.5">
+										<p class="text-[10px] uppercase tracking-wide text-[var(--text-muted)] mb-1">Cost</p>
+										<p class="text-base font-bold text-[var(--text-primary)]">{formatCost(entity?.total_cost)}</p>
+										<p class="text-[10px] text-[var(--text-muted)] mt-0.5 leading-tight">API rate</p>
+									</div>
+									<div class="rounded-lg border border-[var(--border)]/60 bg-[var(--bg-base)] px-3 py-2.5">
+										<p class="text-[10px] uppercase tracking-wide text-[var(--text-muted)] mb-1">Duration</p>
+										<p class="text-base font-bold text-[var(--text-primary)]">{formatDuration(entity?.duration_seconds)}</p>
+									</div>
+									<div class="rounded-lg border border-[var(--border)]/60 bg-[var(--bg-base)] px-3 py-2.5">
+										<p class="text-[10px] uppercase tracking-wide text-[var(--text-muted)] mb-1">Cache hits</p>
+										<p class="text-base font-bold text-[var(--text-primary)]">{((entity?.cache_hit_rate || 0) * 100).toFixed(1)}%</p>
+									</div>
+									<div class="rounded-lg border border-[var(--border)]/60 bg-[var(--bg-base)] px-3 py-2.5">
+										<p class="text-[10px] uppercase tracking-wide text-[var(--text-muted)] mb-1">Tools used</p>
+										<p class="text-base font-bold text-[var(--text-primary)]">{toolsArray.length}</p>
+										<p class="text-[10px] text-[var(--text-muted)] mt-0.5">{totalToolCalls} calls</p>
+									</div>
+								</div>
+
+								<!-- Token breakdown -->
+								<div class="rounded-lg border border-[var(--border)]/60 bg-[var(--bg-base)] px-3 py-2.5">
+									<div class="flex items-baseline justify-between mb-2">
+										<p class="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">Tokens</p>
+										<p class="text-xs font-bold text-[var(--text-primary)] font-mono">{formatTokens(totalTokens)}</p>
+									</div>
+									<div class="flex h-2 rounded-full overflow-hidden bg-[var(--bg-muted)]">
+										<div class="bg-[var(--accent)] transition-all" style="width: {inPct}%" title="Input"></div>
+										<div class="bg-[var(--nav-teal)] transition-all" style="width: {outPct}%" title="Output"></div>
+									</div>
+									<div class="flex justify-between mt-1.5">
+										<span class="flex items-center gap-1 text-[10px] text-[var(--text-muted)]">
+											<span class="w-1.5 h-1.5 rounded-full bg-[var(--accent)]"></span>
+											In · {formatTokens(entity?.total_input_tokens)}
+										</span>
+										<span class="flex items-center gap-1 text-[10px] text-[var(--text-muted)]">
+											Out · {formatTokens(entity?.total_output_tokens)}
+											<span class="w-1.5 h-1.5 rounded-full bg-[var(--nav-teal)]"></span>
+										</span>
+									</div>
+								</div>
+
+								<!-- Tool usage -->
+								{#if sortedTools.length > 0}
+									<div class="flex flex-col gap-1">
+										<p class="text-[10px] uppercase tracking-wide text-[var(--text-muted)] font-medium mb-1">Tool usage</p>
+										{#each sortedTools as tool}
+											{@const pct = (tool.count / maxToolCount) * 100}
+											<div class="flex items-center gap-2 group">
+												<span class="w-28 shrink-0 text-[11px] font-mono text-[var(--text-secondary)] truncate" title={tool.tool_name}>{tool.tool_name}</span>
+												<div class="flex-1 h-1.5 rounded-full bg-[var(--bg-muted)] overflow-hidden">
+													<div class="h-full bg-[var(--accent)]/70 rounded-full transition-all" style="width: {pct}%"></div>
+												</div>
+												<span class="shrink-0 w-6 text-right font-mono text-[10px] text-[var(--text-muted)]">{tool.count}</span>
+											</div>
+										{/each}
+									</div>
+								{/if}
+
+							</div>
+						{:else if activeDrawer === 'tasks'}
+							<TasksTab tasks={tasksArray} />
+						{:else if activeDrawer === 'agents'}
+							{@const allAgents = groupedSubagents.flatMap(([, agents]) => agents)}
+							{#if allAgents.length > 0}
+								<div class="flex flex-col gap-2">
+									<span class="text-[10px] uppercase tracking-wide font-medium text-[var(--text-muted)]">{allAgents.length} agent{allAgents.length !== 1 ? 's' : ''}</span>
+									{#each allAgents as agent}
+										{@const cv = getSubagentColorVars(agent.subagent_type)}
+										{@const live = liveStatus?.subagents?.[agent.agent_id]}
+										{@const duration = calculateSubagentDuration(live?.started_at ?? null, live?.completed_at ?? null)}
+										{@const totalCalls = Object.values(agent.tools_used).reduce((a, b) => a + b, 0)}
+										{@const topTools = Object.entries(agent.tools_used).sort((a,b) => b[1]-a[1]).slice(0,3)}
+										{@const displayId = cleanAgentIdForDisplay(agent.agent_id)}
+										{@const agentHref = `/projects/${encodedName}/${sessionEntity?.uuid?.slice(0,8) || sessionSlug}/agents/${agent.agent_id}`}
+										<div class="rounded-lg border border-[var(--border)]/60 bg-[var(--bg-base)] overflow-hidden" style="border-left: 2px solid {cv.color};">
+											<div class="px-3 py-2.5">
+												<!-- Row 1: type badge + id + running dot + duration -->
+												<div class="flex items-center gap-2">
+													<span class="shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded-full" style="background: {cv.subtle}; color: {cv.color};">{agent.subagent_type ?? 'Agent'}</span>
+													{#if live?.status === 'running'}
+														<span class="shrink-0 w-1.5 h-1.5 rounded-full animate-pulse" style="background: var(--success);"></span>
+													{/if}
+													<a href={agentHref} class="flex-1 min-w-0 font-mono text-[11px] text-[var(--accent)] hover:underline truncate">{displayId}</a>
+													{#if duration !== null}
+														<span class="shrink-0 font-mono text-[10px] text-[var(--text-muted)]">{formatDuration(duration)}</span>
+													{/if}
+												</div>
+												<!-- Row 2: prompt snippet (tap to expand) -->
+												{#if agent.initial_prompt}
+													{@const isAgentExpanded = expandedAgentIds.has(agent.agent_id)}
+													{@const isLongPrompt = agent.initial_prompt.length > 160}
+													<button
+														type="button"
+														onclick={() => {
+															const next = new Set(expandedAgentIds);
+															if (next.has(agent.agent_id)) next.delete(agent.agent_id);
+															else next.add(agent.agent_id);
+															expandedAgentIds = next;
+														}}
+														class="mt-1.5 text-left w-full"
+													>
+														<p class="text-[10px] text-[var(--text-muted)] leading-relaxed {isAgentExpanded ? 'whitespace-pre-wrap' : 'line-clamp-2'}">{agent.initial_prompt}</p>
+														{#if isLongPrompt}
+															<span class="text-[10px] text-[var(--accent)] hover:underline">{isAgentExpanded ? 'Show less' : 'Show more'}</span>
+														{/if}
+													</button>
+												{/if}
+												<!-- Row 3: stats + top tools -->
+												<div class="mt-1.5 flex items-center gap-1.5 flex-wrap">
+													<span class="text-[10px] text-[var(--text-muted)] font-mono">{agent.message_count} msgs</span>
+													<span class="text-[10px] text-[var(--text-muted)]">·</span>
+													<span class="text-[10px] text-[var(--text-muted)] font-mono">{totalCalls} calls</span>
+													{#each topTools as [tool, count]}
+														<span class="text-[10px] px-1.5 py-0.5 rounded bg-[var(--bg-subtle)] border border-[var(--border)]/60 font-mono text-[var(--text-secondary)]">{tool} ×{count}</span>
+													{/each}
+												</div>
+											</div>
+										</div>
+									{/each}
+								</div>
+							{:else}
+								<EmptyState icon={Cpu} title="No subagents" description="No agents were spawned" />
+							{/if}
+						{:else if activeDrawer === 'plan'}
+							{#if plan}
+								<PlanViewer {plan} embedded={true} />
+							{:else}
+								<EmptyState icon={FileEdit} title="No plan" description="No plan was created for this session" />
+							{/if}
+						{:else if activeDrawer === 'skills'}
+							<SkillsPanel skills={skillsArray} projectEncodedName={encodedName} />
+						{:else if activeDrawer === 'commands'}
+							<CommandsPanel commands={commandsArray} projectEncodedName={encodedName} />
+						{:else if activeDrawer === 'shells'}
+							{#if sessionUuid}
+								<SessionShellsSection {sessionUuid} onLoaded={(n) => (shellCount = n)} />
+							{:else}
+								<p class="text-sm text-[var(--text-muted)]">Session UUID unavailable.</p>
+							{/if}
+						{:else if activeDrawer === 'cron'}
+							{#if sessionUuid}
+								<SessionCronSection {sessionUuid} projectEncodedName={encodedName} />
+							{:else}
+								<p class="text-sm text-[var(--text-muted)]">Session UUID unavailable.</p>
+							{/if}
+						{:else if activeDrawer === 'tickets'}
+							{#if sessionUuid}
+								<SessionTicketsSection {sessionUuid} {sessionSlug} initial={tickets} />
+							{:else}
+								<p class="text-sm text-[var(--text-muted)]">Session UUID unavailable.</p>
+							{/if}
+						{/if}
+					</div>
+					<!-- Drawer footer: shell legend -->
+					{#if activeDrawer === 'shells'}
+						<div class="flex-shrink-0 flex items-center gap-4 flex-wrap" style="padding: 10px 20px; border-top: 1px solid #e2e8f0;">
+							<span class="flex items-center gap-1.5 text-[10px] text-[var(--text-faint)]"><span class="w-1.5 h-1.5 rounded-full" style="background: var(--success);"></span>running</span>
+							<span class="flex items-center gap-1.5 text-[10px] text-[var(--text-faint)]"><span class="w-1.5 h-1.5 rounded-full" style="background: var(--info);"></span>done</span>
+							<span class="flex items-center gap-1.5 text-[10px] text-[var(--text-faint)]"><span class="w-1.5 h-1.5 rounded-full" style="background: var(--error);"></span>killed</span>
+							<span class="flex items-center gap-1.5 text-[10px] text-[var(--text-faint)]"><span class="w-1.5 h-1.5 rounded-full" style="background: var(--warning);"></span>timeout</span>
+							<span class="flex items-center gap-1.5 text-[10px] text-[var(--text-faint)]"><span class="w-1.5 h-1.5 rounded-full" style="background: var(--text-faint);"></span>ended</span>
+						</div>
+					{/if}
+				</div>
+			{/if}
+
+			<!-- ── Rail: always at the right edge ───────────────────────────── -->
+			<div
+				class="flex flex-col items-center flex-shrink-0 overflow-y-auto"
+				style="width: 68px; padding: 14px 0; gap: 6px; scrollbar-width: none;"
+			>
+				{#each railItems as item (item.key)}
+					{@const isActive = activeDrawer === item.key}
+					{@const IconComponent = item.icon}
+					{@const iconColor = isActive ? '#ffffff' : item.disabled ? '#94a3b8' : '#475569'}
+					<!-- Wrapper carries the tooltip — pointer-events on button are off when disabled so title fires from wrapper -->
+					<span
+						title={item.disabled ? item.disabledTip : item.label}
+						style="display: flex; align-items: center; justify-content: center; width: 52px; height: 52px;"
+					>
+						<button
+							onclick={() => toggleDrawer(item.key)}
+							aria-pressed={isActive}
+							aria-disabled={item.disabled}
+							class="relative flex items-center justify-center flex-shrink-0 transition-all duration-150"
+							style="width: 52px; height: 52px; border-radius: 12px; border: none; cursor: {item.disabled ? 'default' : 'pointer'}; background: {isActive ? '#0f172a' : 'transparent'}; opacity: {item.disabled ? 0.7 : 1}; pointer-events: {item.disabled ? 'none' : 'auto'};"
+						>
+							{#if item.iconName}
+								<CustomIcon name={item.iconName} size={22} strokeWidth={2} color={iconColor} />
+							{:else if IconComponent}
+								<IconComponent size={22} color={iconColor} strokeWidth={2.5} />
+							{/if}
+						</button>
+					</span>
+				{/each}
+			</div>
+
+			</div><!-- end right group -->
+		</div>
+	</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     STARTING SESSION placeholder
+     ═══════════════════════════════════════════════════════════════════ -->
+{:else if isStarting && liveSession}
+	<div class="space-y-6">
 		<PageHeader
 			title={liveSession.session_id.slice(0, 8)}
 			breadcrumbs={[
 				{ label: 'Dashboard', href: '/' },
 				{ label: 'Projects', href: '/projects' },
-				{
-					label: getProjectName(liveSession.cwd || ''),
-					href: `/projects/${encodedName}`
-				},
+				{ label: getProjectName(liveSession.cwd || ''), href: `/projects/${encodedName}` },
 				{ label: liveSession.session_id.slice(0, 8) }
 			]}
 			subtitle="Session Starting"
 			class="mb-0"
 		/>
-
-		<div
-			class="flex flex-col items-center justify-center py-16 px-4 text-center rounded-lg border border-dashed border-[var(--nav-purple)]/40 bg-[var(--nav-purple-subtle)]"
-		>
+		<div class="flex flex-col items-center justify-center py-16 px-4 text-center rounded-lg border border-dashed border-[var(--nav-purple)]/40 bg-[var(--nav-purple-subtle)]">
 			<div class="p-4 rounded-full bg-[var(--nav-purple)]/10 mb-4">
 				<MessageCircle size={48} strokeWidth={1.5} class="text-[var(--nav-purple)]" />
 			</div>
-			<h3 class="text-lg font-medium text-[var(--text-primary)] mb-2">
-				Waiting for First Message
-			</h3>
+			<h3 class="text-lg font-medium text-[var(--text-primary)] mb-2">Waiting for First Message</h3>
 			<p class="text-sm text-[var(--text-secondary)] max-w-md mb-6">
-				This session has started but hasn't received its first prompt yet. Send your first
-				message to Claude to view the session details.
+				This session has started but hasn't received its first prompt yet.
 			</p>
-
-			<div
-				class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-[var(--nav-purple)]/10 border border-[var(--nav-purple)]/30"
-			>
+			<div class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-[var(--nav-purple)]/10 border border-[var(--nav-purple)]/30">
 				<span class="w-2 h-2 rounded-full bg-[var(--nav-purple)] animate-pulse"></span>
 				<span class="text-xs font-medium text-[var(--nav-purple)]">Starting</span>
 			</div>
-
 			<a
 				href="/projects/{encodedName}"
-				class="
-					mt-6 inline-flex items-center gap-2
-					px-4 py-2
-					text-sm font-medium
-					rounded-md border
-					bg-[var(--bg-muted)] border-[var(--border)] text-[var(--text-secondary)]
-					hover:bg-[var(--bg-subtle)] hover:border-[var(--border-hover)]
-					transition-colors
-				"
+				class="mt-6 inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md border bg-[var(--bg-muted)] border-[var(--border)] text-[var(--text-secondary)] hover:bg-[var(--bg-subtle)] hover:border-[var(--border-hover)] transition-colors"
 			>
 				<ArrowLeft size={16} strokeWidth={2} />
 				Back to Project
 			</a>
 		</div>
-	{:else if entity}
-		<!-- Header -->
+	</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     SUBAGENT SESSION — keep original tab layout
+     ═══════════════════════════════════════════════════════════════════ -->
+{:else if entity && isSubagentSession(entity)}
+	<div class="space-y-6">
 		<ConversationHeader
 			{entity}
 			{encodedName}
@@ -943,67 +1513,21 @@
 			{isRefreshing}
 		/>
 
-		<!-- Tabs -->
 		{#if tabsReady}
 			<Tabs.Root bind:value={activeTab} class="space-y-6">
-				<Tabs.List
-					class="flex items-center gap-1 p-1 bg-[var(--bg-subtle)] rounded-lg w-fit mx-auto border border-[var(--border)]"
-				>
+				<Tabs.List class="flex items-center gap-1 p-1 bg-[var(--bg-subtle)] rounded-lg w-fit mx-auto border border-[var(--border)]">
 					<TabsTrigger value="overview" icon={Info}>Overview</TabsTrigger>
 					<TabsTrigger value="timeline" icon={Clock}>Timeline</TabsTrigger>
 					<TabsTrigger value="tasks" icon={ListTodo}>
 						Tasks
 						{#if tasksArray.length > 0}
-							<span class="text-xs font-mono text-[var(--text-muted)]">
-								{tasksArray.filter((t) => t.status === 'completed')
-									.length}/{tasksArray.length}
-							</span>
+							<span class="text-xs font-mono text-[var(--text-muted)]">{tasksArray.filter((t) => t.status === 'completed').length}/{tasksArray.length}</span>
 						{/if}
 					</TabsTrigger>
-					{#if plan}
-						<TabsTrigger value="plan" icon={FileEdit}>Plan</TabsTrigger>
-					{/if}
 					<TabsTrigger value="files" icon={FileText}>Files</TabsTrigger>
-					{#if isMainSession(entity)}
-						<TabsTrigger value="agents" icon={Users}>
-							Subagents
-							{#if entity.subagent_count}
-								<span class="text-xs font-mono text-[var(--text-muted)]"
-									>{entity.subagent_count}</span
-								>
-							{/if}
-						</TabsTrigger>
-						{#if skillsArray.length > 0}
-							<TabsTrigger value="skills" icon={Zap}>
-								Skills
-								<span class="text-xs font-mono text-[var(--text-muted)]"
-									>{skillsArray.length}</span
-								>
-							</TabsTrigger>
-						{/if}
-						{#if commandsArray.length > 0}
-							<TabsTrigger value="commands" icon={TerminalSquare}>
-								Commands
-								<span class="text-xs font-mono text-[var(--text-muted)]"
-									>{commandsArray.length}</span
-								>
-							</TabsTrigger>
-						{/if}
-						<TabsTrigger value="shells" icon={Activity}>Shells</TabsTrigger>
-					<TabsTrigger value="cron" icon={AlarmClock}>Cron</TabsTrigger>
-					<TabsTrigger value="tickets" icon={TicketIcon}>
-							Tickets
-							{#if tickets.length > 0}
-								<span class="text-xs font-mono text-[var(--text-muted)]"
-									>{tickets.length}</span
-								>
-							{/if}
-						</TabsTrigger>
-					{/if}
 					<TabsTrigger value="analytics" icon={BarChart3}>Analytics</TabsTrigger>
 				</Tabs.List>
 
-				<!-- Overview Tab -->
 				<Tabs.Content value="overview">
 					<ConversationOverview
 						{entity}
@@ -1016,49 +1540,30 @@
 					/>
 				</Tabs.Content>
 
-				<!-- Timeline Tab -->
 				<Tabs.Content value="timeline" class="animate-fade-in">
 					<div class="space-y-4">
 						<div class="flex items-start justify-between gap-4">
 							<div>
-								<h2 class="text-lg font-semibold text-[var(--text-primary)]">
-									Timeline
-								</h2>
+								<h2 class="text-lg font-semibold text-[var(--text-primary)]">Timeline</h2>
 								<p class="text-sm text-[var(--text-muted)]">
 									{#if isTailing && timelineEvents.length > TAIL_COUNT}
 										Showing {TAIL_COUNT} of {timelineEvents.length} events
 									{:else}
-										Chronological sequence of events in this {entityLabel}
+										Chronological sequence of events in this agent
 									{/if}
 								</p>
 							</div>
-
 							{#if isCurrentlyLive && timelineEvents.length > 0}
 								<button
 									onclick={toggleTailing}
-									class="
-										inline-flex items-center gap-1.5 px-3 py-1.5
-										text-xs font-medium rounded-[var(--radius-md)] border
-										transition-all duration-150 shrink-0
-										{isTailing
-										? 'bg-[var(--success-subtle)] border-[var(--success)]/50 text-[var(--success)]'
-										: 'bg-[var(--bg-base)] border-[var(--border)] text-[var(--text-muted)] hover:border-[var(--success)]/30 hover:bg-[var(--success-subtle)]/50'}
-									"
-									title={isTailing
-										? 'Showing last 3 events - click to show all'
-										: 'Click to show only last 3 events'}
+									class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border transition-all duration-150 shrink-0 {isTailing ? 'bg-[var(--success-subtle)] border-[var(--success)]/50 text-[var(--success)]' : 'bg-[var(--bg-base)] border-[var(--border)] text-[var(--text-muted)]'}"
 									aria-pressed={isTailing}
 								>
-									<ArrowDown
-										size={14}
-										strokeWidth={2}
-										class={isTailing ? 'animate-pulse' : ''}
-									/>
-									<span>Tail Events</span>
+									<ArrowDown size={14} strokeWidth={2} class={isTailing ? 'animate-pulse' : ''} />
+									Tail Events
 								</button>
 							{/if}
 						</div>
-
 						{#if timelineEvents.length > 0}
 							<TimelineRail
 								events={timelineEvents}
@@ -1068,209 +1573,59 @@
 								{currentAgentId}
 								{projectPath}
 								projectEncoded={encodedName}
-								sessionSlug={sessionSlug}
+								{sessionSlug}
 								searchQuery={showConversationSearch ? conversationSearchQuery : ''}
-								onSearchMatchCount={(count) => {
-									searchMatchCount = count;
-								}}
-								onCurrentMatchChange={(idx) => {
-									currentSearchMatch = idx;
-								}}
+								onSearchMatchCount={(count) => { searchMatchCount = count; }}
+								onCurrentMatchChange={(idx) => { currentSearchMatch = idx; }}
 							/>
 						{:else}
-							<EmptyState
-								icon={Clock}
-								title="No timeline events available"
-								description="Timeline events will appear here as they occur"
-							/>
+							<EmptyState icon={Clock} title="No timeline events available" description="Timeline events will appear here as they occur" />
 						{/if}
 					</div>
 				</Tabs.Content>
 
-				<!-- Tasks Tab -->
 				<Tabs.Content value="tasks" class="animate-fade-in">
 					<TasksTab tasks={tasksArray} />
 				</Tabs.Content>
 
-				<!-- Plan Tab -->
-				{#if plan}
-					<Tabs.Content value="plan" class="animate-fade-in">
-						<PlanViewer {plan} embedded={true} />
-					</Tabs.Content>
-				{/if}
-
-				<!-- Files Tab -->
 				<Tabs.Content value="files" class="animate-fade-in">
-					<div class="space-y-4">
-						<div>
-							<h2 class="text-lg font-semibold text-[var(--text-primary)]">
-								File Activity
-							</h2>
-							<p class="text-sm text-[var(--text-muted)]">
-								All file operations performed during this {entityLabel}
-							</p>
-						</div>
-
-						{#if fileActivities.length > 0}
-							<FileActivityTable
-								activities={fileActivities}
-								{projectPath}
-								{currentAgentId}
-								{subagentTypes}
-							/>
-						{:else}
-							<EmptyState
-								icon={FileText}
-								title="No file activity recorded"
-								description="File operations will appear here when files are accessed"
-							/>
-						{/if}
-					</div>
+					{#if fileActivities.length > 0}
+						<FileActivityTable activities={fileActivities} {projectPath} {currentAgentId} {subagentTypes} />
+					{:else}
+						<EmptyState icon={FileText} title="No file activity recorded" description="File operations will appear here when files are accessed" />
+					{/if}
 				</Tabs.Content>
 
-				<!-- Subagents Tab (sessions only) -->
-				{#if isMainSession(entity)}
-					<Tabs.Content value="agents" class="animate-fade-in">
-						<div class="space-y-4">
-							<div>
-								<h2 class="text-lg font-semibold text-[var(--text-primary)]">
-									Subagents ({entity.subagents?.length || 0})
-								</h2>
-								<p class="text-sm text-[var(--text-muted)]">
-									Agents spawned during this session, grouped by type
-								</p>
-							</div>
-
-							{#if groupedSubagents.length > 0}
-								<div class="space-y-4">
-									{#each groupedSubagents as [type, agents] (type)}
-										<SubagentGroup
-											{type}
-											{agents}
-											projectEncoded={encodedName}
-											sessionSlug={entity?.uuid?.slice(0, 8) || sessionSlug}
-											liveSubagents={liveStatus?.subagents ?? {}}
-										/>
-									{/each}
-								</div>
-							{:else}
-								<div
-									class="flex flex-col items-center justify-center rounded-lg border border-dashed border-[var(--border)] py-12"
-								>
-									<Users
-										size={32}
-										strokeWidth={1.5}
-										class="text-[var(--text-muted)]/50"
-									/>
-									<p class="mt-2 text-sm text-[var(--text-muted)]">
-										No subagents were spawned during this session
-									</p>
-								</div>
-							{/if}
-						</div>
-					</Tabs.Content>
-
-					<!-- Skills Tab (sessions only, when skills exist) -->
-					{#if skillsArray.length > 0}
-						<Tabs.Content value="skills" class="animate-fade-in">
-							<SkillsPanel skills={skillsArray} projectEncodedName={encodedName} />
-						</Tabs.Content>
-					{/if}
-
-					<!-- Commands Tab (sessions only, when commands exist) -->
-					{#if commandsArray.length > 0}
-						<Tabs.Content value="commands" class="animate-fade-in">
-							<CommandsPanel
-								commands={commandsArray}
-								projectEncodedName={encodedName}
-							/>
-						</Tabs.Content>
-					{/if}
-
-					<!-- Tickets Tab (parity with project page tab; same component
-						 that previously sat above ConversationView). -->
-					<Tabs.Content value="tickets" class="animate-fade-in">
-						{#if sessionUuid}
-							<SessionTicketsSection
-								{sessionUuid}
-								{sessionSlug}
-								initial={tickets}
-							/>
-						{:else}
-							<p class="text-sm text-[var(--text-muted)] m-0 px-1 py-6 text-center">
-								Session UUID unavailable.
-							</p>
-						{/if}
-					</Tabs.Content>
-
-					<Tabs.Content value="shells" class="animate-fade-in">
-						{#if sessionUuid}
-							<SessionShellsSection {sessionUuid} />
-						{:else}
-							<p class="text-sm text-[var(--text-muted)] m-0 px-1 py-6 text-center">
-								Session UUID unavailable.
-							</p>
-						{/if}
-					</Tabs.Content>
-
-					<Tabs.Content value="cron" class="animate-fade-in">
-						{#if sessionUuid}
-							<SessionCronSection {sessionUuid} projectEncodedName={encodedName} />
-						{:else}
-							<p class="text-sm text-[var(--text-muted)] m-0 px-1 py-6 text-center">
-								Session UUID unavailable.
-							</p>
-						{/if}
-					</Tabs.Content>
-				{/if}
-
-				<!-- Analytics Tab -->
 				<Tabs.Content value="analytics" class="animate-fade-in">
 					<div class="space-y-6">
-						<div>
-							<h2 class="text-lg font-semibold text-[var(--text-primary)]">
-								{isSubagentSession(entity) ? 'Agent' : 'Session'} Analytics
-							</h2>
-							<p class="text-sm text-[var(--text-muted)]">
-								Detailed usage metrics for this {entityLabel}
-							</p>
-						</div>
-
 						<StatsGrid stats={analyticsStats} columns={5} />
-
 						{#if toolsArray.length > 0}
 							<div class="grid gap-6 lg:grid-cols-2">
 								<ToolUsageTable tools={toolsArray} totalCalls={totalToolCalls} />
 								<ToolsChart toolsUsed={toolsUsedRecord} />
 							</div>
 						{:else}
-							<EmptyState
-								icon={BarChart3}
-								title="No tools used during this {entityLabel}"
-								description="Tool usage statistics will appear here when tools are used"
-							/>
+							<EmptyState icon={BarChart3} title="No tools used" description="Tool usage statistics will appear here" />
 						{/if}
 					</div>
 				</Tabs.Content>
 			</Tabs.Root>
 		{/if}
-	{:else}
+	</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     LOADING / ERROR state
+     ═══════════════════════════════════════════════════════════════════ -->
+{:else}
+	<div class="space-y-6">
 		<SessionDetailSkeleton />
-	{/if}
-</div>
+	</div>
+{/if}
 
 <!-- Session Ended Toast Notification -->
 {#if sessionEnded}
 	<div
-		class="
-			fixed bottom-4 right-4 z-50
-			flex items-center gap-2.5
-			px-4 py-3
-			bg-[var(--bg-subtle)]
-			border border-[var(--border)]
-			rounded-lg shadow-lg
-			animate-fade-in
-		"
+		class="fixed bottom-4 right-4 z-50 flex items-center gap-2.5 px-4 py-3 bg-[var(--bg-subtle)] border border-[var(--border)] rounded-lg shadow-lg animate-fade-in"
 	>
 		<div class="w-2.5 h-2.5 rounded-full bg-[var(--text-muted)]"></div>
 		<span class="text-sm font-medium text-[var(--text-primary)]">

--- a/frontend/src/lib/components/conversation/ConversationView.svelte
+++ b/frontend/src/lib/components/conversation/ConversationView.svelte
@@ -911,6 +911,7 @@
 		| 'cron';
 
 	let activeDrawer = $state<DrawerKey | null>(null);
+	let drawerOpen = $state(false);
 	let drawerWidth = $state(296);
 	let resumeCopied = $state(false);
 	let expandedAgentIds = $state<Set<string>>(new Set());
@@ -947,7 +948,12 @@
 	let resumeCopyTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	function toggleDrawer(key: DrawerKey) {
-		activeDrawer = activeDrawer === key ? null : key;
+		if (activeDrawer === key) {
+			drawerOpen = !drawerOpen;
+		} else {
+			activeDrawer = key;
+			drawerOpen = true;
+		}
 	}
 
 	type RailItem = { key: DrawerKey; icon: typeof Info | null; iconName?: string; label: string; disabled: boolean; disabledTip: string };
@@ -981,6 +987,7 @@
 		if (activeDrawer === null) return;
 		const next = (activeDrawerIdx + dir + enabledRailItems.length) % enabledRailItems.length;
 		activeDrawer = enabledRailItems[next].key;
+		drawerOpen = true;
 	}
 
 	async function handleResumeCopy() {
@@ -1020,18 +1027,18 @@
 	>
 		<!-- ── Session Header ─────────────────────────────────────────────── -->
 		<div
-			class="flex-shrink-0 bg-white"
+			class="flex-shrink-0 bg-[var(--bg-base)]"
 			style="padding: 13px 24px 14px;"
 		>
 			<!-- Breadcrumb row -->
-			<div class="flex items-center gap-1 mb-2" style="font-size: 11px; color: #94a3b8;">
-				<a href="/" class="hover:text-[#64748b] transition-colors" style="color: #94a3b8;">Dashboard</a>
-				<span style="color: #d1d5db;">/</span>
-				<a href="/projects" class="hover:text-[#64748b] transition-colors" style="color: #94a3b8;">Projects</a>
-				<span style="color: #d1d5db;">/</span>
-				<a href="/projects/{encodedName}" class="hover:text-[#64748b] transition-colors" style="color: #94a3b8;">{getProjectName(projectPath || '')}</a>
-				<span style="color: #d1d5db;">/</span>
-				<span style="color: #64748b; font-family: 'JetBrains Mono', monospace;">{shortId}</span>
+			<div class="flex items-center gap-1 mb-2" style="font-size: 11px; color: var(--text-faint);">
+				<a href="/" class="hover:text-[var(--text-muted)] transition-colors" style="color: var(--text-faint);">Dashboard</a>
+				<span style="color: var(--border);">/</span>
+				<a href="/projects" class="hover:text-[var(--text-muted)] transition-colors" style="color: var(--text-faint);">Projects</a>
+				<span style="color: var(--border);">/</span>
+				<a href="/projects/{encodedName}" class="hover:text-[var(--text-muted)] transition-colors" style="color: var(--text-faint);">{getProjectName(projectPath || '')}</a>
+				<span style="color: var(--border);">/</span>
+				<span style="color: var(--text-muted); font-family: 'JetBrains Mono', monospace;">{shortId}</span>
 			</div>
 
 			<!-- Title row -->
@@ -1039,7 +1046,7 @@
 				<div class="min-w-0 flex-1">
 					<!-- Session title -->
 					<h1
-						class="leading-[1.3] text-[#0f172a]"
+						class="leading-[1.3] text-[var(--text-primary)]"
 						style="font-size: 17px; font-weight: 700; letter-spacing: -0.02em; text-wrap: pretty;"
 					>
 						{sessionTitle}
@@ -1050,21 +1057,21 @@
 						<!-- Session ID chip -->
 						<span
 							class="inline-flex items-center"
-							style="font-size: 10.5px; background: #f1f5f9; border: 1px solid #e2e8f0; border-radius: 4px; padding: 2px 7px; color: #64748b; font-family: 'JetBrains Mono', monospace;"
+							style="font-size: 10.5px; background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 4px; padding: 2px 7px; color: var(--text-muted); font-family: 'JetBrains Mono', monospace;"
 						>#{shortId}</span>
 
 						<!-- Date -->
 						{#if sessionEntity.start_time}
-							<span class="inline-flex items-center gap-1" style="font-size: 11px; color: #64748b;">
-								<Calendar size={11} color="#94a3b8" />
+							<span class="inline-flex items-center gap-1" style="font-size: 11px; color: var(--text-muted);">
+								<Calendar size={11} color="var(--text-faint)" />
 								{formatDateFull(sessionEntity.start_time)}
 							</span>
 						{/if}
 
 						<!-- Duration -->
 						{#if sessionEntity.duration_seconds}
-							<span class="inline-flex items-center gap-1" style="font-size: 11px; color: #64748b;">
-								<Clock size={11} color="#94a3b8" />
+							<span class="inline-flex items-center gap-1" style="font-size: 11px; color: var(--text-muted);">
+								<Clock size={11} color="var(--text-faint)" />
 								{formatDuration(sessionEntity.duration_seconds)}
 							</span>
 						{/if}
@@ -1073,9 +1080,9 @@
 						{#if primaryModel}
 							<span
 								class="inline-flex items-center gap-1"
-								style="font-size: 10.5px; font-weight: 500; color: #7c3aed; background: #faf5ff; border: 1px solid #e9d5ff; border-radius: 4px; padding: 2px 7px;"
+								style="font-size: 10.5px; font-weight: 500; color: var(--nav-purple); background: var(--nav-purple-subtle); border: 1px solid color-mix(in srgb, var(--nav-purple) 25%, transparent); border-radius: 4px; padding: 2px 7px;"
 							>
-								<Sparkles size={10} color="#7c3aed" />
+								<Sparkles size={10} color="var(--nav-purple)" />
 								{primaryModel}
 							</span>
 						{/if}
@@ -1084,9 +1091,9 @@
 						{#if primaryBranch}
 							<span
 								class="inline-flex items-center gap-1"
-								style="font-size: 10.5px; font-weight: 500; color: #0891b2; background: #f0f9ff; border: 1px solid #bae6fd; border-radius: 4px; padding: 2px 7px;"
+								style="font-size: 10.5px; font-weight: 500; color: var(--nav-teal); background: var(--nav-teal-subtle); border: 1px solid color-mix(in srgb, var(--nav-teal) 25%, transparent); border-radius: 4px; padding: 2px 7px;"
 							>
-								<GitBranch size={10} color="#0891b2" />
+								<GitBranch size={10} color="var(--nav-teal)" />
 								{primaryBranch}
 							</span>
 						{/if}
@@ -1096,16 +1103,16 @@
 							{@const ci = sessionEntity.chain_info}
 							<span
 								class="inline-flex items-center gap-1"
-								style="font-size: 10.5px; color: #64748b; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 4px; padding: 2px 7px;"
+								style="font-size: 10.5px; color: var(--text-muted); background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 4px; padding: 2px 7px;"
 							>
-								<Link2 size={10} color="#94a3b8" />
+								<Link2 size={10} color="var(--text-faint)" />
 								Session {ci.position + 1} of {ci.total}
 							</span>
 						{/if}
 
 						<!-- Cost -->
 						{#if sessionEntity.total_cost}
-							<span style="font-size: 11px; color: #64748b;">{formatCost(sessionEntity.total_cost)}</span>
+							<span style="font-size: 11px; color: var(--text-muted);">{formatCost(sessionEntity.total_cost)}</span>
 						{/if}
 
 						<!-- Live status -->
@@ -1130,8 +1137,8 @@
 
 						<!-- Syncing indicator -->
 						{#if isRefreshing}
-							<span class="inline-flex items-center gap-1" style="font-size: 10.5px; color: #0891b2;">
-								<RefreshCw size={10} class="animate-spin" color="#0891b2" />
+							<span class="inline-flex items-center gap-1" style="font-size: 10.5px; color: var(--nav-teal);">
+								<RefreshCw size={10} class="animate-spin" color="var(--nav-teal)" />
 								Syncing
 							</span>
 						{/if}
@@ -1149,11 +1156,11 @@
 							style="
 								padding: 5px 10px;
 								border-radius: 7px;
-								border: 1px solid {isTailing ? '#bbf7d0' : '#e2e8f0'};
-								background: {isTailing ? '#f0fdf4' : '#fff'};
+								border: 1px solid {isTailing ? 'color-mix(in srgb, var(--nav-green) 30%, transparent)' : 'var(--border)'};
+								background: {isTailing ? 'var(--nav-green-subtle)' : 'var(--bg-base)'};
 								font-size: 11px;
 								font-weight: 500;
-								color: {isTailing ? '#16a34a' : '#64748b'};
+								color: {isTailing ? 'var(--nav-green)' : 'var(--text-muted)'};
 								box-shadow: 0 1px 2px rgba(0,0,0,0.04);
 							"
 						>
@@ -1168,19 +1175,19 @@
 						class="inline-flex items-center gap-1.5 transition-all"
 						style="
 							padding: 7px 14px;
-							border: 1px solid #e2e8f0;
+							border: 1px solid var(--border);
 							border-radius: 7px;
-							background: #fff;
+							background: var(--bg-base);
 							font-size: 12px;
 							font-weight: 500;
-							color: {resumeCopied ? '#16a34a' : '#374151'};
+							color: {resumeCopied ? 'var(--nav-green)' : 'var(--text-primary)'};
 							box-shadow: 0 1px 2px rgba(0,0,0,0.04);
 							white-space: nowrap;
 						"
 						title="Copy: claude --resume {sessionEntity.uuid}"
 					>
 						{#if resumeCopied}
-							<Check size={12} color="#16a34a" />
+							<Check size={12} color="var(--nav-green)" />
 							Copied!
 						{:else}
 							<Play size={12} />
@@ -1195,7 +1202,7 @@
 		<div class="flex flex-1 min-h-0" style="gap: 10px; padding: 8px 0 8px; overflow: hidden; align-items: stretch;">
 
 			<!-- ── Timeline column ─────────────────────────────────────────── -->
-			<div class="flex-1 flex flex-col overflow-hidden min-w-0" style="background: #fff;">
+			<div class="flex-1 flex flex-col overflow-hidden min-w-0" style="background: var(--bg-base);">
 				{#if timelineEvents.length > 0}
 					<div class="flex-1 overflow-y-auto" style="scrollbar-width: none;">
 						<TimelineRail
@@ -1221,21 +1228,21 @@
 			</div>
 
 			<!-- ── Right group: drawer + rail, no gap between them ──────────── -->
-			<div class="flex flex-shrink-0 overflow-hidden" style="border-radius: 12px; background: #f1f5f9;">
+			<div class="flex flex-shrink-0 overflow-hidden" style="border-radius: 12px; background: var(--bg-subtle);">
 
 			<!-- ── Drawer ────────────────────────────────────────────────────── -->
-			{#if activeDrawer !== null}
+			{#if drawerOpen && activeDrawer !== null}
 				<div
 					class="flex flex-col overflow-hidden flex-shrink-0"
-					style="width: 350px; border-right: 1px solid #e2e8f0;"
+					style="width: 350px; border-right: 1px solid var(--border);"
 				>
 					<!-- Drawer header -->
-					<div class="flex items-center justify-between flex-shrink-0" style="height: 44px; padding: 0 16px; border-bottom: 1px solid #e2e8f0;">
-						<span style="font-size: 13px; font-weight: 600; color: #0f172a; letter-spacing: -0.01em;">{drawerTitle}</span>
+					<div class="flex items-center justify-between flex-shrink-0" style="height: 44px; padding: 0 16px; border-bottom: 1px solid var(--border);">
+						<span style="font-size: 13px; font-weight: 600; color: var(--text-primary); letter-spacing: -0.01em;">{drawerTitle}</span>
 						<div class="flex items-center" style="gap: 2px;">
-							<button onclick={() => cycleDrawer(-1)} disabled={activeDrawerIdx <= 0} style="width: 26px; height: 26px; border: none; background: none; color: #64748b; opacity: {activeDrawerIdx <= 0 ? 0.25 : 1}; cursor: {activeDrawerIdx <= 0 ? 'default' : 'pointer'}; display: flex; align-items: center; justify-content: center; border-radius: 4px;" aria-label="Previous drawer"><ChevronLeft size={15} /></button>
-							<button onclick={() => cycleDrawer(1)} disabled={activeDrawerIdx >= enabledRailItems.length - 1} style="width: 26px; height: 26px; border: none; background: none; color: #64748b; opacity: {activeDrawerIdx >= enabledRailItems.length - 1 ? 0.25 : 1}; cursor: {activeDrawerIdx >= railItems.length - 1 ? 'default' : 'pointer'}; display: flex; align-items: center; justify-content: center; border-radius: 4px;" aria-label="Next drawer"><ChevronRight size={15} /></button>
-							<button onclick={() => (activeDrawer = null)} style="width: 26px; height: 26px; border: none; background: none; color: #64748b; cursor: pointer; display: flex; align-items: center; justify-content: center; border-radius: 4px;" aria-label="Close drawer"><X size={15} /></button>
+							<button onclick={() => cycleDrawer(-1)} disabled={activeDrawerIdx <= 0} style="width: 26px; height: 26px; border: none; background: none; color: var(--text-muted); opacity: {activeDrawerIdx <= 0 ? 0.25 : 1}; cursor: {activeDrawerIdx <= 0 ? 'default' : 'pointer'}; display: flex; align-items: center; justify-content: center; border-radius: 4px;" aria-label="Previous drawer"><ChevronLeft size={15} /></button>
+							<button onclick={() => cycleDrawer(1)} disabled={activeDrawerIdx >= enabledRailItems.length - 1} style="width: 26px; height: 26px; border: none; background: none; color: var(--text-muted); opacity: {activeDrawerIdx >= enabledRailItems.length - 1 ? 0.25 : 1}; cursor: {activeDrawerIdx >= railItems.length - 1 ? 'default' : 'pointer'}; display: flex; align-items: center; justify-content: center; border-radius: 4px;" aria-label="Next drawer"><ChevronRight size={15} /></button>
+							<button onclick={() => (drawerOpen = false)} style="width: 26px; height: 26px; border: none; background: none; color: var(--text-muted); cursor: pointer; display: flex; align-items: center; justify-content: center; border-radius: 4px;" aria-label="Close drawer"><X size={15} /></button>
 						</div>
 					</div>
 					<!-- Drawer body -->
@@ -1437,9 +1444,10 @@
 				style="width: 68px; padding: 14px 0; gap: 6px; scrollbar-width: none;"
 			>
 				{#each railItems as item (item.key)}
-					{@const isActive = activeDrawer === item.key}
+					{@const isSelected = activeDrawer === item.key}
+					{@const isOpen = isSelected && drawerOpen}
 					{@const IconComponent = item.icon}
-					{@const iconColor = isActive ? '#ffffff' : item.disabled ? '#94a3b8' : '#475569'}
+					{@const iconColor = isSelected ? 'var(--rail-active-icon)' : item.disabled ? 'var(--text-faint)' : 'var(--text-primary)'}
 					<!-- Wrapper carries the tooltip — pointer-events on button are off when disabled so title fires from wrapper -->
 					<span
 						title={item.disabled ? item.disabledTip : item.label}
@@ -1447,10 +1455,10 @@
 					>
 						<button
 							onclick={() => toggleDrawer(item.key)}
-							aria-pressed={isActive}
+							aria-pressed={isOpen}
 							aria-disabled={item.disabled}
 							class="relative flex items-center justify-center flex-shrink-0 transition-all duration-150"
-							style="width: 52px; height: 52px; border-radius: 12px; border: none; cursor: {item.disabled ? 'default' : 'pointer'}; background: {isActive ? '#0f172a' : 'transparent'}; opacity: {item.disabled ? 0.7 : 1}; pointer-events: {item.disabled ? 'none' : 'auto'};"
+							style="width: 52px; height: 52px; border-radius: 12px; border: none; cursor: {item.disabled ? 'default' : 'pointer'}; background: {isOpen ? 'var(--rail-active-bg)' : 'transparent'}; opacity: {isSelected ? 1 : item.disabled ? 0.3 : 0.85}; pointer-events: {item.disabled ? 'none' : 'auto'};"
 						>
 							{#if item.iconName}
 								<CustomIcon name={item.iconName} size={22} strokeWidth={2} color={iconColor} />

--- a/frontend/src/lib/components/conversation/ConversationView.svelte
+++ b/frontend/src/lib/components/conversation/ConversationView.svelte
@@ -957,14 +957,14 @@
 		const items: RailItem[] = [
 			{ key: 'overview',  icon: Info,        label: 'Overview',  disabled: false, disabledTip: '' },
 			{ key: 'files',     icon: FileText,    label: 'Files',     disabled: fileActivities.length === 0, disabledTip: 'No file activity in this session' },
-			{ key: 'analytics', icon: BarChart2,   label: 'Analytics', disabled: false, disabledTip: '' },
+			{ key: 'analytics', icon: null, iconName: 'analytics', label: 'Analytics', disabled: false, disabledTip: '' },
 			{ key: 'tasks',     icon: CheckSquare, label: 'Tasks',     disabled: tasksArray.length === 0, disabledTip: 'No tasks in this session' },
 		];
 		if (isMain) {
 			const agentCount = (entity as { subagents?: unknown[] }).subagents?.length ?? 0;
 			items.push({ key: 'agents',   icon: null, iconName: 'agents',  label: 'Agents',   disabled: agentCount === 0,          disabledTip: 'No agents in this session' });
 			items.push({ key: 'plan',     icon: null, iconName: 'plans',   label: 'Plan',     disabled: !plan,                     disabledTip: 'No plan in this session' });
-			items.push({ key: 'skills',   icon: Zap,                       label: 'Skills',   disabled: skillsArray.length === 0,  disabledTip: 'No skills in this session' });
+			items.push({ key: 'skills',   icon: null, iconName: 'skills',  label: 'Skills',   disabled: skillsArray.length === 0,  disabledTip: 'No skills in this session' });
 			items.push({ key: 'commands', icon: Terminal,                  label: 'Commands', disabled: commandsArray.length === 0, disabledTip: 'No commands in this session' });
 			items.push({ key: 'shells',   icon: null, iconName: 'shells',  label: 'Shells',   disabled: shellCount === 0,           disabledTip: 'No background shells in this session' });
 			items.push({ key: 'cron',     icon: null, iconName: 'cron',    label: 'Cron',     disabled: cronCount === 0,            disabledTip: 'No cron jobs in this session' });

--- a/frontend/src/lib/components/conversation/ConversationView.svelte
+++ b/frontend/src/lib/components/conversation/ConversationView.svelte
@@ -968,7 +968,7 @@
 			items.push({ key: 'commands', icon: Terminal,                  label: 'Commands', disabled: commandsArray.length === 0, disabledTip: 'No commands in this session' });
 			items.push({ key: 'shells',   icon: null, iconName: 'shells',  label: 'Shells',   disabled: shellCount === 0,           disabledTip: 'No background shells in this session' });
 			items.push({ key: 'cron',     icon: null, iconName: 'cron',    label: 'Cron',     disabled: cronCount === 0,            disabledTip: 'No cron jobs in this session' });
-			items.push({ key: 'tickets',  icon: null, iconName: 'tickets', label: 'Tickets',  disabled: tickets.length === 0,      disabledTip: 'No tickets in this session' });
+			items.push({ key: 'tickets',  icon: null, iconName: 'tickets', label: 'Tickets',  disabled: false,                     disabledTip: '' });
 		}
 		return items;
 	});
@@ -1412,14 +1412,20 @@
 							{/if}
 						{/if}
 					</div>
-					<!-- Drawer footer: shell legend -->
+					<!-- Drawer footer legends -->
 					{#if activeDrawer === 'shells'}
-						<div class="flex-shrink-0 flex items-center gap-4 flex-wrap" style="padding: 10px 20px; border-top: 1px solid #e2e8f0;">
+						<div class="flex-shrink-0 flex items-center gap-4 flex-wrap" style="padding: 10px 20px; border-top: 1px solid var(--border);">
 							<span class="flex items-center gap-1.5 text-[10px] text-[var(--text-faint)]"><span class="w-1.5 h-1.5 rounded-full" style="background: var(--success);"></span>running</span>
 							<span class="flex items-center gap-1.5 text-[10px] text-[var(--text-faint)]"><span class="w-1.5 h-1.5 rounded-full" style="background: var(--info);"></span>done</span>
 							<span class="flex items-center gap-1.5 text-[10px] text-[var(--text-faint)]"><span class="w-1.5 h-1.5 rounded-full" style="background: var(--error);"></span>killed</span>
 							<span class="flex items-center gap-1.5 text-[10px] text-[var(--text-faint)]"><span class="w-1.5 h-1.5 rounded-full" style="background: var(--warning);"></span>timeout</span>
 							<span class="flex items-center gap-1.5 text-[10px] text-[var(--text-faint)]"><span class="w-1.5 h-1.5 rounded-full" style="background: var(--text-faint);"></span>ended</span>
+						</div>
+					{:else if activeDrawer === 'tasks'}
+						<div class="flex-shrink-0 flex items-center justify-center gap-4 flex-wrap" style="padding: 10px 20px; border-top: 1px solid var(--border);">
+							<span class="flex items-center gap-1.5 text-[10px] text-[var(--text-faint)]"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/></svg>Pending</span>
+							<span class="flex items-center gap-1.5 text-[10px]" style="color: var(--nav-blue);"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>In Progress</span>
+							<span class="flex items-center gap-1.5 text-[10px]" style="color: var(--success);"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>Completed</span>
 						</div>
 					{/if}
 				</div>

--- a/frontend/src/lib/components/cron/SessionCronSection.svelte
+++ b/frontend/src/lib/components/cron/SessionCronSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { Clock, Loader2, Info, ChevronRight } from 'lucide-svelte';
+	import { Clock, Loader2, ChevronRight, Repeat, Zap, ExternalLink } from 'lucide-svelte';
 	import { API_BASE } from '$lib/config';
 	import type { CronJob, CronListResponse } from '$lib/api-types';
 
@@ -30,7 +30,6 @@
 		}
 	});
 
-	// ── status helpers ────────────────────────────────────────────────────────
 	type DerivedStatus = 'active' | 'expired' | 'deleted';
 
 	function statusOf(j: CronJob): DerivedStatus {
@@ -39,11 +38,8 @@
 		return 'active';
 	}
 
-	let hasLiveState = $derived(
-		jobs.some((j) => j.latest_state !== null && j.latest_state !== undefined)
-	);
+	let hasLiveState = $derived(jobs.some((j) => j.latest_state !== null && j.latest_state !== undefined));
 
-	// ── helpers ───────────────────────────────────────────────────────────────
 	function toggle(key: string) {
 		const next = new Set(openIds);
 		next.has(key) ? next.delete(key) : next.add(key);
@@ -69,14 +65,8 @@
 		const min = Math.floor(sec / 60);
 		const hr = Math.floor(min / 60);
 		const day = Math.floor(hr / 24);
-		if (day >= 1) {
-			const rh = hr - day * 24;
-			return rh > 0 ? `${day}d ${rh}h` : `${day}d`;
-		}
-		if (hr >= 1) {
-			const rm = min - hr * 60;
-			return rm > 0 ? `${hr}h ${rm}m` : `${hr}h`;
-		}
+		if (day >= 1) { const rh = hr - day * 24; return rh > 0 ? `${day}d ${rh}h` : `${day}d`; }
+		if (hr >= 1) { const rm = min - hr * 60; return rm > 0 ? `${hr}h ${rm}m` : `${hr}h`; }
 		if (min >= 1) return `${min}m`;
 		return `${sec}s`;
 	}
@@ -88,12 +78,11 @@
 	}
 
 	function formatAbsolute(iso: string): string {
-		return new Date(iso).toLocaleString(undefined, {
-			month: 'short',
-			day: 'numeric',
-			hour: '2-digit',
-			minute: '2-digit'
-		});
+		return new Date(iso).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+	}
+
+	function formatDate(iso: string): string {
+		return new Date(iso).toLocaleString(undefined, { month: 'short', day: 'numeric' });
 	}
 
 	function formatShortTime(iso: string): string {
@@ -101,14 +90,7 @@
 	}
 
 	type DotVariant = 'truth' | 'likely' | 'expired' | 'deleted';
-
-	interface StatusMeta {
-		dot: DotVariant;
-		label: string;
-		isLikely: boolean;
-		via: string | null;
-		truth: boolean;
-	}
+	interface StatusMeta { dot: DotVariant; label: string; isLikely: boolean; via: string | null; truth: boolean; }
 
 	function getStatusMeta(j: CronJob): StatusMeta {
 		const s = statusOf(j);
@@ -116,21 +98,14 @@
 			const truth = j.latest_state !== null && j.latest_state !== undefined;
 			return truth
 				? { dot: 'truth', label: 'ACTIVE', isLikely: false, via: null, truth: true }
-				: { dot: 'likely', label: 'LIKELY ACTIVE', isLikely: true, via: null, truth: false };
+				: { dot: 'likely', label: 'ACTIVE', isLikely: true, via: null, truth: false };
 		}
-		if (s === 'expired') {
-			return { dot: 'expired', label: 'TTL EXPIRED', isLikely: false, via: null, truth: false };
-		}
+		if (s === 'expired') return { dot: 'expired', label: 'TTL EXPIRED', isLikely: false, via: null, truth: false };
 		const viaMap: Record<string, string> = {
-			CronDelete: 'via explicit delete',
-			session_end: 'via session end',
-			expiry: 'via expiry',
-			unknown: 'deletion unobserved'
+			CronDelete: 'via explicit delete', session_end: 'via session end', expiry: 'via expiry', unknown: 'deletion unobserved'
 		};
 		return {
-			dot: 'deleted',
-			label: 'DELETED',
-			isLikely: false,
+			dot: 'deleted', label: 'DELETED', isLikely: false,
 			via: j.deleted_via ? (viaMap[j.deleted_via] ?? j.deleted_via) : 'deletion unobserved',
 			truth: false
 		};
@@ -155,53 +130,41 @@
 	}
 </script>
 
-<div class="section">
-	<!-- Section header -->
+<div class="cron-wrap">
+	<!-- Header -->
 	<div class="sec-header">
-		<div>
-			<h2 class="sec-title">Scheduled jobs</h2>
-			<p class="sec-sub">
-				{#if hasLiveState}
-					Live state captured via hook.
-				{:else}
-					Reconstructed from session JSONL — cron is in-memory and session-scoped.
-				{/if}
-			</p>
-		</div>
+		<span class="sec-label">
+			{#if loading}Cron jobs{:else}{jobs.length} cron job{jobs.length !== 1 ? 's' : ''}{/if}
+		</span>
 		{#if !loading && jobs.length > 0 && projectEncodedName}
 			<a href="/cron?project={projectEncodedName}" class="view-all">
-				View all in project →
+				View all <ExternalLink size={9} />
 			</a>
 		{/if}
 	</div>
 
-	<!-- No-hook notice -->
+	<!-- Inferred-state note -->
 	{#if !hasLiveState && !loading && jobs.length > 0}
-		<div class="notice">
-			<Info size={13} class="shrink-0 mt-px" style="color: var(--info);" />
-			<span>
-				The optional <code>cron_state_capture.py</code> hook is not installed — "likely active"
-				status is inferred from the 7-day TTL window.
-			</span>
-		</div>
+		<p class="inferred-note">
+			Status inferred from 7-day TTL — install <code>cron_state_capture.py</code> for live state.
+		</p>
 	{/if}
 
 	<!-- Loading -->
 	{#if loading}
 		<div class="center-state">
-			<Loader2 size={18} class="animate-spin" style="color: var(--text-faint);" />
+			<Loader2 size={14} class="animate-spin" style="color: var(--text-faint);" />
 		</div>
 
 	<!-- Error -->
 	{:else if error}
-		<div class="error-state">Failed to load cron jobs: {error}</div>
+		<p class="error-note">Failed to load: {error}</p>
 
 	<!-- Empty -->
 	{:else if jobs.length === 0}
 		<div class="empty-state">
-			<Clock size={24} style="opacity: 0.35; color: var(--text-faint);" />
-			<p class="m-0">No scheduled jobs recorded for this session.</p>
-			<p class="empty-hint">They appear here when Claude runs <code>CronCreate</code>.</p>
+			<Clock size={18} style="opacity: 0.3; color: var(--text-faint);" />
+			<p class="m-0">No scheduled jobs in this session.</p>
 		</div>
 
 	<!-- Job list -->
@@ -214,185 +177,123 @@
 				{@const ttl = getTtlInfo(job)}
 				{@const s = statusOf(job)}
 				{@const human = cronHuman(job.cron_expression)}
+				{@const visibleFires = (job.fires ?? []).filter((f) => f.outcome_excerpt || f.inference_source === 'hook')}
 
 				<div class="cron-card" class:expanded class:gone={s !== 'active'}>
 					<!-- Collapsed row -->
 					<button type="button" class="cron-row" onclick={() => toggle(key)}>
-						<span class="caret" class:open={expanded}>
-							<ChevronRight size={13} />
-						</span>
-
+						<!-- Status dot -->
 						<span
 							class="status-dot"
 							class:dot-truth={meta.dot === 'truth'}
 							style={dotStyle(meta.dot)}
 						></span>
 
+						<!-- Content column -->
 						<div class="row-content">
-							<!-- Line 1 -->
+							<!-- Line 1: ID + recur type + status -->
 							<div class="row-head">
 								<span class="cron-id">{(job.cron_id ?? job.tool_use_id).slice(0, 8)}</span>
-								<span class="pill pill-schedule">{human}</span>
-								{#if job.recurring}
-									<span class="pill pill-recur">RECURRING</span>
-								{:else}
-									<span class="pill pill-once">ONE-SHOT</span>
-								{/if}
+								<span class="recur-icon" class:recur-on={job.recurring} title={job.recurring ? 'Recurring' : 'One-shot'}>
+									{#if job.recurring}<Repeat size={10} />{:else}<Zap size={10} />{/if}
+								</span>
 								<span
 									class="status-tag"
-									class:tag-active-likely={s === 'active'}
+									class:tag-active={s === 'active' && !meta.isLikely}
+									class:tag-likely={meta.isLikely}
 									class:tag-inactive={s !== 'active'}
 								>
-									{meta.label}
-									{#if meta.isLikely}<span class="qm">·?</span>{/if}
+									{meta.label}{#if meta.isLikely}<sup class="qm">?</sup>{/if}
 									{#if meta.via}<span class="via"> · {meta.via}</span>{/if}
 								</span>
-								{#if meta.truth}
-									<span class="pill pill-hook">HOOK</span>
-								{/if}
+								{#if meta.truth}<span class="pill-hook">HOOK</span>{/if}
 							</div>
 
 							<!-- Line 2: Prompt -->
-							<div class="row-prompt">
-								<span class="quote">"</span>{job.prompt}<span class="quote">"</span>
-							</div>
+							<div class="row-prompt" class:expanded>{job.prompt}</div>
 
-							<!-- Line 3: TTL bar -->
-							<div class="ttl-inline">
-								<div class="ttl-track">
-									<div
-										class="ttl-fill"
-										style="width: {ttl.pct}%; background: {ttl.expired
-											? 'var(--text-faint)'
-											: ttl.warn
-												? 'var(--warning)'
-												: 'var(--success)'}; {ttl.expired ? 'opacity: 0.4;' : ''}"
-									></div>
-								</div>
-								<span class="ttl-label">
-									{#if s === 'deleted'}
-										deleted
-									{:else if ttl.expired}
-										TTL expired
-									{:else}
-										{formatRelative(ttl.remaining)} left
-									{/if}
-								</span>
-								{#if job.fires && job.fires.length > 0}
+							<!-- Line 3: schedule · fires · TTL -->
+							<div class="row-meta">
+								<span class="mono-dim">{human}</span>
+								{#if visibleFires.length > 0}
 									<span class="sep">·</span>
-									<span class="ttl-label">{job.fires.length} {job.fires.length === 1 ? 'fire' : 'fires'}</span>
+									<span class="mono-dim">{visibleFires.length} {visibleFires.length === 1 ? 'fire' : 'fires'}</span>
+								{/if}
+								<span class="sep">·</span>
+								{#if s === 'deleted'}
+									<span class="mono-dim">deleted</span>
+								{:else if ttl.expired}
+									<span class="mono-dim">TTL elapsed</span>
+								{:else}
+									<span class="mono-dim" class:warn-text={ttl.warn}>{formatRelative(ttl.remaining)} left</span>
 								{/if}
 							</div>
 						</div>
+
+						<!-- Caret -->
+						<span class="caret" class:open={expanded}>
+							<ChevronRight size={13} />
+						</span>
 					</button>
 
 					<!-- Expanded panel -->
 					{#if expanded}
 						<div class="panel">
-							<!-- Left: kv details -->
-							<div class="kv-col">
+							<!-- Meta strip -->
+							<div class="meta-row">
 								<div class="kv-row">
-									<span class="kv-label">Cron ID</span>
-									<span class="kv-val" style="color: var(--accent);">{job.cron_id ?? job.tool_use_id}</span>
-								</div>
-								<div class="kv-row">
-									<span class="kv-label">Schedule</span>
+									<span class="kv-label">Lifetime</span>
 									<span class="kv-val">
-										{job.cron_expression}<span class="kv-dim"> · {human}</span>
-									</span>
-								</div>
-								<div class="kv-row">
-									<span class="kv-label">Created</span>
-									<span class="kv-val">
-										{formatAbsolute(job.created_at)}<span class="kv-dim"> · {formatTimeAgo(job.created_at)}</span>
-									</span>
-								</div>
-								<div class="kv-row">
-									<span class="kv-label">TTL expires</span>
-									<span class="kv-val">
-										{formatAbsolute(job.ttl_expires_at)}<span class="kv-dim"> · {formatTimeAgo(job.ttl_expires_at)}</span>
+										{formatDate(job.created_at)} → {formatDate(job.ttl_expires_at)}
+										<span class="kv-dim"> · 7 days</span>
 									</span>
 								</div>
 								{#if job.deleted_at}
 									<div class="kv-row">
 										<span class="kv-label">Deleted</span>
-										<span class="kv-val">
-											{formatAbsolute(job.deleted_at)}<span class="kv-dim"> · {meta.via}</span>
-										</span>
+										<span class="kv-val">{formatAbsolute(job.deleted_at)}<span class="kv-dim"> · {meta.via}</span></span>
 									</div>
 								{/if}
 								{#if job.latest_state}
 									<div class="kv-row">
-										<span class="kv-label">Ground-truth state</span>
-										<span class="kv-val">
-											<span style="color: var(--success);">● alive</span>
-											<span class="kv-dim"> · observed {formatTimeAgo(job.latest_state.captured_at)}</span>
-										</span>
+										<span class="kv-label">Live state</span>
+										<span class="kv-val"><span style="color: var(--success);">● alive</span><span class="kv-dim"> · {formatTimeAgo(job.latest_state.captured_at)}</span></span>
 									</div>
 								{/if}
 								<div class="kv-row">
-									<span class="kv-label">Prompt</span>
-									<div class="prompt-block">
-										<span class="barb">{'>'}</span>
-										{job.prompt}
-									</div>
+									<span class="kv-label">Schedule</span>
+									<span class="kv-val mono">{job.cron_expression}<span class="kv-dim"> · {human}</span></span>
 								</div>
 							</div>
 
-							<!-- Right: fires -->
-							<div class="fires-col">
-								<div class="fires-header">
-									<span class="kv-label">
-										{#if !job.fires || job.fires.length === 0}
-											No fires recorded
-										{:else}
-											Fires · {job.fires.length}
-											{job.fires.length === 1 ? 'event' : 'events'}
-										{/if}
-									</span>
-									{#if job.fires && job.fires.length > 0}
-										<span class="fires-source">
-											{job.fires.some((f) => f.inference_source === 'hook')
-												? 'hook · ground truth'
-												: 'inferred from logs'}
-										</span>
-									{/if}
-								</div>
+							<!-- Fires section -->
+							<div class="fires-section">
+								<span class="kv-label">
+									{#if visibleFires.length === 0}No fires recorded{:else}Fires · {visibleFires.length} {visibleFires.length === 1 ? 'event' : 'events'}{/if}
+								</span>
 
-								{#if !job.fires || job.fires.length === 0}
+								{#if visibleFires.length === 0}
 									<div class="fires-empty">
-										{#if job.recurring}
-											No fires yet. <b>Cron was created {formatTimeAgo(job.created_at)}</b> and no fires have been observed in the session log.
-										{:else}
-											One-shot cron hasn't fired yet — scheduled for <b>{formatAbsolute(job.ttl_expires_at)}</b>.
-										{/if}
+										{#if job.recurring}No fires observed in session log.{:else}One-shot — no fires recorded.{/if}
 									</div>
 								{:else}
-									<div class="fires-scroll">
-										{#each job.fires as fire}
+									<div class="fire-timeline">
+										{#each visibleFires as fire, i}
 											{@const truth = fire.inference_source === 'hook'}
-											{@const low = !truth && fire.inference_confidence < 0.7}
-											{@const pct = Math.round(fire.inference_confidence * 100)}
-											<div class="fire-card">
-												<div class="fire-head">
-													<span class="fire-time">
-														<b>{formatShortTime(fire.fired_at)}</b>
-													</span>
-													<span class="fire-ago">· {formatTimeAgo(fire.fired_at)}</span>
-													<span class="fire-conf" class:low>
-														{#if truth}
-															<span style="color: var(--success);">ground truth</span>
-														{:else}
-															<span class="conf-bar">
-																<span class="conf-fill" style="width: {pct}%;"></span>
-															</span>
-															<span class="conf-pct">~{pct}%</span>
-														{/if}
-													</span>
+											{@const last = i === visibleFires.length - 1}
+											<div class="fire-tl-row" class:last>
+												<div class="fire-tl-track">
+													<span class="fire-tl-dot" class:truth></span>
+													{#if !last}<span class="fire-tl-line"></span>{/if}
 												</div>
-												{#if fire.outcome_excerpt}
-													<div class="fire-body">{fire.outcome_excerpt}</div>
-												{/if}
+												<div class="fire-tl-content">
+													<span class="fire-tl-time">{formatShortTime(fire.fired_at)}</span>
+													<span class="fire-tl-ago">{formatTimeAgo(fire.fired_at)}</span>
+													{#if truth}<span class="fire-confirmed">confirmed</span>{/if}
+													{#if fire.outcome_excerpt}
+														<p class="fire-tl-body">{fire.outcome_excerpt}</p>
+													{/if}
+												</div>
 											</div>
 										{/each}
 									</div>
@@ -407,92 +308,75 @@
 </div>
 
 <style>
-	.section {
+	.cron-wrap {
 		display: flex;
 		flex-direction: column;
-		gap: 12px;
+		gap: 10px;
 	}
 
 	.sec-header {
 		display: flex;
-		align-items: flex-start;
+		align-items: center;
 		justify-content: space-between;
-		gap: 12px;
+		gap: 8px;
 	}
 
-	.sec-title {
-		font-size: 16px;
+	.sec-label {
+		font-size: 10px;
+		letter-spacing: 0.07em;
+		text-transform: uppercase;
 		font-weight: 600;
-		color: var(--text-primary);
-		margin: 0 0 4px;
-	}
-
-	.sec-sub {
-		font-size: 13px;
 		color: var(--text-muted);
-		margin: 0;
 	}
 
 	.view-all {
-		font-size: 12px;
-		color: var(--text-secondary);
-		text-decoration: none;
-		white-space: nowrap;
-		flex-shrink: 0;
-	}
-
-	.view-all:hover {
-		color: var(--accent);
-	}
-
-	.notice {
-		display: flex;
-		align-items: flex-start;
-		gap: 8px;
-		background: var(--info-subtle);
-		border: 1px solid var(--border);
-		border-radius: 8px;
-		padding: 10px 12px;
-		font-size: 12.5px;
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		font-size: 10px;
 		color: var(--text-muted);
+		text-decoration: none;
+	}
+	.view-all:hover { color: var(--accent); }
+
+	.inferred-note {
+		font-size: 10px;
+		color: var(--text-faint);
+		margin: 0;
 		line-height: 1.5;
+	}
+
+	.inferred-note code {
+		font-family: var(--font-mono);
+		color: var(--text-muted);
+	}
+
+	.error-note {
+		font-size: 12px;
+		color: var(--error);
+		margin: 0;
 	}
 
 	.center-state {
 		display: flex;
 		justify-content: center;
-		padding: 48px 0;
-	}
-
-	.error-state {
-		background: var(--warning-subtle);
-		border: 1px solid var(--border);
-		border-radius: 8px;
-		padding: 12px 16px;
-		font-size: 13px;
-		color: var(--warning);
+		padding: 32px 0;
 	}
 
 	.empty-state {
 		border: 1px dashed var(--border);
 		border-radius: 10px;
-		padding: 32px 20px;
-		text-align: center;
+		padding: 28px 16px;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
 		gap: 8px;
-		font-size: 13px;
+		text-align: center;
+		font-size: 12px;
 		color: var(--text-muted);
 	}
 
-	.empty-hint {
-		font-size: 12px;
-		color: var(--text-faint);
-		margin: 0;
-	}
-
-	/* ── Cron list ──────────────────────────────────────────────────────────── */
+	/* ── List ─── */
 	.cron-list {
 		display: flex;
 		flex-direction: column;
@@ -504,30 +388,23 @@
 		background: var(--bg-base);
 		border-radius: 10px;
 		overflow: hidden;
-		transition:
-			border-color 0.15s,
-			box-shadow 0.15s;
+		transition: border-color 0.15s, box-shadow 0.15s;
 	}
-
-	.cron-card:hover {
-		border-color: var(--border-hover);
-	}
-
+	.cron-card:hover { border-color: var(--border-hover); }
 	.cron-card.expanded {
 		border-color: var(--border-hover);
 		box-shadow: 0 1px 0 var(--border-subtle), 0 4px 14px -6px var(--border-subtle);
 	}
+	.cron-card.gone { background: var(--bg-subtle); }
+	.cron-card.gone.expanded { background: var(--bg-base); }
 
-	.cron-card.gone {
-		background: var(--bg-subtle);
-	}
-
+	/* ── Row ─── */
 	.cron-row {
 		display: grid;
-		grid-template-columns: 16px 12px 1fr;
+		grid-template-columns: 10px 1fr 16px;
 		align-items: center;
-		gap: 12px;
-		padding: 12px 14px;
+		gap: 10px;
+		padding: 11px 13px;
 		width: 100%;
 		cursor: pointer;
 		user-select: none;
@@ -541,12 +418,9 @@
 		display: flex;
 		align-items: center;
 		transition: transform 0.15s;
+		flex-shrink: 0;
 	}
-
-	.caret.open {
-		transform: rotate(90deg);
-		color: var(--text-primary);
-	}
+	.caret.open { transform: rotate(90deg); color: var(--text-primary); }
 
 	.status-dot {
 		width: 8px;
@@ -557,20 +431,21 @@
 
 	.dot-truth {
 		box-shadow: 0 0 0 3px rgba(var(--success-rgb), 0.18);
-		animation: sessionCronPulse 1.6s infinite;
+		animation: cronPulse 1.6s infinite;
 	}
 
-	@keyframes sessionCronPulse {
-		0% { box-shadow: 0 0 0 0 rgba(var(--success-rgb), 0.6); }
-		70% { box-shadow: 0 0 0 6px rgba(var(--success-rgb), 0); }
-		100% { box-shadow: 0 0 0 0 rgba(var(--success-rgb), 0); }
+	@keyframes cronPulse {
+		0%   { box-shadow: 0 0 0 0   rgba(var(--success-rgb), 0.6); }
+		70%  { box-shadow: 0 0 0 5px rgba(var(--success-rgb), 0);   }
+		100% { box-shadow: 0 0 0 0   rgba(var(--success-rgb), 0);   }
 	}
 
+	/* ── Row content ─── */
 	.row-content {
 		min-width: 0;
 		display: flex;
 		flex-direction: column;
-		gap: 4px;
+		gap: 3px;
 	}
 
 	.row-head {
@@ -587,37 +462,18 @@
 		color: var(--accent);
 	}
 
-	.pill {
+	.recur-icon {
 		display: inline-flex;
 		align-items: center;
-		font-size: 10px;
-		font-weight: 600;
-		letter-spacing: 0.04em;
-		text-transform: uppercase;
-		padding: 1px 6px;
+		justify-content: center;
+		width: 18px;
+		height: 18px;
 		border-radius: 4px;
-		font-family: var(--font-mono);
-	}
-
-	.pill-schedule {
-		background: var(--accent-muted);
-		color: var(--accent);
-	}
-
-	.pill-recur {
-		background: var(--info-subtle);
-		color: var(--info);
-	}
-
-	.pill-once {
 		background: var(--bg-muted);
-		color: var(--text-secondary);
+		color: var(--text-faint);
+		flex-shrink: 0;
 	}
-
-	.pill-hook {
-		background: var(--success-subtle);
-		color: var(--success);
-	}
+	.recur-icon.recur-on { background: var(--info-subtle); color: var(--info); }
 
 	.status-tag {
 		font-size: 10px;
@@ -629,17 +485,15 @@
 		align-items: center;
 		gap: 3px;
 	}
-
-	.tag-active-likely {
-		color: var(--success);
-	}
+	.tag-active, .tag-likely { color: var(--success); }
+	.tag-inactive { color: var(--text-faint); }
 
 	.qm {
-		font-family: var(--font-mono);
-		font-size: 10px;
-		opacity: 0.7;
+		font-size: 8px;
+		opacity: 0.6;
 		letter-spacing: 0;
 		text-transform: none;
+		font-weight: 500;
 	}
 
 	.via {
@@ -650,66 +504,59 @@
 		font-size: 10.5px;
 	}
 
+	.pill-hook {
+		font-family: var(--font-mono);
+		font-size: 9px;
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		padding: 1px 5px;
+		border-radius: 4px;
+		background: var(--success-subtle);
+		color: var(--success);
+	}
+
 	.row-prompt {
-		font-size: 12.5px;
+		font-size: 12px;
 		line-height: 1.45;
 		color: var(--text-primary);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}
-
-	.quote {
-		font-family: var(--font-mono);
-		color: var(--text-faint);
+	.row-prompt.expanded {
+		white-space: normal;
+		overflow: visible;
+		text-overflow: unset;
 	}
 
-	.ttl-inline {
+	.row-meta {
 		display: flex;
+		flex-wrap: wrap;
 		align-items: center;
-		gap: 8px;
-	}
-
-	.ttl-track {
-		flex: 1;
-		height: 2px;
-		background: var(--bg-muted);
-		border-radius: 99px;
-		overflow: hidden;
-		max-width: 100px;
-	}
-
-	.ttl-fill {
-		height: 100%;
-		border-radius: 99px;
-		transition: width 0.3s;
-	}
-
-	.ttl-label {
+		gap: 5px;
 		font-size: 11px;
-		color: var(--text-faint);
+	}
+
+	.mono-dim {
 		font-family: var(--font-mono);
-		white-space: nowrap;
+		color: var(--text-muted);
 	}
+	.warn-text { color: var(--warning) !important; }
+	.sep { color: var(--text-faint); }
 
-	.sep {
-		color: var(--text-faint);
-	}
-
-	/* ── Expanded panel ─────────────────────────────────────────────────────── */
+	/* ── Expanded panel ─── */
 	.panel {
 		border-top: 1px dashed var(--border);
-		padding: 14px 16px 16px;
-		display: grid;
-		grid-template-columns: 220px 1fr;
-		align-items: stretch;
-		gap: 18px;
-	}
-
-	.kv-col {
+		padding: 13px 14px 14px;
 		display: flex;
 		flex-direction: column;
-		gap: 10px;
+		gap: 14px;
+	}
+
+	.meta-row {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
 	}
 
 	.kv-row {
@@ -728,173 +575,106 @@
 
 	.kv-val {
 		font-family: var(--font-mono);
-		font-size: 12px;
+		font-size: 11.5px;
 		line-height: 1.5;
 		color: var(--text-primary);
 	}
+	.kv-val.mono { font-family: var(--font-mono); }
+	.kv-dim { color: var(--text-faint); }
 
-	.kv-dim {
-		color: var(--text-faint);
-	}
-
-	.prompt-block {
-		background: var(--bg-subtle);
-		border: 1px solid var(--border);
-		border-radius: 7px;
-		padding: 8px 10px;
-		font-family: var(--font-mono);
-		font-size: 11.5px;
-		line-height: 1.55;
-		color: var(--text-primary);
-		white-space: pre-wrap;
-		word-break: break-word;
-		margin-top: 2px;
-	}
-
-	.barb {
-		color: var(--accent);
-		font-weight: 600;
-		margin-right: 5px;
-	}
-
-	/* ── Fires column ───────────────────────────────────────────────────────── */
-	.fires-col {
-		min-width: 0;
+	/* ── Fires ─── */
+	.fires-section {
 		display: flex;
 		flex-direction: column;
-	}
-
-	.fires-scroll {
-		max-height: 400px;
-		overflow-y: auto;
-		padding-right: 4px;
-	}
-
-	.fires-scroll::-webkit-scrollbar {
-		width: 4px;
-	}
-
-	.fires-scroll::-webkit-scrollbar-track {
-		background: transparent;
-	}
-
-	.fires-scroll::-webkit-scrollbar-thumb {
-		background: var(--border-hover);
-		border-radius: 99px;
-	}
-
-	.fires-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		margin-bottom: 8px;
-	}
-
-	.fires-source {
-		font-size: 10px;
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-		color: var(--text-faint);
-	}
-
-	.fire-card {
-		background: var(--bg-subtle);
-		border: 1px solid var(--border);
-		border-radius: 7px;
-		padding: 8px 10px;
-		margin-bottom: 5px;
-	}
-
-	.fire-head {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		gap: 6px;
-		margin-bottom: 4px;
-	}
-
-	.fire-time {
-		font-family: var(--font-mono);
-		font-size: 11px;
-		color: var(--text-muted);
-	}
-
-	.fire-time b {
-		color: var(--text-primary);
-		font-weight: 500;
-	}
-
-	.fire-ago {
-		font-size: 11px;
-		color: var(--text-faint);
-	}
-
-	.fire-conf {
-		margin-left: auto;
-		display: inline-flex;
-		align-items: center;
-		gap: 5px;
-		font-family: var(--font-mono);
-		font-size: 10.5px;
-	}
-
-	.conf-bar {
-		width: 32px;
-		height: 2px;
-		background: var(--border);
-		border-radius: 99px;
-		overflow: hidden;
-		display: inline-block;
-	}
-
-	.conf-fill {
-		height: 100%;
-		background: var(--text-muted);
-		opacity: 0.5;
-		border-radius: 99px;
-		display: block;
-	}
-
-	.fire-conf.low .conf-fill {
-		background: var(--warning);
-		opacity: 0.7;
-	}
-
-	.conf-pct {
-		color: var(--text-muted);
-	}
-
-	.fire-conf.low .conf-pct {
-		color: var(--warning);
-	}
-
-	.fire-body {
-		font-size: 12.5px;
-		line-height: 1.55;
-		color: var(--text-primary);
-		white-space: pre-wrap;
-		word-break: break-word;
+		gap: 0;
+		border-top: 1px dashed var(--border);
+		padding-top: 12px;
 	}
 
 	.fires-empty {
-		padding: 16px;
+		margin-top: 8px;
+		padding: 12px;
 		text-align: center;
 		color: var(--text-muted);
-		background: var(--bg-subtle);
 		border: 1px dashed var(--border);
 		border-radius: 7px;
-		font-size: 12px;
-		line-height: 1.55;
+		font-size: 11.5px;
 	}
 
-	.fires-empty b {
+	.fire-timeline {
+		display: flex;
+		flex-direction: column;
+		margin-top: 10px;
+	}
+
+	.fire-tl-row {
+		display: grid;
+		grid-template-columns: 18px 1fr;
+		gap: 0 8px;
+	}
+
+	.fire-tl-track {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		padding-top: 3px;
+	}
+
+	.fire-tl-dot {
+		width: 7px;
+		height: 7px;
+		border-radius: 50%;
+		background: var(--border-hover);
+		flex-shrink: 0;
+	}
+	.fire-tl-dot.truth {
+		background: var(--success);
+		box-shadow: 0 0 0 2px rgba(var(--success-rgb), 0.2);
+	}
+
+	.fire-tl-line {
+		flex: 1;
+		width: 1px;
+		background: var(--border);
+		margin: 3px 0;
+		min-height: 8px;
+	}
+
+	.fire-tl-content {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		gap: 0 6px;
+		padding-bottom: 11px;
+	}
+	.fire-tl-row.last .fire-tl-content { padding-bottom: 0; }
+
+	.fire-tl-time {
+		font-family: var(--font-mono);
+		font-size: 11.5px;
+		font-weight: 600;
 		color: var(--text-primary);
-		font-weight: 500;
 	}
 
-	@media (max-width: 640px) {
-		.panel {
-			grid-template-columns: 1fr;
-		}
+	.fire-tl-ago {
+		font-size: 11px;
+		color: var(--text-faint);
+	}
+
+	.fire-confirmed {
+		font-size: 10px;
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--success);
+	}
+
+	.fire-tl-body {
+		width: 100%;
+		margin: 3px 0 0;
+		font-size: 11.5px;
+		line-height: 1.5;
+		color: var(--text-muted);
+		word-break: break-word;
 	}
 </style>

--- a/frontend/src/lib/components/icons/Icon.svelte
+++ b/frontend/src/lib/components/icons/Icon.svelte
@@ -3,11 +3,13 @@
 		name: string;
 		size?: number;
 		strokeWidth?: number;
+		color?: string;
 	}
 
-	let { name, size = 24, strokeWidth = 1.5 }: Props = $props();
+	let { name, size = 24, strokeWidth = 1.5, color }: Props = $props();
 </script>
 
+<span style={color ? `color: ${color}; display: contents;` : 'display: contents;'}>
 {#if name === 'projects'}
 	<svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width={strokeWidth} stroke-linecap="round" stroke-linejoin="round">
 		<circle cx="12" cy="20" r="2" />
@@ -138,3 +140,4 @@
 		<line x1="8" y1="20" x2="16" y2="20" />
 	</svg>
 {/if}
+</span>

--- a/frontend/src/lib/components/plan/PlanViewer.svelte
+++ b/frontend/src/lib/components/plan/PlanViewer.svelte
@@ -61,8 +61,8 @@
 </script>
 
 {#if embedded}
-	<!-- Embedded mode: just the markdown content, no wrapper -->
-	<div class="markdown-preview max-w-none prose prose-slate dark:prose-invert" use:markdownCopyButtons={renderedContent}>
+	<!-- Embedded mode: compact markdown for narrow drawers -->
+	<div class="markdown-preview markdown-preview--compact max-w-none" use:markdownCopyButtons={renderedContent}>
 		{@html renderedContent}
 	</div>
 {:else}

--- a/frontend/src/lib/components/shells/SessionShellsSection.svelte
+++ b/frontend/src/lib/components/shells/SessionShellsSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { Activity, Play, X, Square, Loader2 } from 'lucide-svelte';
+	import { Activity, Loader2 } from 'lucide-svelte';
 	import { API_BASE } from '$lib/config';
 	import type {
 		BackgroundShell,
@@ -9,8 +9,9 @@
 
 	interface Props {
 		sessionUuid: string;
+		onLoaded?: (count: number) => void;
 	}
-	let { sessionUuid }: Props = $props();
+	let { sessionUuid, onLoaded }: Props = $props();
 
 	let loading = $state(true);
 	let error = $state<string | null>(null);
@@ -23,12 +24,22 @@
 			if (!res.ok) throw new Error(`API ${res.status}`);
 			const data = (await res.json()) as ShellsListResponse;
 			shells = data.shells ?? [];
+			onLoaded?.(shells.length);
 		} catch (e) {
 			error = e instanceof Error ? e.message : String(e);
 		} finally {
 			loading = false;
 		}
 	});
+
+	function statusColor(shell: BackgroundShell): string {
+		if (shell.terminated_at === null) return 'var(--success)';
+		const r = shell.terminated_by ?? 'session_end';
+		if (r === 'kill') return 'var(--error)';
+		if (r === 'natural') return 'var(--info)';
+		if (r === 'timeout') return 'var(--warning)';
+		return 'var(--text-faint)';
+	}
 
 	function formatDuration(start: string, end: string | null): string {
 		const s = new Date(start).getTime();
@@ -44,158 +55,68 @@
 		if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
 		return `${(n / (1024 * 1024)).toFixed(1)} MB`;
 	}
+
 </script>
 
-<div class="space-y-4">
-	<div class="flex items-baseline justify-between gap-4">
-		<div>
-			<h2 class="text-lg font-semibold text-[var(--text-primary)] m-0">Background shells</h2>
-			<p class="text-sm text-[var(--text-muted)] m-0">
-				Long-running <code class="font-mono text-xs">Bash</code> and
-				<code class="font-mono text-xs">Monitor</code> processes spawned in this session.
-			</p>
-		</div>
+<div class="flex flex-col gap-2">
+
+	<!-- Header -->
+	<div class="flex items-center justify-between">
+		<p class="text-[10px] uppercase tracking-wide font-medium text-[var(--text-muted)]">Background shells</p>
 		{#if !loading && shells.length > 0}
-			<a
-				href="/shells?project={shells[0].project_encoded_name ?? ''}"
-				class="text-xs text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors"
-			>
-				View all in project →
+			<a href="/shells?project={shells[0].project_encoded_name ?? ''}" class="text-[10px] text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors">
+				View all →
 			</a>
 		{/if}
 	</div>
 
 	{#if loading}
-		<div class="flex items-center justify-center py-12 text-[var(--text-muted)]">
-			<Loader2 size={20} class="animate-spin" />
+		<div class="flex justify-center py-6 text-[var(--text-muted)]">
+			<Loader2 size={14} class="animate-spin" />
 		</div>
 	{:else if error}
-		<div
-			class="rounded-lg border border-[var(--error)] bg-[var(--error-subtle)] p-4 text-sm text-[var(--error)]"
-		>
-			Failed to load shells: {error}
-		</div>
+		<p class="text-xs text-[var(--error)]">Failed to load: {error}</p>
 	{:else if shells.length === 0}
-		<div
-			class="rounded-lg border border-dashed border-[var(--border)] p-8 text-center text-sm text-[var(--text-muted)]"
-		>
-			<Activity size={28} class="mx-auto mb-3 opacity-40" />
-			<p class="m-0">No background shells recorded for this session.</p>
-			<p class="m-0 mt-1 text-xs">
-				They appear here when Claude runs <code class="font-mono">Bash{'{run_in_background:true}'}</code>
-				or <code class="font-mono">Monitor</code>.
-			</p>
+		<div class="rounded-lg border border-dashed border-[var(--border)] py-6 px-4 text-center">
+			<Activity size={18} class="mx-auto mb-1.5 opacity-30" />
+			<p class="text-xs text-[var(--text-muted)] m-0">No background shells in this session.</p>
 		</div>
 	{:else}
-		<ul class="space-y-2">
+		<div class="flex flex-col gap-2">
 			{#each shells as shell (shell.id)}
 				{@const isRunning = shell.terminated_at === null}
-				{@const isMonitor = shell.tool_name === 'Monitor'}
-				{@const isKilled = shell.terminated_by === 'kill'}
-				{@const statusColor = isRunning
-					? 'var(--status-active)'
-					: isKilled
-						? 'var(--error)'
-						: shell.terminated_by === 'natural'
-							? 'var(--status-done)'
-							: 'var(--text-muted)'}
-				<li
-					class="rounded-lg border border-[var(--border)] hover:border-[var(--border-hover)] transition-colors overflow-hidden"
-					style:background={isMonitor ? 'var(--info-subtle)' : 'var(--bg-subtle)'}
-				>
+				{@const color = statusColor(shell)}
+				<div class="rounded-lg border border-[var(--border)]/60 overflow-hidden bg-[var(--bg-base)]">
 					<button
 						type="button"
-						class="w-full text-left p-3 flex items-center gap-3 hover:bg-[var(--bg-muted)] transition-colors"
+						class="w-full text-left px-2.5 py-2 flex items-center gap-2 hover:bg-[var(--bg-subtle)] transition-colors"
 						onclick={() => (expandedId = expandedId === shell.id ? null : shell.id)}
 					>
 						<span
-							class="inline-block w-2 h-2 rounded-full shrink-0"
-							style:background={statusColor}
-							aria-hidden="true"
+							class="shrink-0 w-1.5 h-1.5 rounded-full {isRunning ? 'animate-pulse' : ''}"
+							style:background={color}
 						></span>
-						<code
-							class="font-mono text-sm text-[var(--text-primary)] shrink-0 min-w-[8ch]"
-						>
-							{shell.shell_id ?? '—'}
-						</code>
-						<span
-							class="text-xs uppercase tracking-wide font-medium shrink-0"
-							style:color={statusColor}
-						>
-							{#if isRunning}
-								<Play size={11} class="inline" /> running
-							{:else if isKilled}
-								<X size={11} class="inline" /> killed
-							{:else}
-								<Square size={11} class="inline" /> {shell.terminated_by}
-							{/if}
-						</span>
-						<span
-							class="text-xs text-[var(--text-muted)] font-mono truncate flex-1"
-							title={shell.command}
-						>
-							{shell.command}
-						</span>
-						<span class="text-xs text-[var(--text-muted)] shrink-0 font-mono">
-							{formatDuration(shell.spawned_at, shell.terminated_at)}
-							{#if shell.poll_count > 0}
-								· {shell.poll_count} polls
-							{/if}
-						</span>
+						<code class="font-mono text-[11px] text-[var(--text-primary)] shrink-0">{shell.shell_id ?? '—'}</code>
+						<span class="font-mono text-[10px] text-[var(--text-muted)] truncate flex-1" title={shell.command}>{shell.command}</span>
+						<span class="shrink-0 font-mono text-[10px] text-[var(--text-muted)]">{formatDuration(shell.spawned_at, shell.terminated_at)}</span>
 					</button>
 
 					{#if expandedId === shell.id}
-						<div
-							class="border-t border-[var(--border)] p-4 space-y-3 bg-[var(--bg-base)]"
-						>
-							<div>
-								<div class="text-xs uppercase tracking-wide text-[var(--text-muted)] mb-1">
-									Command
-								</div>
-								<pre
-									class="font-mono text-xs text-[var(--text-primary)] bg-[var(--bg-subtle)] p-3 rounded overflow-x-auto m-0 whitespace-pre-wrap break-all"
-								>{shell.command}{shell.command_truncated ? '\n…(truncated)' : ''}</pre>
-							</div>
-							<div class="grid grid-cols-2 gap-3 text-xs">
-								<div>
-									<span class="text-[var(--text-muted)]">Spawned:</span>
-									<span class="font-mono text-[var(--text-primary)]">
-										{shell.spawned_at}
-									</span>
-								</div>
-								{#if shell.terminated_at}
-									<div>
-										<span class="text-[var(--text-muted)]">Ended:</span>
-										<span class="font-mono text-[var(--text-primary)]">
-											{shell.terminated_at}
-										</span>
-									</div>
-								{/if}
-								<div>
-									<span class="text-[var(--text-muted)]">Total output:</span>
-									<span class="font-mono text-[var(--text-primary)]">
-										{formatBytes(shell.total_output_bytes)}
-									</span>
-								</div>
-								<div>
-									<span class="text-[var(--text-muted)]">Tool:</span>
-									<span class="font-mono text-[var(--text-primary)]">{shell.tool_name}</span>
-								</div>
+						<div class="border-t border-[var(--border)]/40 px-2.5 py-2 space-y-1.5 bg-[var(--bg-subtle)]">
+							<pre class="font-mono text-[10px] text-[var(--text-primary)] bg-[var(--bg-muted)] px-2 py-1.5 rounded overflow-x-auto m-0 whitespace-pre-wrap break-all">{shell.command}{shell.command_truncated ? '\n…(truncated)' : ''}</pre>
+							<div class="grid grid-cols-2 gap-x-3 gap-y-1 text-[10px]">
+								<div class="text-[var(--text-muted)]">Spawned <span class="font-mono text-[var(--text-secondary)]">{new Date(shell.spawned_at).toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'})}</span></div>
+								{#if shell.terminated_at}<div class="text-[var(--text-muted)]">Ended <span class="font-mono text-[var(--text-secondary)]">{new Date(shell.terminated_at).toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'})}</span></div>{/if}
+								<div class="text-[var(--text-muted)]">Output <span class="font-mono text-[var(--text-secondary)]">{formatBytes(shell.total_output_bytes)}</span></div>
+								{#if shell.poll_count > 0}<div class="text-[var(--text-muted)]">Polls <span class="font-mono text-[var(--text-secondary)]">{shell.poll_count}</span></div>{/if}
 							</div>
 							{#if shell.polls && shell.polls.length > 0}
-								<div>
-									<div class="text-xs uppercase tracking-wide text-[var(--text-muted)] mb-1">
-										Latest poll output
-									</div>
-									<pre
-										class="font-mono text-xs text-[var(--text-secondary)] bg-[var(--bg-subtle)] p-3 rounded overflow-x-auto m-0 max-h-40 whitespace-pre-wrap break-all"
-									>{shell.polls[shell.polls.length - 1].output_excerpt ?? '(empty)'}</pre>
-								</div>
+								<pre class="font-mono text-[10px] text-[var(--text-secondary)] bg-[var(--bg-muted)] px-2 py-1.5 rounded overflow-x-auto m-0 max-h-32 whitespace-pre-wrap break-all">{shell.polls[shell.polls.length - 1].output_excerpt ?? '(empty)'}</pre>
 							{/if}
 						</div>
 					{/if}
-				</li>
+				</div>
 			{/each}
-		</ul>
+		</div>
 	{/if}
 </div>

--- a/frontend/src/lib/components/skills/SkillsPanel.svelte
+++ b/frontend/src/lib/components/skills/SkillsPanel.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { Zap, FileText, ExternalLink } from 'lucide-svelte';
+	import { Zap, ExternalLink } from 'lucide-svelte';
 	import type { SkillUsage } from '$lib/api-types';
-	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import { cleanSkillName, getSkillColorVars } from '$lib/utils';
 
 	interface Props {
@@ -11,7 +10,6 @@
 
 	let { skills, projectEncodedName }: Props = $props();
 
-	// Deduplicate skills by name (multiple invocation sources can create duplicates)
 	let deduplicatedSkills = $derived.by(() => {
 		const map = new Map<string, SkillUsage>();
 		for (const skill of skills) {
@@ -25,106 +23,57 @@
 		return [...map.values()];
 	});
 
-	// Sort skills by count (descending)
 	let sortedSkills = $derived([...deduplicatedSkills].sort((a, b) => b.count - a.count));
 
-	// Get skill detail link
 	function getSkillHref(skill: SkillUsage): string {
 		const encodedName = encodeURIComponent(skill.name);
-		const projectParam = projectEncodedName
-			? `?project=${encodeURIComponent(projectEncodedName)}`
-			: '';
+		const projectParam = projectEncodedName ? `?project=${encodeURIComponent(projectEncodedName)}` : '';
 		return `/skills/${encodedName}${projectParam}`;
 	}
 </script>
 
-<div class="space-y-4">
-	<div>
-		<h2 class="text-lg font-semibold text-[var(--text-primary)]">
-			Skills ({deduplicatedSkills.length})
-		</h2>
-		<p class="text-sm text-[var(--text-muted)]">
-			Skills invoked during this session via the /skill command
-		</p>
+<div class="flex flex-col gap-2">
+	<span class="text-[10px] uppercase tracking-wide font-medium text-[var(--text-muted)]">
+		{sortedSkills.length} skill{sortedSkills.length !== 1 ? 's' : ''}
+	</span>
+
+	<div class="flex flex-col gap-1.5">
+		{#each sortedSkills as skill (skill.name)}
+			{@const href = getSkillHref(skill)}
+			{@const cv = getSkillColorVars(skill.name, skill.is_plugin, skill.plugin)}
+			{@const displayName = cleanSkillName(skill.name, skill.is_plugin)}
+			<a
+				{href}
+				class="group flex items-center gap-2.5 px-3 py-2.5 no-underline rounded-lg border border-[var(--border)]/60 bg-[var(--bg-base)] hover:bg-[var(--bg-subtle)] hover:border-[var(--border-hover)] transition-colors"
+			>
+				<!-- Icon dot -->
+				<span
+					class="shrink-0 flex items-center justify-center w-6 h-6 rounded-md"
+					style="background: {cv.subtle}; color: {cv.color};"
+				>
+					<Zap size={13} strokeWidth={2} />
+				</span>
+
+				<!-- Name + type -->
+				<div class="flex-1 min-w-0">
+					<span class="text-xs font-medium text-[var(--text-primary)] truncate block" title={skill.name}>{displayName}</span>
+					<div class="flex items-center gap-1 mt-0.5">
+						{#if skill.is_plugin}
+							<span class="text-[10px] font-medium px-1 py-px rounded" style="background: {cv.subtle}; color: {cv.color};">Plugin</span>
+							{#if skill.plugin}<span class="text-[10px] text-[var(--text-faint)] truncate">{skill.plugin}</span>{/if}
+						{:else}
+							<span class="text-[10px] font-medium px-1 py-px rounded bg-[var(--accent)]/10 text-[var(--accent)]">File</span>
+						{/if}
+					</div>
+				</div>
+
+				<!-- Count + link -->
+				<div class="shrink-0 flex items-center gap-1.5">
+					<span class="font-mono text-[11px] font-semibold" style="color: {cv.color};">{skill.count}×</span>
+					<ExternalLink size={11} class="text-[var(--text-faint)] group-hover:text-[var(--accent)] transition-colors" />
+				</div>
+			</a>
+		{/each}
 	</div>
 
-	{#if sortedSkills.length > 0}
-		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-			{#each sortedSkills as skill (skill.name)}
-				{@const href = getSkillHref(skill)}
-				{@const skillColors = getSkillColorVars(skill.name, skill.is_plugin, skill.plugin)}
-				<a
-					{href}
-					class="group flex items-start gap-4 p-4 bg-[var(--bg-base)] border border-[var(--border)] rounded-xl transition-all hover:border-[var(--accent)]/50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 no-underline"
-				>
-					<!-- Icon -->
-					<div
-						class="p-2.5 rounded-lg shrink-0 transition-colors"
-						style="background-color: {skillColors.subtle}; color: {skillColors.color};"
-					>
-						<Zap size={20} />
-					</div>
-
-					<!-- Content -->
-					<div class="min-w-0 flex-1">
-						<div class="flex items-center gap-2">
-							<span
-								class="font-medium text-[var(--text-primary)] truncate"
-								title={skill.name}
-							>
-								{cleanSkillName(skill.name, skill.is_plugin)}
-							</span>
-							<ExternalLink
-								size={14}
-								class="text-[var(--text-muted)] group-hover:text-[var(--accent)] transition-colors shrink-0"
-							/>
-						</div>
-
-						<div class="flex items-center gap-2 text-xs text-[var(--text-muted)] mt-1">
-							{#if skill.is_plugin}
-								{#if skill.plugin}
-									<span class="inline-flex items-center gap-1.5">
-										<span
-											class="px-1.5 py-0.5 rounded text-[10px] uppercase font-medium"
-											style="background-color: {skillColors.subtle}; color: {skillColors.color};"
-										>
-											Plugin
-										</span>
-										<span class="text-[var(--text-faint)]">{skill.plugin}</span>
-									</span>
-								{:else}
-									<span
-										class="px-1.5 py-0.5 rounded text-[10px] uppercase font-medium"
-										style="background-color: {skillColors.subtle}; color: {skillColors.color};"
-									>
-										Plugin
-									</span>
-								{/if}
-							{:else}
-								<span
-									class="px-1.5 py-0.5 bg-[var(--accent)]/10 text-[var(--accent)] rounded text-[10px] uppercase font-medium"
-								>
-									File
-								</span>
-							{/if}
-						</div>
-					</div>
-
-					<!-- Count badge -->
-					<div
-						class="shrink-0 px-2.5 py-1 rounded-full text-xs font-medium"
-						style="background-color: {skillColors.subtle}; color: {skillColors.color};"
-					>
-						{skill.count}x
-					</div>
-				</a>
-			{/each}
-		</div>
-	{:else}
-		<EmptyState
-			icon={Zap}
-			title="No skills used"
-			description="Skills invoked via /skill commands will appear here"
-		/>
-	{/if}
 </div>

--- a/frontend/src/lib/components/tasks/TaskFlowView.svelte
+++ b/frontend/src/lib/components/tasks/TaskFlowView.svelte
@@ -219,23 +219,10 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.25rem;
-		padding-left: 0.5rem;
-		border-left: 2px solid var(--border);
-		margin-left: 0.75rem;
 	}
 
 	.task-node {
 		position: relative;
-	}
-
-	.task-node::before {
-		content: '';
-		position: absolute;
-		left: -0.5rem;
-		top: 0.875rem;
-		width: 0.5rem;
-		height: 2px;
-		background: var(--border);
 	}
 
 	.node-header {

--- a/frontend/src/lib/components/tasks/TaskFlowView.svelte
+++ b/frontend/src/lib/components/tasks/TaskFlowView.svelte
@@ -176,21 +176,6 @@
 			</div>
 		{/each}
 
-		<!-- Legend -->
-		<div class="legend">
-			<div class="legend-item">
-				<Circle size={12} class="text-[var(--text-muted)]" />
-				<span>Pending</span>
-			</div>
-			<div class="legend-item">
-				<Loader2 size={12} class="text-[var(--nav-blue)]" />
-				<span>In Progress</span>
-			</div>
-			<div class="legend-item">
-				<Check size={12} class="text-[var(--success)]" />
-				<span>Completed</span>
-			</div>
-		</div>
 	</div>
 {/if}
 
@@ -306,9 +291,8 @@
 		font-size: 0.8rem;
 		font-weight: 500;
 		color: var(--text-primary);
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
+		word-break: break-word;
+		min-width: 0;
 	}
 
 	.status-badge {
@@ -396,18 +380,5 @@
 		color: var(--text-secondary);
 	}
 
-	.legend {
-		display: flex;
-		gap: 1rem;
-		padding-top: 1rem;
-		border-top: 1px solid var(--border);
-	}
 
-	.legend-item {
-		display: flex;
-		align-items: center;
-		gap: 0.375rem;
-		font-size: 0.7rem;
-		color: var(--text-muted);
-	}
 </style>

--- a/frontend/src/lib/components/tasks/TasksTab.svelte
+++ b/frontend/src/lib/components/tasks/TasksTab.svelte
@@ -52,8 +52,8 @@
 			{tasks.length} task{tasks.length !== 1 ? 's' : ''}
 		</span>
 
-		<!-- View Toggle -->
-		{#if tasks.length > 0}
+		<!-- View Toggle (hidden in drawer — flow only at 350px) -->
+		<!-- {#if tasks.length > 0}
 			<div class="flex items-center gap-0.5 p-0.5 bg-[var(--bg-muted)] rounded border border-[var(--border)]">
 				<button
 					class="flex items-center gap-1 px-2 py-0.5 text-[11px] font-medium rounded transition-all {viewMode === 'flow' ? 'bg-[var(--bg-base)] text-[var(--text-primary)] shadow-sm' : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'}"
@@ -70,21 +70,15 @@
 					<LayoutGrid size={12} />Grid
 				</button>
 			</div>
-		{/if}
+		{/if} -->
 	</div>
 
 	{#if tasks.length > 0}
 		<!-- Progress Summary -->
 		<TasksProgressBar tasks={enrichedTasks} />
 
-		<!-- Task Views -->
-		{#if viewMode === 'flow'}
-			<!-- Flow View: Vertical list with dependency lines -->
-			<TaskFlowView tasks={enrichedTasks} {getTaskSubject} />
-		{:else}
-			<!-- Grid View: Kanban columns -->
-			<TasksKanban tasks={enrichedTasks} {getTaskSubject} />
-		{/if}
+		<!-- Task Views (drawer always uses flow — grid toggle hidden) -->
+		<TaskFlowView tasks={enrichedTasks} {getTaskSubject} />
 	{:else}
 		<EmptyState
 			icon={ListTodo}

--- a/frontend/src/lib/components/tasks/TasksTab.svelte
+++ b/frontend/src/lib/components/tasks/TasksTab.svelte
@@ -46,45 +46,28 @@
 	const getTaskSubject = $derived(createTaskSubjectLookup(tasks));
 </script>
 
-<div class="space-y-4">
-	<div class="flex items-start justify-between gap-4">
-		<div>
-			<h2 class="text-lg font-semibold text-[var(--text-primary)]">
-				Tasks ({tasks.length})
-			</h2>
-			<p class="text-sm text-[var(--text-muted)]">Structured work plan for this session</p>
-		</div>
+<div class="space-y-3">
+	<div class="flex items-center justify-between gap-2">
+		<span class="text-[10px] uppercase tracking-wide font-medium text-[var(--text-muted)]">
+			{tasks.length} task{tasks.length !== 1 ? 's' : ''}
+		</span>
 
 		<!-- View Toggle -->
 		{#if tasks.length > 0}
-			<div
-				class="flex items-center gap-0.5 p-0.5 bg-[var(--bg-muted)] rounded-md border border-[var(--border)]"
-			>
+			<div class="flex items-center gap-0.5 p-0.5 bg-[var(--bg-muted)] rounded border border-[var(--border)]">
 				<button
-					class="
-						flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded transition-all
-						{viewMode === 'flow'
-						? 'bg-[var(--bg-base)] text-[var(--text-primary)] shadow-sm'
-						: 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'}
-					"
+					class="flex items-center gap-1 px-2 py-0.5 text-[11px] font-medium rounded transition-all {viewMode === 'flow' ? 'bg-[var(--bg-base)] text-[var(--text-primary)] shadow-sm' : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'}"
 					onclick={() => setViewMode('flow')}
 					aria-pressed={viewMode === 'flow'}
 				>
-					<LayoutList size={14} />
-					Flow
+					<LayoutList size={12} />Flow
 				</button>
 				<button
-					class="
-						flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded transition-all
-						{viewMode === 'grid'
-						? 'bg-[var(--bg-base)] text-[var(--text-primary)] shadow-sm'
-						: 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'}
-					"
+					class="flex items-center gap-1 px-2 py-0.5 text-[11px] font-medium rounded transition-all {viewMode === 'grid' ? 'bg-[var(--bg-base)] text-[var(--text-primary)] shadow-sm' : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'}"
 					onclick={() => setViewMode('grid')}
 					aria-pressed={viewMode === 'grid'}
 				>
-					<LayoutGrid size={14} />
-					Grid
+					<LayoutGrid size={12} />Grid
 				</button>
 			</div>
 		{/if}

--- a/frontend/src/lib/components/tickets/SessionTicketsSection.svelte
+++ b/frontend/src/lib/components/tickets/SessionTicketsSection.svelte
@@ -1,25 +1,21 @@
 <script lang="ts">
 	import type { CreateLinkResponse, SessionTicketRow } from '$lib/api-types';
 	import { API_BASE } from '$lib/config';
-	import { Ticket as TicketIcon, Undo2, Plus } from 'lucide-svelte';
-	import TicketBadge from './TicketBadge.svelte';
+	import { ExternalLink, X, Undo2 } from 'lucide-svelte';
+	import { normalizeStatus, statusColorVar, PROVIDER_META } from '$lib/ticket-helpers';
 	import TicketLinkInput from './TicketLinkInput.svelte';
 	import { onDestroy } from 'svelte';
 
 	interface Props {
 		sessionUuid: string;
 		sessionSlug?: string | null;
-		/** Initial tickets fetched server-side. Component holds local state from here. */
 		initial?: SessionTicketRow[];
 	}
 
 	let { sessionUuid, sessionSlug, initial = [] }: Props = $props();
 
-	// Seed once at construction. Route changes unmount the component so we don't
-	// need to react to `initial` changing.
 	let tickets = $state<SessionTicketRow[]>($state.snapshot(initial));
 
-	// Undo toast state — keyed by linkId so we never overlap.
 	type PendingUndo = {
 		ticket: SessionTicketRow;
 		expiresAt: number;
@@ -34,9 +30,7 @@
 		if (countdownInterval) return;
 		countdownInterval = setInterval(() => {
 			tick++;
-			if (!pending || pending.expiresAt <= Date.now()) {
-				stopCountdown();
-			}
+			if (!pending || pending.expiresAt <= Date.now()) stopCountdown();
 		}, 250);
 	}
 	function stopCountdown() {
@@ -46,7 +40,6 @@
 	onDestroy(stopCountdown);
 
 	let secondsLeft = $derived.by(() => {
-		// reference tick so this recomputes
 		void tick;
 		if (!pending) return 0;
 		return Math.max(0, Math.ceil((pending.expiresAt - Date.now()) / 1000));
@@ -66,21 +59,16 @@
 	}
 
 	function requestUnlink(ticket: SessionTicketRow) {
-		// Optimistic remove
 		tickets = tickets.filter((t) => t.id !== ticket.id);
-
-		// If there's already a pending undo, commit it immediately (we only show one toast)
 		if (pending) {
 			clearTimeout(pending.timeoutId);
 			void commitUnlink(pending.ticket);
 		}
-
 		const timeoutId = setTimeout(() => {
 			void commitUnlink(ticket);
 			pending = null;
 			stopCountdown();
 		}, UNDO_MS);
-
 		pending = { ticket, expiresAt: Date.now() + UNDO_MS, timeoutId };
 		startCountdown();
 	}
@@ -88,7 +76,6 @@
 	function undoUnlink() {
 		if (!pending) return;
 		clearTimeout(pending.timeoutId);
-		// Restore the ticket at the top (most recent linked-at)
 		tickets = [pending.ticket, ...tickets];
 		pending = null;
 		stopCountdown();
@@ -96,83 +83,83 @@
 
 	async function commitUnlink(ticket: SessionTicketRow) {
 		try {
-			const res = await fetch(`${API_BASE}/sessions/${sessionUuid}/tickets/${ticket.id}`, {
-				method: 'DELETE'
-			});
-			if (!res.ok) {
-				// Restore on failure
-				tickets = [ticket, ...tickets];
-			}
+			const res = await fetch(`${API_BASE}/sessions/${sessionUuid}/tickets/${ticket.id}`, { method: 'DELETE' });
+			if (!res.ok) tickets = [ticket, ...tickets];
 		} catch {
 			tickets = [ticket, ...tickets];
 		}
 	}
 </script>
 
-<section
-	class="flex flex-col gap-2.5 px-4 py-3 rounded-lg border border-[var(--border)] bg-[var(--bg-base)]"
-	aria-labelledby="tickets-heading"
->
-	<header class="flex items-center justify-between gap-2">
-		<div class="flex items-center gap-2">
-			<TicketIcon size={13} class="text-[var(--text-muted)]" />
-			<span
-				id="tickets-heading"
-				class="font-mono text-[12px] text-[var(--accent)]"
-			>
-				$ tickets
-			</span>
-			<span class="font-mono text-[11px] text-[var(--text-faint)]">
-				[{tickets.length} linked]
-			</span>
-		</div>
-	</header>
+<div class="flex flex-col gap-2.5">
+	<span class="text-[10px] uppercase tracking-wide font-medium text-[var(--text-muted)]">
+		{tickets.length} ticket{tickets.length !== 1 ? 's' : ''} linked
+	</span>
 
+	<!-- Ticket list -->
 	{#if tickets.length > 0}
-		<ul class="flex flex-wrap gap-1.5 m-0 p-0 list-none">
+		<div class="flex flex-col gap-2">
 			{#each tickets as ticket (ticket.id)}
-				<li>
-					<TicketBadge
-						{ticket}
-						variant="pill"
-						showStatus={true}
-						onRemove={() => requestUnlink(ticket)}
-					/>
-				</li>
-			{/each}
-		</ul>
-	{/if}
+				{@const norm = normalizeStatus(ticket.status)}
+				{@const meta = PROVIDER_META[ticket.provider]}
+				<div class="rounded-lg border border-[var(--border)] bg-[var(--bg-base)] overflow-hidden">
+					<!-- Card header: provider chip + key + unlink -->
+					<div class="flex items-center gap-2 px-3 pt-3 pb-2">
+						<!-- Provider badge -->
+						<span
+							class="shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-bold uppercase tracking-wide"
+							style="background: var({meta?.subtleVar ?? '--bg-muted'}); color: var({meta?.colorVar ?? '--text-muted'});"
+						>{meta?.short ?? '??'}</span>
 
-	{#if pending}
-		<div
-			class="inline-flex items-center gap-2 px-2.5 py-1 rounded-full bg-[var(--bg-muted)] border border-dashed border-[var(--border)] text-[11px] text-[var(--text-muted)] self-start"
-			role="status"
-			aria-live="polite"
-		>
-			<Undo2 size={11} />
-			<span>
-				Unlinked
-				<code class="font-mono">{pending.ticket.external_key}</code>
-			</span>
-			<span class="text-[var(--text-faint)]">· undo in {secondsLeft}s</span>
-			<button
-				type="button"
-				onclick={undoUnlink}
-				class="text-[var(--accent)] hover:underline font-semibold focus-ring"
-			>
-				Undo
-			</button>
+						<!-- Key link -->
+						<a
+							href={ticket.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="flex-1 min-w-0 font-mono text-xs font-semibold text-[var(--accent)] hover:underline inline-flex items-center gap-1"
+						>
+							<span class="truncate">{ticket.external_key}</span>
+							<ExternalLink size={10} class="shrink-0 opacity-60" />
+						</a>
+
+						<!-- Unlink -->
+						<button
+							type="button"
+							onclick={() => requestUnlink(ticket)}
+							class="shrink-0 p-1 rounded text-[var(--text-faint)] hover:text-[var(--error)] hover:bg-[var(--error-subtle)] transition-colors"
+							title="Unlink"
+						>
+							<X size={13} />
+						</button>
+					</div>
+
+					<!-- Title -->
+					{#if ticket.title}
+						<p class="px-3 pb-2 text-xs text-[var(--text-primary)] leading-relaxed line-clamp-2 m-0">{ticket.title}</p>
+					{/if}
+
+					<!-- Status footer -->
+					{#if norm.verbatim}
+						<div class="flex items-center gap-1.5 px-3 py-2 border-t border-[var(--border)]/60">
+							<span class="w-2 h-2 rounded-full shrink-0" style="background: var({statusColorVar(norm.key)})"></span>
+							<span class="text-[11px] font-medium text-[var(--text-secondary)] uppercase tracking-wide">{norm.verbatim}</span>
+						</div>
+					{/if}
+				</div>
+			{/each}
 		</div>
 	{/if}
 
-	{#if tickets.length === 0 && !pending}
-		<p class="text-[11px] text-[var(--text-muted)] m-0 inline-flex items-center gap-1.5">
-			<Plus size={10} />
-			Paste a URL, key, or
-			<code class="font-mono px-1 py-px rounded bg-[var(--bg-muted)] text-[var(--text-secondary)]">owner/repo#N</code>
-			below to link this session.
-		</p>
+	<!-- Undo toast -->
+	{#if pending}
+		<div class="flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-[var(--bg-muted)] border border-dashed border-[var(--border)] text-[11px] text-[var(--text-muted)]">
+			<Undo2 size={11} class="shrink-0" />
+			<span class="flex-1 min-w-0 truncate">Unlinked <code class="font-mono">{pending.ticket.external_key}</code></span>
+			<span class="shrink-0 text-[var(--text-faint)]">{secondsLeft}s</span>
+			<button type="button" onclick={undoUnlink} class="shrink-0 text-[var(--accent)] hover:underline font-semibold">Undo</button>
+		</div>
 	{/if}
 
+	<!-- Link input -->
 	<TicketLinkInput {sessionUuid} {sessionSlug} onCreated={handleCreated} />
-</section>
+</div>

--- a/frontend/src/lib/components/tickets/TicketLinkInput.svelte
+++ b/frontend/src/lib/components/tickets/TicketLinkInput.svelte
@@ -109,7 +109,7 @@
 		<div class="relative flex-1 min-w-0">
 			<input
 				type="text"
-				placeholder="Paste URL or ref (e.g. LINEAR-123, owner/repo#42)"
+				placeholder="URL or ref (e.g. LINEAR-1)"
 				value={ref}
 				oninput={onInput}
 				disabled={phase === 'validating' || phase === 'success'}
@@ -183,14 +183,9 @@
 
 	<!-- Below-input feedback row -->
 	{#if phase === 'idle'}
-		<p class="text-[11px] text-[var(--text-faint)] inline-flex items-center gap-1.5 m-0">
-			<Sparkles size={10} />
-			<span>
-				Or use
-				<code class="font-mono px-1 py-px rounded bg-[var(--bg-muted)] text-[var(--text-secondary)]">/link-ticket-to-session</code>
-				in this session, or push a branch named
-				<code class="font-mono px-1 py-px rounded bg-[var(--bg-muted)] text-[var(--text-secondary)]">feat/ABC-123-…</code>
-			</span>
+		<p class="text-[11px] text-[var(--text-faint)] flex items-start gap-1.5 m-0 leading-relaxed">
+			<Sparkles size={10} class="shrink-0 mt-0.5" />
+			<span>Or use <code class="font-mono px-1 py-px rounded bg-[var(--bg-muted)] text-[var(--text-secondary)] break-all">/link-ticket-to-session</code> in chat.</span>
 		</p>
 	{:else if phase === 'typing' && detected}
 		<p class="text-[11px] text-[var(--text-secondary)] inline-flex items-center gap-1.5 m-0">

--- a/frontend/src/lib/components/timeline/TimelineEventCard.svelte
+++ b/frontend/src/lib/components/timeline/TimelineEventCard.svelte
@@ -188,7 +188,8 @@
 		<!-- Node circle -->
 		<button
 			class="
-				relative z-10 flex h-8 w-8 items-center justify-center rounded-full border-2 transition-all duration-200
+				relative z-10 flex items-center justify-center rounded-full border-2 transition-all duration-200
+				h-8 w-8
 				{isPlanEvent ? 'bg-[var(--event-plan-subtle)]' : config.bgColor}
 				{isPlanEvent ? 'border-[var(--event-plan)]/60' : config.borderColor}
 				group-hover:scale-110 group-hover:shadow-lg
@@ -204,7 +205,7 @@
 			title="Hide event"
 			aria-label="Hide event"
 		>
-			<IconComponent
+				<IconComponent
 				class="h-4 w-4 {isPlanEvent ? 'text-[var(--event-plan)]' : config.color}"
 			/>
 		</button>
@@ -218,29 +219,13 @@
 	</div>
 
 	<!-- Content card -->
-	{#if isMediumEffortThinking}
-		<div class="mb-4 flex-1 min-w-0 rounded-lg border border-dashed border-[var(--event-thinking)]/30 border-l-[3px] border-l-[var(--event-thinking)]/40 bg-[var(--bg-subtle)]/50 px-4 py-2.5 pl-5">
-			<div class="flex items-center justify-between gap-3">
-				<div class="flex items-center gap-2 min-w-0">
-					<span class="text-sm font-medium text-[var(--text-muted)]">Thinking</span>
-					<span class="text-xs text-[var(--text-muted)]/50 truncate">· content not stored</span>
-				</div>
-				<span
-					class="whitespace-nowrap font-mono text-xs text-[var(--text-muted)]/50 tabular-nums shrink-0"
-					title={formatDate(event.timestamp)}
-				>
-					{formatElapsedTime(event.timestamp, sessionStartTime)}
-				</span>
-			</div>
-		</div>
-	{:else}
 	<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 	<div
 		class="
-			mb-4 flex-1 min-w-0 rounded-lg border border-l-[3px] bg-[var(--bg-subtle)] p-4 pl-5 transition-all duration-200
-			hover:shadow-md
+			mb-4 flex-1 min-w-0 rounded-lg border border-l-2 bg-[var(--bg-subtle)] p-4 pl-5 transition-all duration-200
+			hover:shadow-sm
 			{hasExpandableContent ? 'cursor-pointer' : ''}
-			{isPlanEvent ? 'border-[var(--event-plan)]/60' : config.borderColor}
+			{isPlanEvent ? 'border-[var(--event-plan)]/20' : config.borderColor}
 			{isPlanEvent ? 'border-l-[var(--event-plan)]' : config.leftAccent}
 		"
 		onclick={() => {
@@ -269,7 +254,7 @@
 			<div class="flex-1 space-y-1">
 				<!-- Title and badges -->
 				<div class="flex items-center gap-2 flex-wrap">
-					<span class="font-medium text-[var(--text-primary)]">
+					<span class="text-sm font-medium text-[var(--text-primary)]">
 						{#if searchQuery}
 							{@html highlightText(displayTitle, searchQuery)}
 						{:else}
@@ -463,5 +448,4 @@
 			<!-- todo_update uses TodoUpdateDetail inline, no extra expanded content needed -->
 		{/if}
 	</div>
-	{/if}
 </div>

--- a/frontend/src/lib/components/timeline/TimelineFilterBar.svelte
+++ b/frontend/src/lib/components/timeline/TimelineFilterBar.svelte
@@ -265,23 +265,32 @@
 			{/if}
 		</div>
 
-		<!-- Event Count -->
-		<div class="text-[11px] text-[var(--text-muted)] font-mono shrink-0 opacity-60">
+		<!-- Event Count + Clear (inline, always on first row) -->
+		<div class="flex items-center gap-2 shrink-0">
+			<div class="text-[11px] text-[var(--text-muted)] font-mono opacity-60">
+				{#if hasActiveFilters}
+					<span class="text-[var(--text-primary)] font-semibold opacity-100">{matchingEvents}</span>
+					<span class="opacity-50"> of </span>
+					<span class="opacity-80">{totalEvents}</span>
+					<span class="opacity-50 ml-0.5">events</span>
+				{:else}
+					<span class="font-medium opacity-80">{totalEvents}</span>
+					<span class="opacity-50 ml-0.5">events</span>
+				{/if}
+			</div>
 			{#if hasActiveFilters}
-				<span class="text-[var(--text-primary)] font-semibold opacity-100"
-					>{matchingEvents}</span
+				<button
+					onclick={onClear}
+					class="inline-flex items-center gap-1 px-2 py-1 text-[11px] font-medium text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-muted)] rounded-[var(--radius-md)] border border-[var(--border)] transition-colors"
 				>
-				<span class="opacity-50"> of </span>
-				<span class="opacity-80">{totalEvents}</span>
-				<span class="opacity-50 ml-0.5">events</span>
-			{:else}
-				<span class="font-medium opacity-80">{totalEvents}</span>
-				<span class="opacity-50 ml-0.5">events</span>
+					<X size={12} strokeWidth={2} />
+					Clear
+				</button>
 			{/if}
 		</div>
 	</div>
 
-	<!-- Bottom Row: Filters -->
+	<!-- Filter chips -->
 	<div class="flex flex-wrap items-center gap-x-1.5 gap-y-2 min-h-[32px]">
 		{#each filters as filter}
 			{@const count = counts[filter.countKey]}
@@ -306,32 +315,9 @@
 				>
 					<filter.icon size={14} strokeWidth={2} class={colors.icon} />
 					<span class="hidden md:inline">{filter.label}</span>
-					<span class="font-mono opacity-70">
-						{count}
-					</span>
+					<span class="font-mono opacity-70">{count}</span>
 				</button>
 			{/if}
 		{/each}
-
-		{#if hasActiveFilters}
-			<button
-				onclick={onClear}
-				class="
-					ml-auto
-					inline-flex items-center gap-1.5
-					px-2.5 py-1.5
-					text-xs font-medium
-					text-[var(--text-muted)]
-					hover:text-[var(--text-primary)]
-					hover:bg-[var(--bg-muted)]
-					rounded-[var(--radius-md)]
-					border border-[var(--border)]
-					transition-colors
-				"
-			>
-				<X size={14} strokeWidth={2} />
-				<span>Clear</span>
-			</button>
-		{/if}
 	</div>
 </div>

--- a/frontend/src/lib/components/timeline/TimelineRail.svelte
+++ b/frontend/src/lib/components/timeline/TimelineRail.svelte
@@ -36,6 +36,8 @@
 		projectEncoded?: string;
 		/** Session slug (short UUID) for building subagent links */
 		sessionSlug?: string;
+		/** When true, filter bar sticks to top-0 (scroll container is an ancestor, not the page) */
+		contained?: boolean;
 	}
 
 	let {
@@ -50,7 +52,8 @@
 		onSearchMatchCount,
 		onCurrentMatchChange,
 		projectEncoded,
-		sessionSlug
+		sessionSlug,
+		contained = false
 	}: Props = $props();
 
 	// Auto-scroll state
@@ -312,11 +315,11 @@
 			onClear={timeline.clearFilters}
 			searchQuery={timeline.searchQuery}
 			onSearchChange={timeline.setSearchQuery}
-			class="mb-6 sticky top-14 z-20"
+			class="sticky {contained ? 'top-0' : 'top-14'} z-20 {contained ? '' : 'mb-6'}"
 		/>
 
 		<!-- Timeline -->
-		<div class="pl-2" bind:this={timelineContentRef}>
+		<div class="pt-4 mx-[2.5%]" bind:this={timelineContentRef}>
 			{#each timeline.viewItems as item, loopIndex (item.id)}
 				{#if 'type' in item && item.type === 'gap'}
 					{@const gapItem = item}

--- a/frontend/src/lib/components/timeline/tool-icons.ts
+++ b/frontend/src/lib/components/timeline/tool-icons.ts
@@ -99,63 +99,63 @@ export const eventTypeConfig = {
 		icon: MessageSquareIcon,
 		color: 'text-[var(--event-prompt)]',
 		bgColor: 'bg-[var(--event-prompt-subtle)]',
-		borderColor: 'border-[var(--event-prompt)]/60',
+		borderColor: 'border-[var(--event-prompt)]/25',
 		leftAccent: 'border-l-[var(--event-prompt)]'
 	},
 	tool_call: {
 		icon: TerminalIcon,
 		color: 'text-[var(--event-tool)]',
 		bgColor: 'bg-[var(--event-tool-subtle)]',
-		borderColor: 'border-[var(--event-tool)]/60',
+		borderColor: 'border-[var(--event-tool)]/25',
 		leftAccent: 'border-l-[var(--event-tool)]'
 	},
 	subagent_spawn: {
 		icon: BotIcon,
 		color: 'text-[var(--event-subagent)]',
 		bgColor: 'bg-[var(--event-subagent-subtle)]',
-		borderColor: 'border-[var(--event-subagent)]/60',
+		borderColor: 'border-[var(--event-subagent)]/25',
 		leftAccent: 'border-l-[var(--event-subagent)]'
 	},
 	thinking: {
 		icon: BrainIcon,
 		color: 'text-[var(--event-thinking)]',
 		bgColor: 'bg-[var(--event-thinking-subtle)]',
-		borderColor: 'border-[var(--event-thinking)]/60',
+		borderColor: 'border-[var(--event-thinking)]/25',
 		leftAccent: 'border-l-[var(--event-thinking)]'
 	},
 	response: {
 		icon: MessageCircleIcon,
 		color: 'text-[var(--event-response)]',
 		bgColor: 'bg-[var(--event-response-subtle)]',
-		borderColor: 'border-[var(--event-response)]/60',
+		borderColor: 'border-[var(--event-response)]/25',
 		leftAccent: 'border-l-[var(--event-response)]'
 	},
 	todo_update: {
 		icon: ListTodoIcon,
 		color: 'text-[var(--event-todo)]',
 		bgColor: 'bg-[var(--event-todo-subtle)]',
-		borderColor: 'border-[var(--event-todo)]/60',
+		borderColor: 'border-[var(--event-todo)]/25',
 		leftAccent: 'border-l-[var(--event-todo)]'
 	},
 	command_invocation: {
 		icon: TerminalSquareIcon,
 		color: 'text-[var(--event-command)]',
 		bgColor: 'bg-[var(--event-command-subtle)]',
-		borderColor: 'border-[var(--event-command)]/60',
+		borderColor: 'border-[var(--event-command)]/25',
 		leftAccent: 'border-l-[var(--event-command)]'
 	},
 	skill_invocation: {
 		icon: TerminalSquareIcon,
 		color: 'text-[var(--accent)]',
 		bgColor: 'bg-[var(--accent)]/10',
-		borderColor: 'border-[var(--accent)]/60',
+		borderColor: 'border-[var(--accent)]/25',
 		leftAccent: 'border-l-[var(--accent)]'
 	},
 	builtin_command: {
 		icon: TerminalSquareIcon,
 		color: 'text-gray-400',
 		bgColor: 'bg-gray-500/10',
-		borderColor: 'border-gray-500/60',
+		borderColor: 'border-gray-500/25',
 		leftAccent: 'border-l-gray-500'
 	}
 } as const;

--- a/frontend/src/routes/agents/+page.svelte
+++ b/frontend/src/routes/agents/+page.svelte
@@ -1,624 +1,704 @@
 <script lang="ts">
-	import {
-		Bot,
-		Search,
-		Play,
-		Clock,
-		Cpu,
-		Puzzle,
-		Wrench,
-		FolderOpen,
-		ChevronsUpDown,
-		ChevronsDownUp,
-		ExternalLink
-	} from 'lucide-svelte';
+	import { Search, Sparkles, Info, TrendingUp, ChevronRight } from 'lucide-svelte';
+	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
 	import { navigating } from '$app/stores';
-	import { listNavigation } from '$lib/actions/listNavigation';
+	import { replaceState, beforeNavigate } from '$app/navigation';
+	import { tick } from 'svelte';
 	import PageHeader from '$lib/components/layout/PageHeader.svelte';
-	import SkeletonBox from '$lib/components/skeleton/SkeletonBox.svelte';
-	import SkeletonText from '$lib/components/skeleton/SkeletonText.svelte';
-	import SkeletonStatsCard from '$lib/components/skeleton/SkeletonStatsCard.svelte';
-	import SkeletonAgentCard from '$lib/components/skeleton/SkeletonAgentCard.svelte';
-	import StatsGrid from '$lib/components/StatsGrid.svelte';
-	import SegmentedControl from '$lib/components/ui/SegmentedControl.svelte';
-	import CollapsibleGroup from '$lib/components/ui/CollapsibleGroup.svelte';
-	import AgentUsageCard from '$lib/components/agents/AgentUsageCard.svelte';
-	import AgentUsageTable from '$lib/components/agents/AgentUsageTable.svelte';
-	import UsageAnalytics from '$lib/components/charts/UsageAnalytics.svelte';
-	import type { AgentCategory, AgentUsageSummary, StatItem } from '$lib/api-types';
+	import StackedAreaChart from '$lib/components/charts/StackedAreaChart.svelte';
 	import {
-		formatTokens,
 		getSubagentColorVars,
 		getPluginColorVars,
-		getScopeColorVars,
-		getSubagentChartHex,
 		getSubagentTypeDisplayName
 	} from '$lib/utils';
+	import { API_BASE } from '$lib/config';
+	import type { AgentUsageSummary, UsageTrendResponse } from '$lib/api-types';
 
-	// Server data — loaded once, never re-fetched on tab switch
 	let { data } = $props();
 
-	// Pure client-side filter state (no goto, no navigation, no flicker)
-	let searchQuery = $state('');
-	let selectedCategory = $state<AgentCategory>('all');
-	let viewMode = $state<'agents' | 'table' | 'analytics'>('agents');
-
-	const viewOptions = [
-		{ label: 'By Category', value: 'agents' },
-		{ label: 'All Agents', value: 'table' },
-		{ label: 'Usage Analytics', value: 'analytics' }
-	];
-
-	// Category filter options — dynamically built from actual data so empty categories are hidden
-	const allCategoryDefs: { label: string; value: string }[] = [
-		{ label: 'Built-in', value: 'builtin' },
-		{ label: 'Plugins', value: 'plugin' },
-		{ label: 'Custom', value: 'custom' },
-		{ label: 'Project', value: 'project' },
-		{ label: 'Claude Tax', value: 'claude_tax' },
-		{ label: 'Unknown', value: 'unknown' }
-	];
-	let categoryOptions = $derived([
-		{ label: 'All', value: 'all' },
-		...allCategoryDefs.filter((c) => (data.usage.by_category[c.value] ?? 0) > 0)
-	]);
-
-	// Stats from full dataset (unfiltered)
-	let stats = $derived<StatItem[]>([
-		{
-			title: 'Total Agents',
-			value: data.usage.total,
-			icon: Bot,
-			color: 'purple'
-		},
-		{
-			title: 'Total Runs',
-			value: data.usage.total_runs.toLocaleString(),
-			icon: Play,
-			color: 'blue'
-		},
-		{
-			title: 'Tokens In',
-			value: formatTokens(
-				data.usage.agents.reduce((sum, a) => sum + a.total_input_tokens, 0)
-			),
-			icon: Cpu,
-			color: 'green'
-		},
-		{
-			title: 'Tokens Out',
-			value: formatTokens(
-				data.usage.agents.reduce((sum, a) => sum + a.total_output_tokens, 0)
-			),
-			icon: Cpu,
-			color: 'orange'
-		}
-	]);
-
-	// Client-side filtering — instant, no round-trip (matches skills page pattern)
-	let filteredAgents = $derived.by(() => {
-		let agents = data.usage.agents;
-
-		if (selectedCategory !== 'all') {
-			agents = agents.filter((a) => a.category === selectedCategory);
-		}
-
-		if (searchQuery.trim()) {
-			const q = searchQuery.toLowerCase();
-			agents = agents.filter(
-				(a) =>
-					a.agent_name.toLowerCase().includes(q) ||
-					(a.subagent_type && a.subagent_type.toLowerCase().includes(q)) ||
-					(a.plugin_source && a.plugin_source.toLowerCase().includes(q))
-			);
-		}
-
-		return agents;
-	});
-
-	let maxRuns = $derived(
-		filteredAgents.length > 0 ? Math.max(...filteredAgents.map((a) => a.total_runs)) : 100
-	);
-
-	// Group agents by category or plugin source for display
-	interface AgentGroup {
-		key: string;
-		label: string;
-		icon: typeof Bot;
-		agents: AgentUsageSummary[];
-		pluginName: string | null;
+	function initParam(key: string, fallback: string): string {
+		if (browser) return new URLSearchParams(window.location.search).get(key) ?? fallback;
+		return fallback;
 	}
 
-	let groupedAgents = $derived.by<AgentGroup[]>(() => {
-		const agents = filteredAgents;
-		const groups: Map<string, AgentGroup> = new Map();
+	let activeView = $state<'overview' | 'analytics'>(
+		(initParam('view', 'overview') as 'overview' | 'analytics')
+	);
+	let searchQuery = $state(initParam('search', ''));
+	let selectedFilter = $state<'all' | 'plugin' | 'custom' | 'builtin' | 'project'>(
+		(initParam('filter', 'all') as 'all' | 'plugin' | 'custom' | 'builtin' | 'project')
+	);
+	let selectedCategory = $state<string | null>(null); // null = all categories
 
-		for (const agent of agents) {
-			let groupKey: string;
-			let groupLabel: string;
-			let groupIcon: typeof Bot;
-			let pluginName: string | null = null;
-
-			if (agent.category === 'plugin' && agent.plugin_source) {
-				groupKey = `plugin:${agent.plugin_source}`;
-				groupLabel = agent.plugin_source;
-				groupIcon = Puzzle;
-				pluginName = agent.plugin_source;
-			} else if (agent.category === 'builtin') {
-				groupKey = 'builtin';
-				groupLabel = 'Built-in Agents';
-				groupIcon = Bot;
-			} else if (agent.category === 'custom') {
-				groupKey = 'custom';
-				groupLabel = 'Custom Agents';
-				groupIcon = Wrench;
-			} else if (agent.category === 'project') {
-				groupKey = 'project';
-				groupLabel = 'Project Agents';
-				groupIcon = FolderOpen;
-			} else if (agent.category === 'claude_tax') {
-				groupKey = 'claude_tax';
-				groupLabel = 'Claude Tax';
-				groupIcon = Cpu;
-			} else if (agent.category === 'unknown') {
-				groupKey = 'unknown';
-				groupLabel = 'Unclassified Agents';
-				groupIcon = Bot;
-			} else {
-				groupKey = 'other';
-				groupLabel = 'Other Agents';
-				groupIcon = Bot;
-			}
-
-			if (!groups.has(groupKey)) {
-				groups.set(groupKey, {
-					key: groupKey,
-					label: groupLabel,
-					icon: groupIcon,
-					agents: [],
-					pluginName
-				});
-			}
-			groups.get(groupKey)!.agents.push(agent);
-		}
-
-		const sortOrder = ['builtin', 'custom', 'project', 'claude_tax', 'unknown'];
-		return Array.from(groups.values()).sort((a, b) => {
-			const aOrder = sortOrder.indexOf(a.key);
-			const bOrder = sortOrder.indexOf(b.key);
-			if (aOrder !== -1 && bOrder !== -1) return aOrder - bOrder;
-			if (aOrder !== -1) return -1;
-			if (bOrder !== -1) return 1;
-			return a.label.localeCompare(b.label);
+	$effect(() => {
+		if (!browser) return;
+		const v = activeView;
+		const f = selectedFilter;
+		const s = searchQuery;
+		tick().then(() => {
+			const url = new URL(window.location.href);
+			if (v !== 'overview') url.searchParams.set('view', v);
+			else url.searchParams.delete('view');
+			if (f !== 'all') url.searchParams.set('filter', f);
+			else url.searchParams.delete('filter');
+			if (s.trim()) url.searchParams.set('search', s.trim());
+			else url.searchParams.delete('search');
+			replaceState(url.toString(), {});
 		});
 	});
 
-	// Track which groups are expanded (all collapsed by default, matching tools page)
-	let expandedGroups = $state<Set<string>>(new Set());
-	// Snapshot of expanded groups before search
-	let previousExpandedGroups = $state<Set<string> | null>(null);
+	// ── Base data ──────────────────────────────────────────────────────────────
+	let allAgents = $derived<AgentUsageSummary[]>(data.usage.agents || []);
 
-	// Auto-expand/restore logic
-	$effect(() => {
-		const hasSearch = searchQuery.trim().length > 0;
-
-		if (hasSearch) {
-			// Snapshot state if starting a new search
-			if (previousExpandedGroups === null) {
-				previousExpandedGroups = new Set(expandedGroups);
-			}
-			// Auto-expand all matching groups
-			if (groupedAgents.length > 0) {
-				expandedGroups = new Set(groupedAgents.map((g) => g.key));
-			}
-		} else {
-			// Restore previous state if clearing search
-			if (previousExpandedGroups !== null) {
-				expandedGroups = previousExpandedGroups;
-				previousExpandedGroups = null;
-			}
-		}
-	});
-
-	function toggleGroup(key: string) {
-		if (expandedGroups.has(key)) {
-			expandedGroups.delete(key);
-		} else {
-			expandedGroups.add(key);
-		}
-		expandedGroups = new Set(expandedGroups);
+	// ── Grouping ───────────────────────────────────────────────────────────────
+	interface AgentGroup {
+		key: string;
+		label: string;
+		agents: AgentUsageSummary[];
+		pluginName: string | null;
+		category: string;
 	}
 
-	let allExpanded = $derived(
-		groupedAgents.length > 0 && groupedAgents.every((g) => expandedGroups.has(g.key))
+	let groupedAgents = $derived.by<AgentGroup[]>(() => {
+		const groups = new Map<string, AgentGroup>();
+		for (const agent of allAgents) {
+			let key: string, label: string, pluginName: string | null = null, category: string;
+			if (agent.category === 'builtin') {
+				key = 'builtin'; label = 'Built-in Agents'; category = 'builtin';
+			} else if (agent.category === 'plugin' && agent.plugin_source) {
+				key = `plugin:${agent.plugin_source}`; label = agent.plugin_source; pluginName = agent.plugin_source; category = 'plugin';
+			} else if (agent.category === 'custom') {
+				key = 'custom'; label = 'Custom Agents'; category = 'custom';
+			} else if (agent.category === 'project') {
+				key = 'project'; label = 'Project Agents'; category = 'project';
+			} else {
+				key = 'other'; label = 'Other Agents'; category = 'unknown';
+			}
+			if (!groups.has(key)) groups.set(key, { key, label, agents: [], pluginName, category });
+			groups.get(key)!.agents.push(agent);
+		}
+		return Array.from(groups.values());
+	});
+
+	// ── Left panel: sorted by total_runs desc ─────────────────────────────────
+	let leftPanelGroups = $derived.by(() => {
+		return [...groupedAgents]
+			.filter(g => {
+				if (selectedFilter === 'builtin') return g.category === 'builtin';
+				if (selectedFilter === 'plugin') return g.category === 'plugin';
+				if (selectedFilter === 'custom') return g.category === 'custom';
+				if (selectedFilter === 'project') return g.category === 'project';
+				return true;
+			})
+			.sort((a, b) => {
+				const aTotal = a.agents.reduce((sum, ag) => sum + ag.total_runs, 0);
+				const bTotal = b.agents.reduce((sum, ag) => sum + ag.total_runs, 0);
+				return bTotal - aTotal;
+			});
+	});
+
+	// ── Stats ──────────────────────────────────────────────────────────────────
+	let totalRuns = $derived(allAgents.reduce((sum, a) => sum + a.total_runs, 0));
+	let activeAgentsCount = $derived(allAgents.filter(a => a.total_runs > 0).length);
+	let totalAgentsCount = $derived(allAgents.length);
+	let unusedCount = $derived(allAgents.filter(a => a.total_runs === 0).length);
+
+	let grandTotalRuns = $derived(totalRuns > 0 ? totalRuns : 1);
+
+	// ── Right panel: filtered + sorted ────────────────────────────────────────
+	let rightPanelAgents = $derived.by(() => {
+		let agents = allAgents.filter(a => a.total_runs > 0);
+
+		const cat = selectedCategory;
+		if (cat !== null) {
+			agents = agents.filter(a => {
+				if (cat.startsWith('plugin:')) {
+					return a.category === 'plugin' && a.plugin_source === cat.slice(7);
+				}
+				return a.category === cat;
+			});
+		}
+
+		if (selectedFilter === 'builtin') agents = agents.filter(a => a.category === 'builtin');
+		else if (selectedFilter === 'plugin') agents = agents.filter(a => a.category === 'plugin');
+		else if (selectedFilter === 'custom') agents = agents.filter(a => a.category === 'custom');
+		else if (selectedFilter === 'project') agents = agents.filter(a => a.category === 'project');
+
+		if (searchQuery.trim()) {
+			const q = searchQuery.toLowerCase();
+			agents = agents.filter(a =>
+				a.agent_name.toLowerCase().includes(q) ||
+				a.subagent_type.toLowerCase().includes(q) ||
+				(a.plugin_source && a.plugin_source.toLowerCase().includes(q))
+			);
+		}
+
+		return agents.slice().sort((a, b) => b.total_runs - a.total_runs);
+	});
+
+	let globalMax = $derived(
+		rightPanelAgents.length > 0 ? Math.max(...rightPanelAgents.map(a => a.total_runs), 1) : 1
 	);
 
-	function expandAll() {
-		expandedGroups = new Set(groupedAgents.map((g) => g.key));
+	// ── Analytics derived ─────────────────────────────────────────────────────
+	let analyticsTotalRuns = $derived(rightPanelAgents.reduce((sum, a) => sum + a.total_runs, 0));
+	let analyticsTotalCost = $derived(rightPanelAgents.reduce((sum, a) => sum + a.total_cost_usd, 0));
+
+	// ── Insight banner ────────────────────────────────────────────────────────
+	let insightText = $derived.by(() => {
+		if (rightPanelAgents.length === 0) return null;
+		const top = rightPanelAgents[0];
+		const topName = getSubagentTypeDisplayName(top.subagent_type);
+		const topReach = rightPanelAgents.slice().sort((a, b) => b.projects_used_in.length - a.projects_used_in.length)[0];
+		const topReachName = topReach ? getSubagentTypeDisplayName(topReach.subagent_type) : null;
+		if (topReachName && topReachName !== topName) {
+			return {
+				bold: `${topName} leads all runs`,
+				rest: ` · ${topReachName} spans ${topReach.projects_used_in.length} project${topReach.projects_used_in.length !== 1 ? 's' : ''} · ${rightPanelAgents.length} active agents total`
+			};
+		}
+		return {
+			bold: `${rightPanelAgents.length} active agents`,
+			rest: ` · ${topName} leads with ${top.total_runs} runs across ${top.projects_used_in.length} project${top.projects_used_in.length !== 1 ? 's' : ''}`
+		};
+	});
+
+	// ── Project reach panel ───────────────────────────────────────────────────
+	let projectReachAgents = $derived(
+		rightPanelAgents.slice().sort((a, b) => b.projects_used_in.length - a.projects_used_in.length).slice(0, 8)
+	);
+	let projectReachMax = $derived(projectReachAgents.length > 0 ? projectReachAgents[0].projects_used_in.length : 1);
+
+	// ── Trend chart state ─────────────────────────────────────────────────────
+	let trendRange = $state<'7d' | '30d' | '90d'>('90d');
+	let trendData = $state<UsageTrendResponse | null>(null);
+	let trendLoading = $state(false);
+	let trendRangeUserOverride = $state(false);
+
+	const periodMap: Record<'7d' | '30d' | '90d', string> = { '7d': 'week', '30d': 'month', '90d': 'quarter' };
+
+	$effect(() => {
+		if (!browser || activeView !== 'analytics') return;
+		trendLoading = true;
+		const url = new URL(`${API_BASE}/agents/usage/trend`);
+		url.searchParams.set('period', periodMap[trendRange]);
+		fetch(url)
+			.then(r => r.json())
+			.then(d => {
+				trendData = d;
+				if (!trendRangeUserOverride) {
+					const total = (d as UsageTrendResponse)?.total ?? 0;
+					if (total === 0 && trendRange === '90d') trendRange = '30d';
+					else if (total === 0 && trendRange === '30d') trendRange = '7d';
+				}
+			})
+			.catch(() => {})
+			.finally(() => { trendLoading = false; });
+	});
+
+	// ── getGroupFor for StackedAreaChart ──────────────────────────────────────
+	function getGroupFor(itemName: string): { key: string; label: string; color: string } | null {
+		const agent = allAgents.find(a => a.subagent_type === itemName);
+		if (!agent) return null;
+		if (agent.category === 'plugin' && agent.plugin_source) {
+			const colors = getPluginColorVars(agent.plugin_source);
+			return { key: `plugin:${agent.plugin_source}`, label: agent.plugin_source, color: colors.color };
+		}
+		const colors = getSubagentColorVars(agent.subagent_type);
+		const label = agent.category === 'builtin' ? 'built-in' : agent.category === 'custom' ? 'custom' : agent.category === 'project' ? 'project' : 'other';
+		return { key: agent.category, label, color: colors.color };
 	}
 
-	function collapseAll() {
-		expandedGroups = new Set();
+	// ── Helpers ────────────────────────────────────────────────────────────────
+	function shortDate(ts: string | null): string {
+		if (!ts) return '—';
+		const date = new Date(ts);
+		const diffMs = Date.now() - date.getTime();
+		const diffMins = Math.floor(diffMs / 60000);
+		const diffHours = Math.floor(diffMins / 60);
+		const diffDays = Math.floor(diffHours / 24);
+		if (diffMins < 1) return 'now';
+		if (diffMins < 60) return `${diffMins}m`;
+		if (diffHours < 24) return `${diffHours}h`;
+		if (diffDays < 7) return `${diffDays}d`;
+		return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 	}
 
-	function toggleAllGroups() {
-		if (allExpanded) {
-			collapseAll();
+	function getCategoryBadge(agent: AgentUsageSummary): string {
+		if (agent.category === 'plugin' && agent.plugin_source) return agent.plugin_source;
+		if (agent.category === 'builtin') return 'built-in';
+		if (agent.category === 'custom') return 'custom';
+		if (agent.category === 'project') return 'project';
+		return agent.category;
+	}
+
+	function getAgentColors(agent: AgentUsageSummary) {
+		if (agent.category === 'plugin' && agent.plugin_source) return getPluginColorVars(agent.plugin_source);
+		return getSubagentColorVars(agent.subagent_type);
+	}
+
+	let coverageOpen = $state(false);
+
+	function toggleCategory(group: AgentGroup) {
+		const key = group.pluginName ? `plugin:${group.pluginName}` : group.category;
+		if (selectedCategory === key) selectedCategory = null;
+		else selectedCategory = key;
+	}
+
+	// ── Available filter chips (only categories with data) ────────────────────
+	let availableFilters = $derived.by(() => {
+		const cats = new Set(allAgents.map(a => a.category));
+		const filters: { val: 'all' | 'plugin' | 'custom' | 'builtin' | 'project'; lbl: string }[] = [
+			{ val: 'all', lbl: 'All' }
+		];
+		if (cats.has('plugin')) filters.push({ val: 'plugin', lbl: 'Plugin' });
+		if (cats.has('custom')) filters.push({ val: 'custom', lbl: 'Custom' });
+		if (cats.has('builtin')) filters.push({ val: 'builtin', lbl: 'Built-in' });
+		if (cats.has('project')) filters.push({ val: 'project', lbl: 'Project' });
+		return filters;
+	});
+
+	// ── Scroll save/restore when navigating to agent detail ───────────────────
+	const SCROLL_KEY = 'agents_scroll';
+
+	beforeNavigate(({ to }) => {
+		if (!browser) return;
+		if (to?.route.id?.startsWith('/agents/')) {
+			sessionStorage.setItem(SCROLL_KEY, String(window.scrollY));
 		} else {
-			expandAll();
+			sessionStorage.removeItem(SCROLL_KEY);
 		}
-	}
-
-	// Agents with definitions but no usage data
-	let unusedDefinitions = $derived.by(() => {
-		const usedNames = new Set(data.usage.agents.map((a) => a.agent_name));
-		return data.definitions.filter((d) => !usedNames.has(d.name));
 	});
 
-	// Build a category lookup from agent data for analytics filtering
-	// Key by subagent_type since that's what the trend API uses in by_item
-	let agentCategoryMap = $derived.by(() => {
-		const map = new Map<string, string>();
-		for (const agent of data.usage.agents) {
-			map.set(agent.subagent_type, agent.category);
+	onMount(() => {
+		const saved = sessionStorage.getItem(SCROLL_KEY);
+		if (saved !== null) {
+			sessionStorage.removeItem(SCROLL_KEY);
+			requestAnimationFrame(() => window.scrollTo({ top: Number(saved), behavior: 'instant' }));
 		}
-		return map;
 	});
-
-	let excludeFn = $derived.by(() => {
-		if (selectedCategory === 'all') return undefined;
-		return (name: string) => agentCategoryMap.get(name) !== selectedCategory;
-	});
-
-	let hasAgents = $derived(data.usage.agents.length > 0 || unusedDefinitions.length > 0);
-	let hasFilteredAgents = $derived(filteredAgents.length > 0);
 
 	let isPageLoading = $derived(!!$navigating && $navigating.to?.route.id === '/agents');
 </script>
 
-<div class="space-y-8">
-	{#if isPageLoading}
-		<div class="space-y-8" role="status" aria-busy="true" aria-label="Loading...">
-			<!-- Page Header skeleton -->
-			<div>
-				<div class="flex items-center gap-2 mb-2">
-					<SkeletonText width="70px" size="xs" />
-					<span class="text-[var(--text-muted)]">/</span>
-					<SkeletonText width="50px" size="xs" />
-				</div>
-				<div class="flex items-center gap-4">
-					<SkeletonBox width="48px" height="48px" rounded="lg" />
-					<div>
-						<SkeletonText width="100px" size="xl" class="mb-2" />
-						<SkeletonText width="300px" size="sm" />
-					</div>
-				</div>
-			</div>
-
-			<!-- Hero Stats skeleton -->
-			<div
-				class="relative overflow-hidden rounded-2xl p-8 border border-[var(--border)]"
-				style="background: linear-gradient(135deg, rgba(124, 58, 237, 0.02) 0%, rgba(124, 58, 237, 0.06) 100%);"
-			>
-				<div class="relative grid grid-cols-1 sm:grid-cols-4 gap-4">
-					{#each Array(4) as _}
-						<SkeletonStatsCard />
-					{/each}
-				</div>
-			</div>
-
-			<!-- Filters row skeleton -->
-			<div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-				<div class="flex items-center gap-3 flex-wrap">
-					<div class="flex gap-1">
-						{#each Array(3) as _}
-							<SkeletonBox width="110px" height="36px" rounded="lg" />
-						{/each}
-					</div>
-					<div class="flex gap-1">
-						{#each Array(5) as _}
-							<SkeletonBox width="70px" height="32px" rounded="lg" />
-						{/each}
-					</div>
-				</div>
-				<div class="flex items-center gap-3">
-					<SkeletonBox width="256px" height="40px" rounded="lg" />
-					<SkeletonBox width="120px" height="40px" rounded="lg" />
-				</div>
-			</div>
-
-			<!-- Collapsible agent groups skeleton -->
-			<div class="space-y-4">
-				{#each Array(2) as _, groupIndex}
-					<div class="border border-[var(--border)] rounded-[var(--radius-lg)] overflow-hidden bg-[var(--bg-base)]">
-						<div class="flex items-center gap-3 px-4 py-4">
-							<SkeletonBox width="16px" height="16px" rounded="sm" />
-							<SkeletonBox width="32px" height="32px" rounded="md" />
-							<SkeletonText width="120px" size="sm" />
-							<div class="flex-1"></div>
-							<SkeletonText width="60px" size="xs" />
-						</div>
-						{#if groupIndex === 0}
-							<div class="border-t border-[var(--border)] p-4">
-								<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-									{#each Array(3) as _}
-										<SkeletonAgentCard />
-									{/each}
-								</div>
-							</div>
-						{/if}
-					</div>
-				{/each}
-			</div>
+{#if isPageLoading}
+	<div class="-mx-6 -my-8 flex items-center justify-center" style="height: calc(100vh - 56px);">
+		<div class="flex flex-col items-center gap-3">
+			<div style="width: 32px; height: 32px; border: 2px solid var(--accent); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
+			<span class="text-sm text-[var(--text-muted)]">Loading agents…</span>
 		</div>
-	{:else}
-	<!-- Page Header -->
-	<PageHeader
-		title="Agents"
-		iconName="agents"
-		iconColor="--nav-purple"
-		breadcrumbs={[{ label: 'Dashboard', href: '/' }, { label: 'Agents' }]}
-		subtitle="View agent usage analytics and manage custom agent definitions"
-	/>
+	</div>
+{:else}
 
-	<!-- Hero Stats -->
-	{#if hasAgents}
-		<div
-			class="relative overflow-hidden rounded-2xl p-8 border border-[var(--border)]"
-			style="background: linear-gradient(135deg, rgba(124, 58, 237, 0.02) 0%, rgba(124, 58, 237, 0.06) 100%);"
-		>
-			<div
-				class="absolute -top-24 -right-24 w-96 h-96 bg-violet-500/5 rounded-full blur-3xl pointer-events-none"
-			></div>
-			<div
-				class="absolute -bottom-24 -left-24 w-64 h-64 bg-blue-500/3 rounded-full blur-3xl pointer-events-none"
-			></div>
-			<div class="relative">
-				<StatsGrid {stats} columns={4} />
-			</div>
-		</div>
-	{/if}
+<!-- ── Full-bleed split-view container ────────────────────────────────────── -->
+<div
+	class="-mx-6 -my-8 flex flex-col"
+	style="{activeView === 'overview' ? 'height: calc(100vh - 56px); overflow: hidden;' : ''}"
+>
 
-	<!-- Filters Row -->
-	<div
-		class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4"
-		use:listNavigation
-	>
-		<div class="flex items-center gap-3 flex-wrap">
-			<SegmentedControl options={viewOptions} bind:value={viewMode} />
-			<SegmentedControl options={categoryOptions} bind:value={selectedCategory} size="sm" />
-		</div>
-
-		{#if viewMode !== 'analytics'}
-			<div class="flex items-center gap-3 w-full sm:w-auto">
-				<div class="relative flex-1 sm:flex-initial">
-					<Search
-						class="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)]"
-						size={16}
-					/>
-					<input
-						type="text"
-						bind:value={searchQuery}
-						placeholder="Search agents..."
-						class="
-							pl-9 pr-4 py-2
-							bg-[var(--bg-base)]
-							border border-[var(--border)]
-							rounded-lg text-sm
-							focus:outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent)]/20
-							w-full sm:w-64
-							transition-all
-							text-[var(--text-primary)]
-							placeholder:text-[var(--text-faint)]
-						"
-						data-search-input
-					/>
-				</div>
-
-				{#if viewMode === 'agents' && groupedAgents.length > 1}
-					<button
-						onclick={toggleAllGroups}
-						class="
-							flex items-center gap-1.5 px-3 py-2
-							text-sm font-medium
-							text-[var(--text-secondary)]
-							hover:text-[var(--text-primary)]
-							bg-[var(--bg-base)]
-							border border-[var(--border)]
-							rounded-lg
-							transition-all
-							hover:bg-[var(--bg-subtle)]
-							whitespace-nowrap
-						"
-						title={allExpanded ? 'Collapse all groups' : 'Expand all groups'}
-					>
-						{#if allExpanded}
-							<ChevronsDownUp size={16} />
-							<span class="hidden sm:inline">Collapse All</span>
-						{:else}
-							<ChevronsUpDown size={16} />
-							<span class="hidden sm:inline">Expand All</span>
-						{/if}
-					</button>
-				{/if}
-			</div>
-		{/if}
+	<!-- ── Page Header ──────────────────────────────────────────────────────── -->
+	<div class="flex-shrink-0" style="padding: 0 24px; background: var(--bg-base);">
+		<PageHeader
+			title="Agents"
+			iconName="agents"
+			iconColor="--nav-purple"
+			breadcrumbs={[{ label: 'Dashboard', href: '/' }, { label: 'Agents' }]}
+			subtitle="How much are my agents really doing?"
+		/>
 	</div>
 
-	<!-- Content Area -->
-	{#if !hasAgents}
+	<!-- Filter bar — always visible -->
+	<div
+		class="flex flex-shrink-0 items-center"
+		style="padding: 8px 12px; gap: 10px; {activeView === 'analytics' ? 'position: sticky; top: 56px; z-index: 10; background: var(--bg-base); border-bottom: 1px solid var(--border-subtle);' : ''}"
+	>
+		<!-- Left group: view tabs — fixed width matching left panel -->
 		<div
-			class="text-center py-20 bg-[var(--bg-subtle)] rounded-2xl border border-dashed border-[var(--border)]"
+			class="flex rounded-lg p-0.5 flex-shrink-0"
+			style="width: 280px; background: var(--bg-muted);"
+			role="tablist"
+			aria-label="View"
 		>
-			<Bot class="mx-auto text-[var(--text-muted)] mb-3" size={48} />
-			<p class="text-[var(--text-secondary)] font-medium">No agents found</p>
-			<p class="text-sm text-[var(--text-muted)] mt-1">
-				Agent usage data will appear here once you start using Claude Code
-			</p>
-		</div>
-	{:else if !hasFilteredAgents}
-		<div
-			class="text-center py-20 bg-[var(--bg-subtle)] rounded-2xl border border-dashed border-[var(--border)]"
-		>
-			<Search class="mx-auto text-[var(--text-muted)] mb-3" size={48} />
-			<p class="text-[var(--text-secondary)] font-medium">No matching agents</p>
-			<p class="text-sm text-[var(--text-muted)] mt-1">
-				Try adjusting your search or category filter
-			</p>
-		</div>
-	{:else if viewMode === 'analytics'}
-		<!-- Usage Analytics View -->
-		<UsageAnalytics
-			endpoint="/agents/usage/trend"
-			itemLabel="Agents"
-			colorFn={getSubagentChartHex}
-			excludeItemFn={excludeFn}
-			itemLinkPrefix="/agents/"
-			itemDisplayFn={getSubagentTypeDisplayName}
-		/>
-	{:else if viewMode === 'table'}
-		<!-- Flat Table View -->
-		<AgentUsageTable agents={filteredAgents} />
-	{:else}
-		<!-- Grouped Agent Display -->
-		<div class="space-y-4">
-			{#each groupedAgents as group (group.key)}
-				{@const groupColors = group.pluginName
-					? getPluginColorVars(group.pluginName)
-					: group.key === 'project'
-						? getScopeColorVars('project')
-						: group.key === 'custom'
-							? getScopeColorVars('user')
-							: { color: 'var(--text-muted)', subtle: 'var(--bg-subtle)' }}
-				<CollapsibleGroup
-					title={group.label}
-					open={expandedGroups.has(group.key)}
-					onOpenChange={() => toggleGroup(group.key)}
-					accentColor={groupColors.color}
-				>
-					{#snippet icon()}
-						{@const GroupIcon = group.icon}
-						<div
-							class="p-1.5 rounded-md"
-							style="background-color: {groupColors.subtle}; color: {groupColors.color};"
-						>
-							<GroupIcon size={14} />
-						</div>
-					{/snippet}
-					{#snippet metadata()}
-						<div class="flex items-center gap-3">
-							<span class="text-xs text-[var(--text-muted)] tabular-nums">
-								{group.agents.length} agent{group.agents.length !== 1 ? 's' : ''}
-							</span>
-							{#if group.pluginName}
-								<a
-									href="/plugins/{encodeURIComponent(group.pluginName)}"
-									class="
-										inline-flex items-center gap-1 px-2 py-0.5
-										text-[10px] font-medium
-										text-[var(--accent)] hover:text-[var(--text-primary)]
-										bg-[var(--accent-subtle)] hover:bg-[var(--bg-muted)]
-										rounded-full
-										transition-colors
-									"
-									onclick={(e) => e.stopPropagation()}
-									title="View plugin"
-								>
-									<Puzzle size={10} />
-									View plugin
-									<ExternalLink size={9} />
-								</a>
-							{/if}
-						</div>
-					{/snippet}
-
-					<div
-						class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 stagger-children"
-					>
-						{#each group.agents as agent (agent.subagent_type)}
-							<AgentUsageCard {agent} {maxRuns} />
-						{/each}
-					</div>
-				</CollapsibleGroup>
+			{#each ([['overview', 'Overview'], ['analytics', 'Analytics']] as const) as [val, lbl]}
+				<button
+					role="tab"
+					aria-selected={activeView === val}
+					onclick={() => activeView = val}
+					class="flex-1 rounded-md transition-all"
+					style="
+						padding: 4px 8px;
+						font-size: 11px;
+						font-weight: {activeView === val ? '600' : '500'};
+						color: {activeView === val ? 'var(--bg-base)' : 'var(--text-secondary)'};
+						background: {activeView === val ? 'var(--text-primary)' : 'transparent'};
+					"
+				>{lbl}</button>
 			{/each}
 		</div>
 
-		<!-- Defined but Unused Agents -->
-		{#if unusedDefinitions.length > 0 && (selectedCategory === 'all' || selectedCategory === 'custom')}
-			<CollapsibleGroup
-				title="Available Agents"
-				open={expandedGroups.has('available')}
-				onOpenChange={() => toggleGroup('available')}
+		<!-- Right group: type chips + search -->
+		<div class="flex items-center gap-2 flex-1">
+			<div class="flex items-center gap-1.5">
+				{#each availableFilters as { val, lbl }}
+					<button
+						onclick={() => { selectedFilter = val; selectedCategory = null; }}
+						class="rounded-full transition-all"
+						style="
+							padding: 4px 12px;
+							font-size: 11px;
+							font-weight: {selectedFilter === val ? '600' : '500'};
+							color: {selectedFilter === val ? 'var(--accent)' : 'var(--text-secondary)'};
+							background: {selectedFilter === val ? 'var(--accent-muted)' : 'transparent'};
+							border: {selectedFilter === val ? '1.5px solid var(--accent-subtle)' : '1px solid var(--border)'};
+						"
+					>{lbl}</button>
+				{/each}
+			</div>
+			<div class="relative ml-auto">
+				<Search class="absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" size={12} style="color: var(--text-faint);" />
+				<input
+					type="text"
+					bind:value={searchQuery}
+					aria-label="Search agents"
+					placeholder="Search agents…"
+					style="width: 180px; padding: 4px 10px 4px 26px; font-size: 12px; background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 8px; color: var(--text-primary); outline: none;"
+					data-search-input
+				/>
+			</div>
+		</div>
+	</div>
+
+	{#if activeView === 'overview'}
+	<!-- Split view -->
+	<div class="flex flex-1 min-h-0 overflow-hidden" style="padding: 0 12px 12px; gap: 10px;">
+
+		<!-- ── Left Panel: Agent Coverage ──────────────────────────────────── -->
+		<div
+			class="flex-shrink-0 flex flex-col"
+			style="width: 280px; background: var(--bg-base); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; align-self: flex-start;"
+		>
+			<!-- Panel header — accordion trigger -->
+			<button
+				class="w-full text-left flex-shrink-0 transition-colors hover:bg-[var(--bg-subtle)]"
+				style="border-bottom: 1px solid {coverageOpen ? 'var(--border-subtle)' : 'transparent'}; padding: 14px 16px 12px;"
+				onclick={() => coverageOpen = !coverageOpen}
 			>
-				{#snippet icon()}
-					<div class="p-1.5 bg-[var(--bg-subtle)] rounded-md">
-						<Bot size={14} class="text-[var(--text-muted)]" />
-					</div>
-				{/snippet}
-				{#snippet metadata()}
-					<span class="text-xs text-[var(--text-muted)] tabular-nums">
-						{unusedDefinitions.length} agent{unusedDefinitions.length !== 1 ? 's' : ''} &middot;
-						no usage yet
+				<div class="flex items-center justify-between mb-2">
+					<span style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace;">
+						Agent Coverage
 					</span>
-				{/snippet}
+					<div style="color: var(--text-faint); transition: transform 0.2s; transform: rotate({coverageOpen ? 90 : 0}deg);">
+						<ChevronRight size={13} />
+					</div>
+				</div>
+				<!-- Stats: 3 columns -->
+				<div class="flex items-center w-full">
+					<div class="flex flex-col flex-1 items-center">
+						<span style="font-size: 22px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: var(--text-primary); letter-spacing: -1px;">{totalRuns.toLocaleString()}</span>
+						<span style="font-size: 9px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.06em;">runs</span>
+					</div>
+					<div style="width: 1px; height: 32px; background: var(--border);"></div>
+					<div class="flex flex-col flex-1 items-center">
+						<span style="font-size: 22px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: var(--text-primary); letter-spacing: -1px;">{activeAgentsCount}<span style="font-size: 13px; font-weight: 500; color: var(--text-faint);">/{totalAgentsCount}</span></span>
+						<span style="font-size: 9px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.06em;">active</span>
+					</div>
+					{#if unusedCount > 0}
+						<div style="width: 1px; height: 32px; background: var(--border);"></div>
+						<div class="flex flex-col flex-1 items-center">
+							<span style="font-size: 22px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: var(--nav-orange); letter-spacing: -1px;">{unusedCount}</span>
+							<span style="font-size: 9px; color: var(--nav-orange); text-transform: uppercase; letter-spacing: 0.06em; opacity: 0.8;">unused</span>
+						</div>
+					{/if}
+				</div>
+			</button>
 
-				<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 stagger-children">
-					{#each unusedDefinitions as def (def.name)}
-						{@const colorVars = getSubagentColorVars(def.name)}
+			<!-- Group rows — only when accordion is open -->
+			{#if coverageOpen}
+			<div class="flex-1 overflow-y-auto">
+				{#each leftPanelGroups as group}
+					{@const groupRuns = group.agents.reduce((sum, a) => sum + a.total_runs, 0)}
+					{@const pct = grandTotalRuns > 0 ? Math.round((groupRuns / grandTotalRuns) * 100) : 0}
+					{@const colors = group.pluginName ? getPluginColorVars(group.pluginName) : getSubagentColorVars(group.agents[0]?.subagent_type)}
+					{@const isNeverUsed = groupRuns === 0}
+					{@const catKey = group.pluginName ? `plugin:${group.pluginName}` : group.category}
+					{@const isSelected = selectedCategory === catKey}
+					<div
+						role="button"
+						tabindex="0"
+						onclick={() => toggleCategory(group)}
+						onkeydown={(e) => e.key === 'Enter' && toggleCategory(group)}
+						class="border-b cursor-pointer group/row transition-colors"
+						style="
+							padding: 10px 20px;
+							border-color: var(--border-subtle);
+							background: {isSelected ? 'var(--accent-muted)' : 'transparent'};
+							border-left: {isSelected ? '2px solid var(--accent)' : '2px solid transparent'};
+							opacity: {isNeverUsed ? 0.45 : 1};
+						"
+					>
+						<!-- Name row -->
+						<div class="flex items-center justify-between gap-2" style="margin-bottom: 6px;">
+							<span class="flex-1 min-w-0 truncate" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;">
+								{group.label}
+							</span>
+							<div class="flex items-center gap-1.5 flex-shrink-0">
+								{#if groupRuns === grandTotalRuns && grandTotalRuns > 0}
+									<TrendingUp size={10} style="color: var(--nav-orange);" />
+								{/if}
+								<span style="font-size: 12px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: {isNeverUsed ? 'var(--text-faint)' : pct >= 50 ? 'var(--text-secondary)' : 'var(--text-faint)'};">
+									{pct}%
+								</span>
+							</div>
+						</div>
+
+						<!-- Bar + count -->
+						<div class="flex items-center gap-2">
+							<div class="flex-1" style="height: 3px; border-radius: 2px; background: var(--bg-muted); overflow: hidden;">
+								{#if !isNeverUsed}
+									<div style="height: 100%; border-radius: 2px; width: {pct}%; background: var(--accent); opacity: 0.5;"></div>
+								{/if}
+							</div>
+							<span style="font-size: 10px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace; flex-shrink: 0;">
+								{groupRuns.toLocaleString()} runs
+							</span>
+						</div>
+					</div>
+				{/each}
+			</div>
+
+			<!-- Sort footer -->
+			<div class="flex-shrink-0 border-t flex items-center justify-between" style="padding: 10px 16px; border-color: var(--border-subtle);">
+				<span style="font-size: 10px; color: var(--text-faint);">Sorted by total runs</span>
+				{#if selectedCategory !== null}
+					<button onclick={() => selectedCategory = null} style="font-size: 10px; color: var(--accent); font-weight: 600;">
+						Clear ×
+					</button>
+				{/if}
+			</div>
+			{/if}
+		</div>
+
+		<!-- ── Right Panel: Top Agents Leaderboard ─────────────────────────── -->
+		<div class="flex-1 flex flex-col overflow-hidden min-w-0" style="background: var(--bg-base); border: 1px solid var(--border); border-radius: 12px;">
+
+			<!-- Panel header -->
+			<div
+				class="flex-shrink-0 flex items-center justify-between border-b"
+				style="padding: 14px 16px 12px; background: var(--bg-base); border-color: var(--border);"
+			>
+				<div>
+					<div style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace; margin-bottom: 3px;">Top Agents</div>
+					<div style="font-size: 11px; color: var(--text-faint);">
+						{#if selectedCategory !== null}
+							{rightPanelAgents.length} agents · {selectedCategory.startsWith('plugin:') ? selectedCategory.slice(7) : selectedCategory}
+						{:else}
+							{rightPanelAgents.length} active agents ranked by runs
+						{/if}
+					</div>
+				</div>
+			</div>
+
+			<!-- Table container -->
+			<div class="flex-1 overflow-y-auto">
+				{#if rightPanelAgents.length === 0}
+					<div class="flex flex-col items-center justify-center h-full gap-3">
+						<Search size={36} style="color: var(--text-faint);" />
+						<p style="font-size: 13px; color: var(--text-secondary); font-weight: 500;">No matching agents</p>
+						<p style="font-size: 11px; color: var(--text-faint);">Try adjusting filters or search</p>
+					</div>
+				{:else}
+					<!-- Column headers -->
+					<div
+						class="grid sticky top-0 border-b"
+						style="background: var(--bg-base); border-color: var(--border); grid-template-columns: 32px 1fr 120px 100px 72px 80px; padding: 10px 12px 8px;"
+					>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; text-align: center;">#</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase;">Agent</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase;">Category</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; padding: 0 8px;">Runs</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; text-align: right;">Count</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; text-align: right;">Cost</div>
+					</div>
+
+					<!-- Agent rows -->
+					{#each rightPanelAgents as agent, i (agent.subagent_type)}
+						{@const displayName = getSubagentTypeDisplayName(agent.subagent_type)}
+						{@const barWidth = Math.round((agent.total_runs / globalMax) * 100)}
+						{@const badge = getCategoryBadge(agent)}
+						{@const colors = getAgentColors(agent)}
+						{@const useColor = selectedFilter === 'plugin' && agent.category === 'plugin'}
 						<a
-							href="/agents/{encodeURIComponent(def.name)}"
-							class="
-								group block
-								bg-[var(--bg-base)]
-								border border-[var(--border)]
-								rounded-xl
-								p-6
-								shadow-sm hover:shadow-xl hover:-translate-y-1
-								transition-all duration-300
-								relative overflow-hidden
-								focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2
-							"
-							style="border-left: 4px solid {colorVars.color}; opacity: 0.75;"
-							data-list-item
+							href="/agents/{encodeURIComponent(agent.subagent_type)}"
+							class="grid border-b transition-colors hover:bg-[var(--bg-subtle)] no-underline"
+							style="grid-template-columns: 32px 1fr 120px 100px 72px 80px; padding: 8px 12px; border-color: var(--border-subtle); align-items: center;"
 						>
-							<div class="flex items-start justify-between mb-5">
-								<div
-									class="p-3 rounded-xl transition-all duration-300 group-hover:scale-110"
-									style="background-color: {colorVars.subtle}; color: {colorVars.color};"
-								>
-									<Bot size={22} strokeWidth={2.5} />
+							<div style="font-size: 11px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace; text-align: center;">{i + 1}</div>
+							<div class="min-w-0 pr-3">
+								<span class="truncate block" style="font-size: 13px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;" title={displayName}>{displayName}</span>
+							</div>
+							<div class="min-w-0">
+								{#if useColor && agent.plugin_source}
+									<span class="truncate block rounded" style="font-size: 10px; font-weight: 700; font-family: 'JetBrains Mono', monospace; padding: 2px 7px; color: var(--bg-base); background: {colors.color}; display: inline-block; max-width: 100%;" title={agent.plugin_source}>{agent.plugin_source}</span>
+								{:else}
+									<span class="truncate block" style="font-size: 11px; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace;" title={badge}>{badge}</span>
+								{/if}
+							</div>
+							<div style="padding: 0 8px;">
+								<div style="background: var(--bg-muted); height: 4px; border-radius: 2px; overflow: hidden;">
+									<div style="height: 100%; border-radius: 2px; width: {barWidth}%; background: {useColor ? colors.color : 'var(--accent)'}; opacity: 0.7;"></div>
 								</div>
-								<span
-									class="px-2.5 py-1 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-[var(--bg-subtle)] text-[var(--text-muted)]"
-								>
-									Custom
-								</span>
 							</div>
-
-							<h3
-								class="text-lg font-bold text-[var(--text-primary)] mb-4 truncate pr-4 tracking-tight group-hover:text-[var(--accent)] transition-colors"
-							>
-								{def.name}
-							</h3>
-
-							<div
-								class="flex items-center justify-between text-xs text-[var(--text-muted)] pt-4 border-t border-[var(--border-subtle)]"
-							>
-								<span class="flex items-center gap-1.5">
-									<Play size={12} />
-									<span>0 runs</span>
-								</span>
-								<span class="flex items-center gap-1.5">
-									<Clock size={12} />
-									<span>Never used</span>
-								</span>
-							</div>
+							<div style="font-size: 13px; font-weight: 700; font-family: 'JetBrains Mono', monospace; text-align: right; color: {useColor ? colors.color : 'var(--text-primary)'};">{agent.total_runs}</div>
+							<div style="font-size: 11px; font-weight: 500; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace; text-align: right;">${agent.total_cost_usd < 0.01 ? agent.total_cost_usd.toFixed(4) : agent.total_cost_usd.toFixed(2)}</div>
 						</a>
 					{/each}
-				</div>
-			</CollapsibleGroup>
+				{/if}
+			</div>
+		</div>
+
+	</div>
+
+	{:else}
+
+	<!-- Analytics view -->
+	<div style="padding: 18px 24px 64px; display: flex; flex-direction: column; gap: 14px;">
+
+		<!-- Insight banner -->
+		{#if insightText}
+			<div class="flex items-center gap-3 rounded-lg" style="padding: 10px 16px; background: linear-gradient(135deg, var(--accent-muted), color-mix(in oklch, var(--accent-muted), var(--bg-subtle) 50%)); border: 1px solid var(--accent-subtle);">
+				<Sparkles size={14} style="color: var(--accent); flex-shrink: 0;" />
+				<span style="font-size: 12px; color: var(--text-primary); line-height: 1.5;">
+					<strong>{insightText.bold}</strong>{insightText.rest}
+				</span>
+			</div>
 		{/if}
 
+		<!-- Stacked area chart -->
+		<StackedAreaChart
+			trendData={trendData}
+			loading={trendLoading}
+			range={trendRange}
+			onRangeChange={(r) => { trendRangeUserOverride = true; trendRange = r; }}
+			getGroupFor={getGroupFor}
+			label="Agent Runs Over Time"
+		/>
+
+		<!-- Bottom 2-col row -->
+		<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 14px; align-items: start;">
+
+			<!-- Project Reach panel -->
+			<div class="rounded-lg" style="padding: 16px 18px; background: var(--bg-base); border: 1px solid var(--border);">
+				<div style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace; margin-bottom: 2px;">Project Reach</div>
+				<div style="font-size: 11px; color: var(--text-faint); margin-bottom: 14px;">which agents span the most projects</div>
+
+				{#if projectReachAgents.length === 0}
+					<div style="color: var(--text-faint); font-size: 12px; padding: 12px 0;">No data</div>
+				{:else}
+					<!-- Column headers -->
+					<div style="display: grid; grid-template-columns: 1fr 80px 44px; gap: 8px; padding: 0 4px; margin-bottom: 6px;">
+						<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase;">Agent</div>
+						<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase; text-align: center;">projects</div>
+						<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase; text-align: right;">count</div>
+					</div>
+					<div style="border-top: 1px solid var(--border-subtle); padding-top: 4px;">
+						{#each projectReachAgents as agent}
+							{@const colors = getAgentColors(agent)}
+							{@const reach = agent.projects_used_in.length}
+							{@const barPct = projectReachMax > 0 ? Math.round((reach / projectReachMax) * 100) : 0}
+							{@const displayName = getSubagentTypeDisplayName(agent.subagent_type)}
+							<a
+								href="/agents/{encodeURIComponent(agent.subagent_type)}"
+								class="no-underline"
+								style="display: grid; grid-template-columns: 1fr 80px 44px; gap: 8px; align-items: center; padding: 5px 4px; border-radius: 4px; cursor: pointer;"
+								onmouseenter={(e) => (e.currentTarget as HTMLElement).style.background = 'var(--bg-subtle)'}
+								onmouseleave={(e) => (e.currentTarget as HTMLElement).style.background = 'transparent'}
+							>
+								<div class="flex items-center gap-1.5 min-w-0">
+									<div style="width: 5px; height: 5px; border-radius: 50%; background: {colors.color}; flex-shrink: 0;"></div>
+									<span class="truncate" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;" title={displayName}>{displayName}</span>
+								</div>
+								<div style="background: var(--bg-muted); height: 5px; border-radius: 3px; overflow: hidden;">
+									<div style="height: 100%; border-radius: 3px; width: {barPct}%; background: var(--accent);"></div>
+								</div>
+								<div style="font-size: 10px; font-weight: 700; color: {reach >= 3 ? 'var(--accent)' : 'var(--text-faint)'}; text-align: right; font-family: 'JetBrains Mono', monospace;">{reach}</div>
+							</a>
+						{/each}
+					</div>
+					<div style="margin-top: 10px; border-top: 1px solid var(--border-subtle); padding-top: 8px; font-size: 10px; color: var(--text-faint); line-height: 1.5;">
+						Project count shows how many unique projects triggered each agent — high reach means it's woven into your workflow
+					</div>
+				{/if}
+			</div>
+
+			<!-- Real Cost panel -->
+			{#if true}
+				{@const top5 = rightPanelAgents.slice(0, 5)}
+				{@const top5Cost = top5.reduce((s, a) => s + a.total_cost_usd, 0)}
+				{@const costMax = top5.length > 0 ? top5[0].total_cost_usd : 1}
+				{@const otherAgents = rightPanelAgents.slice(5)}
+				{@const otherCost = otherAgents.reduce((s, a) => s + a.total_cost_usd, 0)}
+			<div class="rounded-lg" style="padding: 16px 18px; background: var(--bg-base); border: 1px solid var(--border);">
+				<div style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace; margin-bottom: 2px;">Real Cost</div>
+				<div style="font-size: 11px; color: var(--text-faint); margin-bottom: 12px;">across {analyticsTotalRuns} runs this period</div>
+
+				<!-- Hero total -->
+				<div class="flex items-baseline gap-2" style="margin-bottom: 4px;">
+					<span style="font-size: 32px; font-weight: 700; color: var(--text-primary); font-family: 'JetBrains Mono', monospace; letter-spacing: -1.5px;">${analyticsTotalCost < 0.01 ? analyticsTotalCost.toFixed(4) : analyticsTotalCost.toFixed(2)}</span>
+					<span style="font-size: 12px; color: var(--text-faint);">total</span>
+				</div>
+				<div style="font-size: 11px; color: var(--text-secondary); margin-bottom: 14px; font-family: 'JetBrains Mono', monospace;">
+					${analyticsTotalRuns > 0 ? (analyticsTotalCost / analyticsTotalRuns).toFixed(4) : '0.0000'} per run avg
+				</div>
+
+				<!-- Column headers -->
+				<div style="display: grid; grid-template-columns: 1fr 1fr 68px; gap: 10px; padding: 0 4px; margin-bottom: 6px;">
+					<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase;">Agent</div>
+					<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase;">Cost share</div>
+					<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase; text-align: right;">Cost</div>
+				</div>
+
+				{#each top5 as agent}
+					{@const barPct = costMax > 0 ? Math.round((agent.total_cost_usd / costMax) * 100) : 0}
+					{@const displayName = getSubagentTypeDisplayName(agent.subagent_type)}
+					<a
+						href="/agents/{encodeURIComponent(agent.subagent_type)}"
+						class="no-underline"
+						style="display: grid; grid-template-columns: 1fr 1fr 68px; gap: 10px; align-items: center; padding: 7px 4px; border-radius: 5px; cursor: pointer;"
+						onmouseenter={(e) => (e.currentTarget as HTMLElement).style.background = 'color-mix(in oklch, var(--nav-orange) 6%, transparent)'}
+						onmouseleave={(e) => (e.currentTarget as HTMLElement).style.background = 'transparent'}
+					>
+						<div class="truncate" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;" title={displayName}>{displayName}</div>
+						<div style="background: color-mix(in oklch, var(--nav-orange) 15%, transparent); height: 7px; border-radius: 4px; overflow: hidden;">
+							<div style="background: var(--nav-orange); width: {barPct}%; height: 7px;"></div>
+						</div>
+						<div style="font-size: 12px; font-weight: 700; color: var(--text-primary); text-align: right; font-family: 'JetBrains Mono', monospace;">${agent.total_cost_usd < 0.01 ? agent.total_cost_usd.toFixed(4) : agent.total_cost_usd.toFixed(2)}</div>
+					</a>
+				{/each}
+
+				{#if otherAgents.length > 0}
+					{@const otherBarPct = costMax > 0 ? Math.round((otherCost / costMax) * 100) : 0}
+					<div style="display: grid; grid-template-columns: 1fr 1fr 68px; gap: 10px; align-items: center; padding: 7px 4px; border-top: 1px dashed var(--border-subtle); margin-top: 2px;">
+						<div style="font-size: 11px; color: var(--text-faint); font-style: italic;">{otherAgents.length} other agents</div>
+						<div style="background: var(--bg-muted); height: 7px; border-radius: 4px; overflow: hidden;">
+							<div style="background: var(--text-faint); width: {Math.min(otherBarPct, 100)}%; height: 7px; opacity: 0.5;"></div>
+						</div>
+						<div style="font-size: 12px; font-weight: 600; color: var(--text-faint); text-align: right; font-family: 'JetBrains Mono', monospace;">${otherCost < 0.01 ? otherCost.toFixed(4) : otherCost.toFixed(2)}</div>
+					</div>
+				{/if}
+
+				<div style="margin-top: 12px; border-top: 1px solid var(--border-subtle); padding-top: 8px; font-size: 10px; color: var(--text-faint); line-height: 1.6;">
+					Actual cost from Claude API usage data
+				</div>
+			</div>
+			{/if}
+
+		</div>
+
+	</div>
+
 	{/if}
-	{/if}
+
 </div>
+
+{/if}

--- a/frontend/src/routes/agents/+page.svelte
+++ b/frontend/src/routes/agents/+page.svelte
@@ -298,7 +298,7 @@
 >
 
 	<!-- ── Page Header ──────────────────────────────────────────────────────── -->
-	<div class="flex-shrink-0" style="padding: 0 24px; background: var(--bg-base);">
+	<div class="flex-shrink-0" style="padding: 32px 24px 0; background: var(--bg-base);">
 		<PageHeader
 			title="Agents"
 			iconName="agents"

--- a/frontend/src/routes/analytics/+page.server.ts
+++ b/frontend/src/routes/analytics/+page.server.ts
@@ -16,12 +16,21 @@ export const load: PageServerLoad = async ({ fetch, url }) => {
 
 	const apiUrl = params.toString() ? `${API_BASE}/analytics?${params}` : `${API_BASE}/analytics`;
 
-	const result = await safeFetch<Record<string, unknown>>(fetch, apiUrl);
+	const [result, projectsResult] = await Promise.all([
+		safeFetch<Record<string, unknown>>(fetch, apiUrl),
+		safeFetch<Array<{ path: string; encoded_name: string; session_count: number; display_name?: string }>>(fetch, `${API_BASE}/projects`)
+	]);
 
 	if (!result.ok) {
 		console.error('Failed to fetch analytics:', result.message);
-		return { analytics: null, error: result.message };
+		return { analytics: null, topProjects: [], error: result.message };
 	}
 
-	return { analytics: result.data, error: null };
+	const topProjects = projectsResult.ok
+		? [...(projectsResult.data ?? [])]
+				.sort((a, b) => (b.session_count ?? 0) - (a.session_count ?? 0))
+				.slice(0, 5)
+		: [];
+
+	return { analytics: result.data, topProjects, error: null };
 };

--- a/frontend/src/routes/analytics/+page.svelte
+++ b/frontend/src/routes/analytics/+page.svelte
@@ -1,24 +1,10 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import { browser } from '$app/environment';
-	import { Activity, Zap, Database, Cpu, FolderOpen, Clock, BarChart3 } from 'lucide-svelte';
 	import { goto } from '$app/navigation';
 	import { page, navigating } from '$app/stores';
-	import SkeletonBox from '$lib/components/skeleton/SkeletonBox.svelte';
-	import SkeletonText from '$lib/components/skeleton/SkeletonText.svelte';
-	import SkeletonStatsCard from '$lib/components/skeleton/SkeletonStatsCard.svelte';
-	import { getChartColorPalette } from '$lib/components/charts/chartConfig';
 	import TimeFilterDropdown from '$lib/components/TimeFilterDropdown.svelte';
-	import PageHeader from '$lib/components/layout/PageHeader.svelte';
-	import StatsGrid from '$lib/components/StatsGrid.svelte';
-	import CollapsibleGroup from '$lib/components/ui/CollapsibleGroup.svelte';
-	import type { AnalyticsFilterPeriod, StatItem } from '$lib/api-types';
-	import {
-		analyticsFilterOptions,
-		getTimestampRangeForFilter,
-		isHourBasedFilter,
-		getAnalyticsFilterLabel
-	} from '$lib/utils';
+	import type { AnalyticsFilterPeriod } from '$lib/api-types';
+	import { analyticsFilterOptions, getTimestampRangeForFilter } from '$lib/utils';
 
 	// Read filter directly from URL
 	let selectedFilter = $derived.by((): AnalyticsFilterPeriod => {
@@ -33,7 +19,6 @@
 		const url = new URL($page.url);
 		const range = getTimestampRangeForFilter(filter);
 
-		// Always include timezone offset for accurate local date grouping
 		if (browser) {
 			url.searchParams.set('tz_offset', new Date().getTimezoneOffset().toString());
 		}
@@ -83,7 +68,6 @@
 
 	let { data } = $props();
 
-	// Default analytics object to prevent SSR errors when data is undefined
 	const defaultAnalytics: Analytics = {
 		total_sessions: 0,
 		total_tokens: 0,
@@ -108,11 +92,9 @@
 		}
 	};
 
-	// Merge actual data with defaults to ensure all properties exist
 	let analytics = $derived.by(() => {
 		const rawAnalytics = data.analytics as unknown as Analytics | undefined;
 		if (!rawAnalytics) return defaultAnalytics;
-
 		return {
 			...defaultAnalytics,
 			...rawAnalytics,
@@ -123,616 +105,708 @@
 		};
 	});
 
-	// --- Helpers ---
-	const formatK = (n: number) => {
-		if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
-		if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
-		return n.toString();
-	};
+	let topProjects = $derived(data.topProjects ?? []);
 
-	const formatCurrency = (n: number) =>
-		new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n);
-
-	// --- Date Processing ---
-	let sortedDates = $derived(Object.keys(analytics.sessions_by_date).sort());
-
-	// Stats - context-aware based on filter
-	let last30Days = $derived(sortedDates.slice(-30));
-
-	// For hour-based filters, show sessions per hour; for day-based, show per day
-	let avgDisplay = $derived.by(() => {
-		const numDays = sortedDates.length;
-		const totalSessions = analytics.total_sessions;
-
-		if (numDays === 0 || totalSessions === 0) {
-			return { value: '0', unit: '/day' };
-		}
-
-		// For single-day (hour-based) filters, calculate per-hour rate
-		if (isHourBasedFilter(selectedFilter)) {
-			const hours = parseInt(selectedFilter) || 6;
-			const perHour = (totalSessions / hours).toFixed(1);
-			return { value: perHour, unit: '/hour' };
-		}
-
-		// For multi-day filters, show per-day average
-		const perDay = (totalSessions / numDays).toFixed(1);
-		return { value: perDay, unit: '/day' };
-	});
-
-	// Legacy movingAvg for backward compatibility
-	let movingAvg = $derived(
-		last30Days.length > 0
-			? (
-					last30Days.reduce((sum, d) => sum + (analytics.sessions_by_date[d] || 0), 0) /
-					last30Days.length
-				).toFixed(1)
-			: '0'
-	);
-
-	let tokensPerSession = $derived(
-		analytics.total_sessions > 0
-			? Math.round(analytics.total_tokens / analytics.total_sessions)
-			: 0
-	);
-
-	// Sparkline
-	let sparklineData = $derived(
-		sortedDates.slice(-14).map((d) => analytics.sessions_by_date[d] || 0)
-	);
-	let sparkMax = $derived(Math.max(...sparklineData, 1));
-
-	// --- Model Distribution ---
-	// Use models_categorized if it has data, otherwise fall back to models_used
-	let modelsData = $derived(() => {
-		const categorized = analytics.models_categorized;
-		const used = analytics.models_used;
-		// Check for non-empty objects (empty {} is truthy but has no keys)
-		if (categorized && Object.keys(categorized).length > 0) return categorized;
-		if (used && Object.keys(used).length > 0) return used;
-		return {};
-	});
-
-	let modelDist = $derived(
-		Object.entries(modelsData())
-			.filter(([_, count]) => count > 0)
-			.sort((a, b) => b[1] - a[1])
-			.map(([name, count]) => {
-				const total = Object.values(modelsData()).reduce((a, b) => a + b, 0);
-				return { name, count, perc: total > 0 ? (count / total) * 100 : 0 };
-			})
-			.filter((m) => m.perc >= 2)
-	); // Hide <2%
-
-	const getModelColor = (name: string) => {
-		const lower = name.toLowerCase();
-		if (lower.includes('opus')) return 'var(--model-opus)';
-		if (lower.includes('sonnet')) return 'var(--model-sonnet)';
-		if (lower.includes('haiku')) return 'var(--model-haiku)';
-		return '#14b8a6'; // Teal for 'Other' models
-	};
-
-	// --- Cache ---
-	let cacheHitPercent = $derived((analytics.cache_hit_rate * 100).toFixed(1));
-
-	// --- Cost ---
-	let costPerSession = $derived(
-		analytics.total_sessions ? analytics.estimated_cost_usd / analytics.total_sessions : 0
-	);
-
-	// Format peak hours array (e.g., [9, 10, 11]) to readable range "9am-12pm"
-	const formatPeakHours = (hours: number[]) => {
-		if (!hours || hours.length === 0) return '—';
-		const sorted = [...hours].sort((a, b) => a - b);
-		const start = sorted[0];
-		const end = sorted[sorted.length - 1] + 1; // +1 because it's the *end* of the hour
-		const formatHour = (h: number) => {
-			const hour12 = h % 12 || 12;
-			const ampm = h < 12 ? 'am' : 'pm';
-			return `${hour12}${ampm}`;
-		};
-		return `${formatHour(start)}–${formatHour(end % 24)}`;
-	};
-
-	// Calculate absolute hours from percentage based on total duration
-	const formatHoursFromPct = (pct: number) => {
-		const totalHours = analytics.total_duration_seconds / 3600;
-		const hours = (pct / 100) * totalHours;
-		return hours >= 1 ? `${hours.toFixed(0)}h` : `${(hours * 60).toFixed(0)}m`;
-	};
-
-	// Format date string (YYYY-MM-DD) without timezone shift
-	// Using T12:00:00 to avoid day boundary issues in any timezone
-	const formatDateLabel = (dateStr: string): string => {
-		const d = new Date(dateStr + 'T12:00:00');
-		return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-	};
-
-	// --- Hero Stats ---
-	let stats = $derived<StatItem[]>([
-		{
-			title: 'Total Sessions',
-			value: analytics.total_sessions.toLocaleString(),
-			icon: Activity,
-			color: 'purple'
-		},
-		{
-			title: 'Total Cost',
-			value: formatCurrency(analytics.estimated_cost_usd),
-			footnote: 'Pay-as-you-go API rate — not your subscription cost',
-			icon: Zap,
-			color: 'green'
-		},
-		{
-			title: 'Cache Hit Rate',
-			value: `${cacheHitPercent}%`,
-			icon: Database,
-			color: 'blue'
-		}
-	]);
-
-	let isPageLoading = $derived(!!$navigating && $navigating.to?.route.id === '/analytics');
-
-	// --- Collapsible Group State ---
-	const groupKeys = ['velocity', 'efficiency', 'rhythm'] as const;
-	let expandedGroups = $state<Set<string>>(new Set(groupKeys));
-
-	function toggleGroup(key: string) {
-		if (expandedGroups.has(key)) {
-			expandedGroups.delete(key);
-		} else {
-			expandedGroups.add(key);
-		}
-		expandedGroups = new Set(expandedGroups);
+	// --- Formatters ---
+	function formatTokens(n: number): { value: string; unit: string } {
+		if (n >= 1e12) return { value: (n / 1e12).toFixed(1), unit: 'T' };
+		if (n >= 1e9) return { value: (n / 1e9).toFixed(1), unit: 'B' };
+		if (n >= 1e6) return { value: (n / 1e6).toFixed(1), unit: 'M' };
+		if (n >= 1e3) return { value: (n / 1e3).toFixed(1), unit: 'K' };
+		return { value: n.toString(), unit: '' };
 	}
 
-	// Chart
-	// svelte-ignore non_reactive_update: chartCanvas is only bound once during mount
-	let chartCanvas: HTMLCanvasElement;
-	let chartInstance = $state<any>(null);
+	function formatTokensShort(n: number): string {
+		if (n >= 1e12) return (n / 1e12).toFixed(1) + 'T';
+		if (n >= 1e9) return (n / 1e9).toFixed(1) + 'B';
+		if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
+		if (n >= 1e3) return (n / 1e3).toFixed(1) + 'K';
+		return n.toString();
+	}
 
-	$effect(() => {
-		if (chartInstance && sortedDates) {
-			const newCounts = sortedDates.map((date) => analytics.sessions_by_date[date]);
-			const newLabels = sortedDates.map((date) => formatDateLabel(date));
+	function formatDate(dateStr: string): string {
+		if (!dateStr) return '';
+		const d = new Date(dateStr + 'T12:00:00');
+		return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+	}
 
-			chartInstance.data.labels = newLabels;
-			chartInstance.data.datasets[0].data = newCounts;
-			chartInstance.update();
+function projectDisplayName(p: { path: string; display_name?: string }): string {
+		if (p.display_name) return p.display_name;
+		return p.path.split('/').filter(Boolean).pop() ?? p.path;
+	}
+
+	// --- Derived values ---
+	let sortedDates = $derived(Object.keys(analytics.sessions_by_date).sort());
+
+	let numDays = $derived(Math.max(sortedDates.length, 1));
+
+	let totalHours = $derived(analytics.total_duration_seconds / 3600);
+
+	let avgHoursPerDay = $derived(totalHours / numDays);
+
+	let daysEquivalent = $derived(Math.round(totalHours / 24));
+
+	let avgSessionsPerDay = $derived((analytics.total_sessions / numDays).toFixed(1));
+
+	let subscriptionMultiple = $derived(Math.round(analytics.estimated_cost_usd / 20));
+
+	let avgTokensPerSession = $derived(
+		analytics.total_sessions > 0 ? analytics.total_tokens / analytics.total_sessions : 0
+	);
+
+	let cacheHitPercent = $derived((analytics.cache_hit_rate * 100).toFixed(1));
+
+	let firstSessionDate = $derived(sortedDates[0] ? formatDate(sortedDates[0]) : '');
+
+	let peakDay = $derived.by(() => {
+		let maxCount = 0;
+		let maxDate = '';
+		for (const [date, count] of Object.entries(analytics.sessions_by_date)) {
+			if ((count as number) > maxCount) {
+				maxCount = count as number;
+				maxDate = date;
+			}
 		}
+		return { date: maxDate, count: maxCount };
 	});
 
-	onMount(async () => {
-		const Chart = (await import('chart.js/auto')).default;
-		const colors = getChartColorPalette();
-		const style = getComputedStyle(document.documentElement);
-		const textMuted = style.getPropertyValue('--text-muted').trim() || '#94a3b8';
-		const textPrimary = style.getPropertyValue('--text-primary').trim() || '#0f172a';
-		const border = style.getPropertyValue('--border').trim() || 'rgba(0,0,0,0.08)';
+	// Token breakdown: raw input, cache tokens (all non-input/output), output
+	let cacheTokens = $derived(
+		Math.max(0, analytics.total_tokens - analytics.total_input_tokens - analytics.total_output_tokens)
+	);
+	let totalInputSide = $derived(analytics.total_tokens - analytics.total_output_tokens);
 
-		const sessionCounts = sortedDates.map((date) => analytics.sessions_by_date[date]);
+	// Heatmap
+	type HeatmapDay = { date: string; count: number };
+	type HeatmapMonthLabel = { label: string; weekIndex: number };
+	type TooltipState = { x: number; y: number; day: HeatmapDay } | null;
 
-		chartInstance = new Chart(chartCanvas, {
-			type: 'bar',
-			data: {
-				labels: sortedDates.map((date) => formatDateLabel(date)),
-				datasets: [
-					{
-						label: 'Sessions',
-						data: sessionCounts,
-						backgroundColor: textMuted,
-						hoverBackgroundColor: colors[0],
-						borderRadius: 3,
-						barThickness: 'flex',
-						maxBarThickness: 14
-					}
-				]
-			},
-			options: {
-				responsive: true,
-				maintainAspectRatio: false,
-				plugins: {
-					legend: { display: false },
-					tooltip: {
-						backgroundColor: textPrimary,
-						padding: 10,
-						cornerRadius: 6,
-						displayColors: false
-					}
-				},
-				scales: {
-					y: { beginAtZero: true, grid: { color: border }, ticks: { display: false } },
-					x: {
-						grid: { display: false },
-						ticks: {
-							font: { size: 10 },
-							color: textMuted,
-							maxTicksLimit: 8,
-							maxRotation: 0
-						}
+	// Cell size constants (px)
+	const CELL = 15;
+	const GAP = 3;
+	const STRIDE = CELL + GAP; // 18px per column
+
+	function heatmapColor(count: number): string {
+		if (count === 0) return 'var(--bg-muted)';
+		if (count <= 2) return '#ddd6fe';
+		if (count <= 6) return '#c084fc';
+		if (count <= 12) return '#a855f7';
+		return 'var(--accent)';
+	}
+
+	const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+	const VISIBLE_DOW = new Set([1, 3, 5]); // Mon, Wed, Fri
+
+	// Year filter state
+	let availableYears = $derived.by(() => {
+		const byDate = analytics.sessions_by_date;
+		const years = new Set<number>();
+		for (const date of Object.keys(byDate)) {
+			years.add(parseInt(date.slice(0, 4)));
+		}
+		return [...years].sort((a, b) => b - a); // descending
+	});
+
+	let selectedYear = $state<number>(0); // 0 = unset, will default to latest year
+
+	let activeYear = $derived(selectedYear || availableYears[0] || new Date().getFullYear());
+
+	let heatmapData = $derived.by(() => {
+		const byDate = analytics.sessions_by_date;
+		const year = activeYear;
+
+		if (!year) return { days: [] as HeatmapDay[], totalWeeks: 0, monthLabels: [] as HeatmapMonthLabel[] };
+
+		// Start: Sunday on or before Jan 1 of the selected year
+		const jan1 = new Date(`${year}-01-01T12:00:00`);
+		const startDate = new Date(jan1);
+		startDate.setDate(jan1.getDate() - jan1.getDay());
+
+		// End: Saturday on or after Dec 31 of the selected year (always full year)
+		const dec31 = new Date(`${year}-12-31T12:00:00`);
+		const endDate = new Date(dec31);
+		endDate.setDate(dec31.getDate() + (6 - dec31.getDay()));
+
+		// Build flat list of all calendar days (Sun→Sat columns)
+		const days: HeatmapDay[] = [];
+		const cur = new Date(startDate);
+		while (cur <= endDate) {
+			const yr = cur.getFullYear();
+			const mo = String(cur.getMonth() + 1).padStart(2, '0');
+			const dy = String(cur.getDate()).padStart(2, '0');
+			const dateStr = `${yr}-${mo}-${dy}`;
+			days.push({ date: dateStr, count: byDate[dateStr] || 0 });
+			cur.setDate(cur.getDate() + 1);
+		}
+
+		const totalWeeks = Math.ceil(days.length / 7);
+
+		// Month labels: first week column where each month appears
+		const monthLabels: HeatmapMonthLabel[] = [];
+		const seenMonths = new Set<string>();
+
+		for (let wi = 0; wi < totalWeeks; wi++) {
+			for (let dow = 0; dow < 7; dow++) {
+				const idx = wi * 7 + dow;
+				if (idx >= days.length) break;
+				const monthKey = days[idx].date.slice(0, 7);
+				if (!seenMonths.has(monthKey)) {
+					seenMonths.add(monthKey);
+					const d = new Date(days[idx].date + 'T12:00:00');
+					// Only show month labels for days within the selected year
+					if (d.getFullYear() === year) {
+						monthLabels.push({
+							label: d.toLocaleDateString('en-US', { month: 'short' }),
+							weekIndex: wi
+						});
 					}
 				}
 			}
-		});
+		}
+
+		return { days, totalWeeks, monthLabels };
 	});
+
+	// Tooltip
+	let tooltip = $state<TooltipState>(null);
+
+	function showTooltip(e: MouseEvent, day: HeatmapDay) {
+		const cell = e.currentTarget as HTMLElement;
+		const container = cell.closest('.heatmap-grid-area') as HTMLElement;
+		if (!container) return;
+		const cellRect = cell.getBoundingClientRect();
+		const containerRect = container.getBoundingClientRect();
+		tooltip = {
+			x: cellRect.left - containerRect.left + CELL / 2,
+			y: cellRect.top - containerRect.top,
+			day
+		};
+	}
+
+	function hideTooltip() {
+		tooltip = null;
+	}
+
+	function tooltipLabel(day: HeatmapDay): string {
+		const d = new Date(day.date + 'T12:00:00');
+		const dateLabel = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+		if (day.count === 0) return `No sessions — ${dateLabel}`;
+		const estTokens = avgTokensPerSession > 0 ? Math.round(avgTokensPerSession * day.count) : 0;
+		const tokStr = estTokens > 0 ? `  ·  ~${formatTokensShort(estTokens)} tokens` : '';
+		return `${day.count} session${day.count !== 1 ? 's' : ''}${tokStr} — ${dateLabel}`;
+	}
+
+	// Model mix
+	let modelColors: Record<string, string> = {
+		Opus: '#a855f7',
+		Sonnet: '#c084fc',
+		Haiku: '#e9d5ff',
+		Other: '#7c3aed'
+	};
+
+	let modelMix = $derived.by(() => {
+		const cats = analytics.models_categorized;
+		const total = Object.values(cats).reduce((a, b) => a + b, 0);
+		if (total === 0) return [];
+		return Object.entries(cats)
+			.map(([model, count]) => ({
+				model,
+				count,
+				percentage: Math.round((count / total) * 100)
+			}))
+			.sort((a, b) => b.count - a.count);
+	});
+
+	let isPageLoading = $derived(!!$navigating && $navigating.to?.route.id === '/analytics');
+
+	// Tokens formatted
+	let tokensFormatted = $derived(formatTokens(analytics.total_tokens));
+	let hoursDisplay = $derived(
+		totalHours >= 1000
+			? { value: (totalHours / 1000).toFixed(1), unit: 'Kh' }
+			: { value: Math.round(totalHours).toLocaleString(), unit: 'h' }
+	);
+
+	// Pre-computed for template
+	let totalTokensFormatted = $derived(formatTokens(analytics.total_tokens));
+
+	let tokenCachePct = $derived(
+		analytics.total_tokens > 0 ? (cacheTokens / analytics.total_tokens) * 100 : 0
+	);
+	let tokenInputPct = $derived(
+		analytics.total_tokens > 0 ? (analytics.total_input_tokens / analytics.total_tokens) * 100 : 0
+	);
+	let tokenOutputPct = $derived(
+		analytics.total_tokens > 0
+			? (analytics.total_output_tokens / analytics.total_tokens) * 100
+			: 0
+	);
+
+	let topProjectsMaxSessions = $derived(topProjects[0]?.session_count ?? 1);
 </script>
 
-<div class="max-w-[1100px] mx-auto space-y-6">
+<div class="max-w-[1100px] mx-auto" style="-webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale;">
 	{#if isPageLoading}
-		<div class="space-y-6" role="status" aria-busy="true" aria-label="Loading...">
-			<!-- Page Header skeleton -->
-			<div class="flex items-start justify-between">
-				<div>
-					<div class="flex items-center gap-2 mb-2">
-						<SkeletonText width="70px" size="xs" />
-						<span class="text-[var(--text-muted)]">/</span>
-						<SkeletonText width="80px" size="xs" />
-					</div>
-					<div class="flex items-center gap-4">
-						<SkeletonBox width="48px" height="48px" rounded="lg" />
-						<div>
-							<SkeletonText width="120px" size="xl" class="mb-2" />
-							<SkeletonText width="260px" size="sm" />
-						</div>
-					</div>
-				</div>
-				<SkeletonBox width="140px" height="36px" rounded="md" />
-			</div>
-
-			<!-- Hero Stats skeleton (3 cols) -->
-			<div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-				{#each Array(3) as _}
-					<SkeletonStatsCard />
+		<div class="space-y-5 animate-pulse">
+			<div class="h-24 rounded-lg bg-[var(--bg-muted)]"></div>
+			<div class="grid grid-cols-4 gap-[10px]">
+				{#each Array(4) as _}
+					<div class="h-28 rounded-lg bg-[var(--bg-muted)]"></div>
 				{/each}
 			</div>
-
-			<!-- Velocity group skeleton -->
-			<div class="border border-[var(--border)] rounded-[var(--radius-lg)] overflow-hidden bg-[var(--bg-base)]">
-				<div class="flex items-center gap-3 px-4 py-4">
-					<SkeletonBox width="32px" height="32px" rounded="md" />
-					<SkeletonText width="100px" size="sm" />
-					<div class="flex-1"></div>
-					<SkeletonText width="80px" size="xs" />
-				</div>
-				<div class="border-t border-[var(--border)] p-4">
-					<SkeletonBox height="160px" rounded="lg" />
-				</div>
-			</div>
-
-			<!-- Efficiency group skeleton -->
-			<div class="border border-[var(--border)] rounded-[var(--radius-lg)] overflow-hidden bg-[var(--bg-base)]">
-				<div class="flex items-center gap-3 px-4 py-4">
-					<SkeletonBox width="32px" height="32px" rounded="md" />
-					<SkeletonText width="100px" size="sm" />
-					<div class="flex-1"></div>
-					<SkeletonText width="80px" size="xs" />
-				</div>
-				<div class="border-t border-[var(--border)] p-4">
-					<div class="grid grid-cols-1 lg:grid-cols-4 gap-4">
-						{#each Array(4) as _}
-							<SkeletonBox height="120px" rounded="lg" />
-						{/each}
-					</div>
-				</div>
-			</div>
-
-			<!-- Rhythm group skeleton -->
-			<div class="border border-[var(--border)] rounded-[var(--radius-lg)] overflow-hidden bg-[var(--bg-base)]">
-				<div class="flex items-center gap-3 px-4 py-4">
-					<SkeletonBox width="32px" height="32px" rounded="md" />
-					<SkeletonText width="80px" size="sm" />
-					<div class="flex-1"></div>
-					<SkeletonText width="80px" size="xs" />
-				</div>
-				<div class="border-t border-[var(--border)] p-4 space-y-3">
-					{#each Array(4) as _}
-						<div class="flex items-center gap-3">
-							<SkeletonText width="80px" size="xs" />
-							<SkeletonBox height="6px" rounded="full" class="flex-1" />
-							<SkeletonText width="80px" size="xs" />
-						</div>
-					{/each}
-				</div>
+			<div class="h-48 rounded-lg bg-[var(--bg-muted)]"></div>
+			<div class="h-40 rounded-lg bg-[var(--bg-muted)]"></div>
+			<div class="grid grid-cols-2 gap-[10px]">
+				<div class="h-48 rounded-lg bg-[var(--bg-muted)]"></div>
+				<div class="h-48 rounded-lg bg-[var(--bg-muted)]"></div>
 			</div>
 		</div>
 	{:else}
-	<!-- Page Header with Breadcrumb -->
-	<PageHeader
-		title="Analytics"
-		iconName="analytics"
-		iconColor="--nav-green"
-		breadcrumbs={[{ label: 'Dashboard', href: '/' }, { label: 'Analytics' }]}
-		subtitle="Your coding patterns and AI collaboration"
-	>
-		{#snippet headerRight()}
-			<TimeFilterDropdown {selectedFilter} onFilterChange={handleFilterChange} />
-		{/snippet}
-	</PageHeader>
-
-	<!-- Hero Stats Row -->
-	<StatsGrid {stats} columns={3} />
-
-	<!-- Group 1: Velocity — Activity bar chart -->
-	<CollapsibleGroup
-		title="Velocity"
-		open={expandedGroups.has('velocity')}
-		onOpenChange={() => toggleGroup('velocity')}
-	>
-		{#snippet icon()}
-			<div class="p-1.5 bg-[var(--bg-subtle)] rounded-md">
-				<Activity size={14} class="text-[var(--text-muted)]" />
-			</div>
-		{/snippet}
-		{#snippet metadata()}
-			<div class="flex items-center gap-3 text-xs text-[var(--text-muted)]">
-				<span
-					>Avg: <span class="font-mono text-[var(--text-secondary)]"
-						>{avgDisplay.value}</span
-					>{avgDisplay.unit}</span
-				>
-				<span class="hidden sm:flex items-end gap-0.5 h-6">
-					{#each sparklineData as val, i}
-						<span
-							class="inline-block w-1 rounded-sm"
-							style="height: {Math.max(
-								4,
-								(val / sparkMax) * 100
-							)}%; background-color: var(--accent); opacity: {0.3 +
-								(i / sparklineData.length) * 0.7};"
-						></span>
-					{/each}
-				</span>
-			</div>
-		{/snippet}
-
-		<div class="space-y-4">
-			<!-- Token context row -->
-			<div class="flex gap-3 text-xs text-[var(--text-muted)]">
-				<span
-					><span class="font-mono text-[var(--text-secondary)]"
-						>{formatK(analytics.total_tokens)}</span
-					> tokens</span
-				>
-				<span>•</span>
-				<span
-					><span class="font-mono text-[var(--text-secondary)]"
-						>{(analytics.total_duration_seconds / 3600).toFixed(0)}</span
-					>h</span
-				>
-				<span>•</span>
-				<span
-					><span class="font-mono text-[var(--text-secondary)]"
-						>{formatK(tokensPerSession)}</span
-					> tokens/sess</span
-				>
+		<!-- Page Header -->
+		<div class="mb-3">
+			<!-- Breadcrumb -->
+			<div class="flex items-center gap-[5px] mb-[9px]">
+				<span style="font-size: 13px; color: var(--text-primary);">Dashboard</span>
+				<span style="font-size: 13px; color: var(--text-faint);">/</span>
+				<span style="font-size: 13px; font-weight: 600; color: var(--text-primary);">Analytics</span>
 			</div>
 
-			<!-- Bar chart -->
-			<div class="h-40 w-full">
-				<canvas bind:this={chartCanvas}></canvas>
-			</div>
-		</div>
-	</CollapsibleGroup>
-
-	<!-- Group 2: Efficiency — Cache, Projects, Compute DNA -->
-	<CollapsibleGroup
-		title="Efficiency"
-		open={expandedGroups.has('efficiency')}
-		onOpenChange={() => toggleGroup('efficiency')}
-	>
-		{#snippet icon()}
-			<div class="p-1.5 bg-[var(--bg-subtle)] rounded-md">
-				<Zap size={14} class="text-[var(--text-muted)]" />
-			</div>
-		{/snippet}
-		{#snippet metadata()}
-			<span class="text-xs text-[var(--text-muted)] tabular-nums">
-				{getAnalyticsFilterLabel(selectedFilter)}
-			</span>
-		{/snippet}
-
-		<div class="grid grid-cols-1 lg:grid-cols-4 gap-4">
-			<!-- Cache Card -->
-			<div class="p-5 bg-[var(--bg-subtle)] border border-[var(--border)] rounded-lg">
-				<div class="flex items-center justify-between mb-3">
-					<div class="flex items-center gap-2">
-						<Database size={14} class="text-[var(--text-muted)]" />
-						<span
-							class="text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]"
-							>Cache</span
-						>
-					</div>
-					{#if analytics.cache_hit_rate > 0.85}
-						<span
-							class="px-1.5 py-0.5 bg-[var(--success-subtle)] rounded text-[10px] font-medium text-[var(--success)]"
-						>
-							Excellent
-						</span>
+			<div class="flex items-end justify-between">
+				<div>
+					<h1 style="font-size: 25px; font-weight: 700; color: var(--text-primary); letter-spacing: -0.02em; line-height: 1.2;">
+						Your head has been in the Claude
+					</h1>
+					{#if firstSessionDate}
+						<p class="font-mono mt-1" style="font-size: 13px; color: var(--text-faint);">
+							since {firstSessionDate}
+						</p>
 					{/if}
 				</div>
-				<div class="flex items-baseline gap-1.5 mb-3">
-					<span
-						class="text-xl font-semibold font-mono tabular-nums text-[var(--text-primary)]"
-						>{cacheHitPercent}%</span
-					>
-					<span class="text-xs text-[var(--text-muted)]">hit rate</span>
-				</div>
-				<div
-					class="relative w-full h-1.5 bg-[var(--bg-muted)] rounded-full overflow-hidden"
-				>
-					<div
-						class="absolute top-0 left-0 h-full rounded-full bg-[var(--accent)]"
-						style="width: {analytics.cache_hit_rate * 100}%"
-					></div>
-				</div>
+				<TimeFilterDropdown {selectedFilter} onFilterChange={handleFilterChange} />
 			</div>
+		</div>
 
-			<!-- Projects Card -->
-			<div class="p-5 bg-[var(--bg-subtle)] border border-[var(--border)] rounded-lg">
-				<div class="flex items-center justify-between mb-3">
-					<div class="flex items-center gap-2">
-						<FolderOpen size={14} class="text-[var(--text-muted)]" />
-						<span
-							class="text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]"
-							>Projects</span
-						>
+		<div class="flex flex-col" style="gap: 20px;">
+			<!-- Section 1: How much? -->
+			<div>
+				<div class="font-mono mb-2" style="font-size: 13px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em;">
+					How much?
+				</div>
+				<div class="grid gap-[10px]" style="grid-template-columns: repeat(4, 1fr);">
+					<!-- Time card -->
+					<div class="rounded-lg" style="background: var(--bg-base); border: 1px solid var(--border); padding: 16px 18px;">
+						<div style="font-size: 12px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.07em; margin-bottom: 9px;">
+							Time
+						</div>
+						<div class="font-mono flex items-baseline gap-1" style="line-height: 1;">
+							<span style="font-size: 30px; font-weight: 700; color: var(--text-primary); letter-spacing: -1px;">
+								{hoursDisplay.value}
+							</span>
+							<span style="font-size: 15px; font-weight: 500; color: var(--text-muted); letter-spacing: 0;">
+								{hoursDisplay.unit}
+							</span>
+						</div>
+						<div style="font-size: 13px; color: var(--text-muted); margin-top: 7px;">
+							avg {avgHoursPerDay.toFixed(1)} hours / day
+						</div>
+						<div style="font-size: 12px; color: var(--text-faint); margin-top: 2px;">
+							{daysEquivalent} days equivalent
+						</div>
+					</div>
+
+					<!-- Tokens card -->
+					<div class="rounded-lg" style="background: var(--bg-base); border: 1px solid var(--border); padding: 16px 18px;">
+						<div style="font-size: 12px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.07em; margin-bottom: 9px;">
+							Tokens
+						</div>
+						<div class="font-mono flex items-baseline gap-1" style="line-height: 1;">
+							<span style="font-size: 30px; font-weight: 700; color: var(--text-primary); letter-spacing: -1px;">
+								{tokensFormatted.value}
+							</span>
+							<span style="font-size: 15px; font-weight: 500; color: var(--text-muted); letter-spacing: 0;">
+								{tokensFormatted.unit}
+							</span>
+						</div>
+						<div style="font-size: 13px; color: var(--text-muted); margin-top: 7px;">
+							{cacheHitPercent}% served from cache
+						</div>
+						<div style="font-size: 12px; color: var(--text-faint); margin-top: 2px;">
+							~{formatTokensShort(Math.round(avgTokensPerSession))} per session avg
+						</div>
+					</div>
+
+					<!-- Sessions card -->
+					<div class="rounded-lg" style="background: var(--bg-base); border: 1px solid var(--border); padding: 16px 18px;">
+						<div style="font-size: 12px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.07em; margin-bottom: 9px;">
+							Sessions
+						</div>
+						<div class="font-mono flex items-baseline gap-1" style="line-height: 1;">
+							<span style="font-size: 30px; font-weight: 700; color: var(--text-primary); letter-spacing: -1px;">
+								{analytics.total_sessions.toLocaleString()}
+							</span>
+						</div>
+						<div style="font-size: 13px; color: var(--text-muted); margin-top: 7px;">
+							avg {avgSessionsPerDay} / day
+						</div>
+						<div style="font-size: 12px; color: var(--text-faint); margin-top: 2px;">
+							across {analytics.projects_active} projects
+						</div>
+					</div>
+
+					<!-- Value card (accent) -->
+					<div class="rounded-lg" style="background: var(--accent-muted); border: 1.5px solid var(--accent-subtle); padding: 16px 18px;">
+						<div style="font-size: 12px; color: var(--accent); font-weight: 600; text-transform: uppercase; letter-spacing: 0.07em; margin-bottom: 9px;">
+							Value
+						</div>
+						<div class="font-mono flex items-baseline gap-1" style="line-height: 1;">
+							<span style="font-size: 30px; font-weight: 700; color: var(--text-primary); letter-spacing: -1px;">
+								${Math.round(analytics.estimated_cost_usd).toLocaleString()}
+							</span>
+						</div>
+						<div style="font-size: 13px; color: var(--text-muted); margin-top: 7px;">
+							API-equivalent usage
+						</div>
+						{#if subscriptionMultiple > 1}
+							<div
+								class="inline-flex items-center mt-[7px]"
+								style="background: linear-gradient(135deg, #a855f7, var(--accent)); border-radius: 20px; padding: 2px 9px;"
+							>
+								<span style="font-size: 12px; font-weight: 700; color: #ffffff; letter-spacing: 0.02em;">
+									{subscriptionMultiple}× your $20/mo
+								</span>
+							</div>
+						{/if}
 					</div>
 				</div>
-				<div class="flex items-baseline gap-1.5">
-					<span
-						class="text-xl font-semibold font-mono tabular-nums text-[var(--text-primary)]"
-					>
-						{analytics.projects_active}
-					</span>
-					<span class="text-xs text-[var(--text-muted)]">worked on</span>
-				</div>
 			</div>
 
-			<!-- Compute DNA Card -->
-			<div
-				class="lg:col-span-2 p-5 bg-[var(--bg-subtle)] border border-[var(--border)] rounded-lg"
-			>
-				<div class="flex items-center gap-2 mb-3">
-					<Cpu size={14} class="text-[var(--text-muted)]" />
-					<span
-						class="text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]"
-						>Compute DNA</span
-					>
+			<!-- Section 2: How often? (Activity Heatmap) -->
+			<div>
+				<div class="font-mono mb-2" style="font-size: 13px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em;">
+					How often?
 				</div>
-				<div class="w-full flex h-5 rounded overflow-hidden mb-3">
-					{#each modelDist as model}
-						<div
-							class="h-full"
-							style="width: {model.perc}%; background-color: {getModelColor(
-								model.name
-							)};"
-							title="{model.name}: {model.perc.toFixed(0)}%"
-						></div>
-					{/each}
-				</div>
-				<div class="flex flex-wrap gap-3 text-xs">
-					{#each modelDist as model}
-						<div class="flex items-center gap-1">
-							<div
-								class="w-2 h-2 rounded-full"
-								style="background-color: {getModelColor(model.name)}"
-							></div>
-							<span class="text-[var(--text-secondary)]">{model.name}</span>
-							<span class="text-[var(--text-muted)] font-mono"
-								>{model.perc.toFixed(0)}%</span
-							>
+				<div class="rounded-lg" style="background: var(--bg-base); border: 1px solid var(--border); padding: 16px 18px;">
+					<!-- Card header -->
+					<div class="flex items-baseline justify-between" style="margin-bottom: 16px;">
+						<span style="font-size: 13px; font-weight: 600; color: var(--text-primary);">Activity</span>
+						<span class="font-mono" style="font-size: 13px; color: var(--text-faint);">
+							avg {avgSessionsPerDay} sessions / day{peakDay.count > 0 ? ` · peak ${peakDay.count} on ${formatDate(peakDay.date)}` : ''}
+						</span>
+					</div>
+
+					{#if heatmapData.days.length > 0}
+						<!-- Main heatmap row: day labels + grid + year filter -->
+						<div class="flex items-start" style="gap: 8px;">
+							<!-- Day labels column -->
+							<div class="flex flex-col shrink-0" style="gap: {GAP}px; padding-top: 22px;">
+								{#each DAY_NAMES as name, i}
+									<div
+										class="font-mono"
+										style="height: {CELL}px; line-height: {CELL}px; font-size: 12px; color: {VISIBLE_DOW.has(i) ? 'var(--text-faint)' : 'transparent'};"
+									>{name}</div>
+								{/each}
+							</div>
+
+							<!-- Grid area with tooltip container -->
+							<div class="heatmap-grid-area" style="flex: 1; min-width: 0; overflow-x: auto; position: relative;">
+								<!-- Month labels row -->
+								<div style="position: relative; height: 18px; margin-bottom: 4px; min-width: {heatmapData.totalWeeks * STRIDE}px;">
+									{#each heatmapData.monthLabels as ml}
+										<span
+											class="font-mono"
+											style="position: absolute; top: 0; left: {ml.weekIndex * STRIDE}px; font-size: 12px; color: var(--accent); white-space: nowrap;"
+										>{ml.label}</span>
+									{/each}
+								</div>
+
+								<!-- Cell grid — fixed square cells, scrolls if needed -->
+								<div
+									style="display: grid; grid-template-rows: repeat(7, {CELL}px); grid-auto-flow: column; grid-auto-columns: {CELL}px; gap: {GAP}px; width: fit-content;"
+								>
+									{#each heatmapData.days as day}
+										<div
+											role="img"
+											aria-label={tooltipLabel(day)}
+											style="width: {CELL}px; height: {CELL}px; border-radius: 2px; background: {heatmapColor(day.count)}; cursor: {day.count > 0 ? 'pointer' : 'default'};"
+											onmouseenter={(e) => showTooltip(e, day)}
+											onmouseleave={hideTooltip}
+										></div>
+									{/each}
+								</div>
+
+								<!-- Tooltip -->
+								{#if tooltip}
+									<div
+										class="font-mono"
+										style="
+											position: absolute;
+											left: {tooltip.x}px;
+											top: {tooltip.y - 36}px;
+											transform: translateX(-50%);
+											background: var(--text-primary);
+											color: var(--bg-base);
+											font-size: 12px;
+											padding: 4px 8px;
+											border-radius: 5px;
+											white-space: nowrap;
+											pointer-events: none;
+											z-index: 10;
+											box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+										"
+									>
+										{tooltipLabel(tooltip.day)}
+									</div>
+								{/if}
+							</div>
+
+							<!-- Year filter buttons (right side) -->
+							{#if availableYears.length > 1}
+								<div class="flex flex-col shrink-0" style="gap: 4px; padding-top: 22px;">
+									{#each availableYears as yr}
+										<button
+											type="button"
+											onclick={() => (selectedYear = yr)}
+											class="font-mono"
+											style="
+												font-size: 15px;
+												font-weight: {activeYear === yr ? '700' : '400'};
+												color: {activeYear === yr ? 'var(--accent)' : 'var(--text-faint)'};
+												background: {activeYear === yr ? 'var(--accent-muted)' : 'transparent'};
+												border: 1px solid {activeYear === yr ? 'var(--accent-subtle)' : 'transparent'};
+												border-radius: 4px;
+												padding: 2px 7px;
+												cursor: pointer;
+												transition: color 0.15s, background 0.15s;
+											"
+										>{yr}</button>
+									{/each}
+								</div>
+							{/if}
 						</div>
-					{/each}
+
+						<!-- Legend -->
+						<div class="flex items-center justify-end" style="gap: 5px; margin-top: 12px;">
+							<span style="font-size: 12px; color: var(--text-faint); margin-right: 2px;">Less</span>
+							<div style="width: {CELL}px; height: {CELL}px; border-radius: 2px; background: var(--bg-muted); border: 1px solid var(--border);"></div>
+							<div style="width: {CELL}px; height: {CELL}px; border-radius: 2px; background: #ddd6fe;"></div>
+							<div style="width: {CELL}px; height: {CELL}px; border-radius: 2px; background: #c084fc;"></div>
+							<div style="width: {CELL}px; height: {CELL}px; border-radius: 2px; background: #a855f7;"></div>
+							<div style="width: {CELL}px; height: {CELL}px; border-radius: 2px; background: var(--accent);"></div>
+							<span style="font-size: 12px; color: var(--text-faint); margin-left: 2px;">More</span>
+						</div>
+					{:else}
+						<div style="color: var(--text-faint); font-size: 12px; padding: 24px 0; text-align: center;">
+							No session data available
+						</div>
+					{/if}
+				</div>
+			</div>
+
+			<!-- Section 3: How intensely? -->
+			<div>
+				<div class="font-mono mb-2" style="font-size: 13px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em;">
+					How intensely?
+				</div>
+				<div class="grid gap-[10px]" style="grid-template-columns: 1fr 2fr;">
+					<!-- Left: Token Consumption Summary -->
+					<div class="rounded-lg" style="background: var(--bg-base); border: 1px solid var(--border); padding: 16px 18px;">
+						<div style="font-size: 12px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.07em; margin-bottom: 9px;">
+							Token consumption
+						</div>
+						<div class="font-mono flex items-baseline gap-1 mb-3" style="line-height: 1;">
+							<span style="font-size: 30px; font-weight: 700; color: var(--text-primary); letter-spacing: -1px;">
+								{totalTokensFormatted.value}
+							</span>
+							<span style="font-size: 15px; font-weight: 500; color: var(--text-muted);">{totalTokensFormatted.unit}</span>
+						</div>
+
+						<div class="flex flex-col" style="gap: 8px;">
+							<div class="flex items-center justify-between">
+								<span style="font-size: 13px; color: var(--text-muted);">Input tokens</span>
+								<span class="font-mono" style="font-size: 13px; color: var(--text-primary); font-weight: 500;">
+									{formatTokensShort(totalInputSide)}
+								</span>
+							</div>
+							<div class="flex items-center justify-between">
+								<span style="font-size: 13px; color: var(--text-muted);">Output tokens</span>
+								<span class="font-mono" style="font-size: 13px; color: var(--text-primary); font-weight: 500;">
+									{formatTokensShort(analytics.total_output_tokens)}
+								</span>
+							</div>
+							<div style="height: 1px; background: var(--border); margin: 2px 0;"></div>
+							<div class="flex items-center justify-between">
+								<span style="font-size: 13px; color: var(--text-secondary); font-weight: 500;">Cache efficiency</span>
+								<span class="font-mono" style="font-size: 13px; color: var(--accent); font-weight: 700;">
+									{cacheHitPercent}%
+								</span>
+							</div>
+						</div>
+					</div>
+
+					<!-- Right: Where Tokens Go -->
+					<div class="rounded-lg" style="background: var(--bg-base); border: 1px solid var(--border); padding: 16px 18px;">
+						<div style="font-size: 12px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.07em; margin-bottom: 9px;">
+							Where tokens go
+						</div>
+
+						{#if analytics.total_tokens > 0}
+							<!-- Stacked bar -->
+							<div class="flex mb-4" style="height: 16px; border-radius: 5px; overflow: hidden; gap: 1px;">
+								{#if tokenCachePct > 0}
+									<div
+										style="flex: {tokenCachePct}; background: var(--accent-subtle); border: 1px solid var(--accent-subtle);"
+										title="Cached: {tokenCachePct.toFixed(1)}%"
+									></div>
+								{/if}
+								{#if tokenInputPct > 0}
+									<div
+										style="flex: {tokenInputPct}; background: #a855f7;"
+										title="Uncached input: {tokenInputPct.toFixed(1)}%"
+									></div>
+								{/if}
+								{#if tokenOutputPct > 0}
+									<div
+										style="flex: {tokenOutputPct}; background: var(--accent);"
+										title="Output: {tokenOutputPct.toFixed(1)}%"
+									></div>
+								{/if}
+							</div>
+
+							<!-- Legend -->
+							<div class="flex flex-col" style="gap: 9px;">
+								<div class="flex items-center gap-2">
+									<div style="width: 10px; height: 10px; border-radius: 2px; background: var(--accent-subtle); border: 1px solid var(--accent-subtle); flex-shrink: 0;"></div>
+									<span style="font-size: 13px; color: var(--text-muted); flex: 1;">Cached input</span>
+									<span class="font-mono" style="font-size: 13px; color: var(--text-primary); font-weight: 500;">
+										{formatTokensShort(cacheTokens)}
+									</span>
+									<span class="font-mono" style="font-size: 13px; color: var(--text-faint); width: 40px; text-align: right;">
+										{tokenCachePct.toFixed(1)}%
+									</span>
+								</div>
+								<div class="flex items-center gap-2">
+									<div style="width: 10px; height: 10px; border-radius: 2px; background: #a855f7; flex-shrink: 0;"></div>
+									<span style="font-size: 13px; color: var(--text-muted); flex: 1;">Uncached input</span>
+									<span class="font-mono" style="font-size: 13px; color: var(--text-primary); font-weight: 500;">
+										{formatTokensShort(analytics.total_input_tokens)}
+									</span>
+									<span class="font-mono" style="font-size: 13px; color: var(--text-faint); width: 40px; text-align: right;">
+										{tokenInputPct.toFixed(1)}%
+									</span>
+								</div>
+								<div class="flex items-center gap-2">
+									<div style="width: 10px; height: 10px; border-radius: 2px; background: var(--accent); flex-shrink: 0;"></div>
+									<span style="font-size: 13px; color: var(--text-muted); flex: 1;">Output</span>
+									<span class="font-mono" style="font-size: 13px; color: var(--text-primary); font-weight: 500;">
+										{formatTokensShort(analytics.total_output_tokens)}
+									</span>
+									<span class="font-mono" style="font-size: 13px; color: var(--text-faint); width: 40px; text-align: right;">
+										{tokenOutputPct.toFixed(1)}%
+									</span>
+								</div>
+							</div>
+
+							<div style="height: 1px; background: var(--border); margin: 12px 0 8px;"></div>
+							<p style="font-size: 13px; color: var(--text-faint); line-height: 1.5; font-style: italic;">
+								{cacheHitPercent}% of tokens were cached — you build on context, not prompts from scratch.
+							</p>
+						{:else}
+							<div style="color: var(--text-faint); font-size: 12px;">No token data available</div>
+						{/if}
+					</div>
+				</div>
+			</div>
+
+			<!-- Section 4: Bottom Row — Projects + Models -->
+			<div class="grid gap-[10px]" style="grid-template-columns: 1fr 1fr; padding-bottom: 48px;">
+				<!-- Left: What are you building? -->
+				<div class="rounded-lg" style="background: var(--bg-base); border: 1px solid var(--border); padding: 16px 18px;">
+					<div class="font-mono mb-3" style="font-size: 13px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em;">
+						What are you building?
+					</div>
+					<div class="flex items-baseline mb-4" style="gap: 6px;">
+						<span class="font-mono" style="font-size: 28px; font-weight: 700; color: var(--text-primary); letter-spacing: -0.5px;">
+							{analytics.projects_active}
+						</span>
+						<span style="font-size: 12px; color: var(--text-muted);">
+							projects · {analytics.total_sessions.toLocaleString()} sessions total
+						</span>
+					</div>
+
+					{#if topProjects.length > 0}
+						<div class="flex flex-col" style="gap: 10px;">
+							{#each topProjects as project, i}
+								<div>
+									<div class="flex items-center justify-between mb-1" style="gap: 8px;">
+										<div class="flex items-center gap-2" style="min-width: 0;">
+											<span class="font-mono" style="font-size: 12px; font-weight: 600; color: var(--accent); width: 16px; text-align: right; flex-shrink: 0;">
+												{i + 1}
+											</span>
+											<span style="font-size: 13px; color: var(--text-primary); font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+												{projectDisplayName(project)}
+											</span>
+										</div>
+										<span class="font-mono" style="font-size: 12px; color: var(--text-muted); flex-shrink: 0;">
+											{project.session_count}
+										</span>
+									</div>
+									<div style="height: 6px; background: var(--bg-muted); border-radius: 3px; overflow: hidden; margin-left: 24px;">
+										<div style="background: linear-gradient(90deg, var(--accent), #a855f7); border-radius: 3px; height: 100%; width: {(project.session_count / topProjectsMaxSessions) * 100}%;"></div>
+									</div>
+								</div>
+							{/each}
+						</div>
+						{#if analytics.projects_active > 5}
+							<div style="font-size: 12px; color: var(--text-faint); margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--border);">
+								Showing top 5 of {analytics.projects_active} projects
+							</div>
+						{/if}
+					{:else}
+						<div style="color: var(--text-faint); font-size: 12px;">No project data available</div>
+					{/if}
+				</div>
+
+				<!-- Right: Which models? -->
+				<div class="rounded-lg" style="background: var(--bg-base); border: 1px solid var(--border); padding: 16px 18px;">
+					<div class="font-mono mb-3" style="font-size: 13px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em;">
+						Which models?
+					</div>
+
+					{#if modelMix.length > 0}
+						<!-- Stacked model bar -->
+						<div class="flex mb-4" style="height: 14px; border-radius: 5px; overflow: hidden; gap: 1px;">
+							{#each modelMix as m}
+								<div
+									style="flex: {m.percentage}; background: {modelColors[m.model] ?? 'var(--accent)'};"
+									title="{m.model}: {m.percentage}%"
+								></div>
+							{/each}
+						</div>
+
+						<!-- Model legend -->
+						<div class="flex flex-col" style="gap: 9px;">
+							{#each modelMix as m}
+								<div class="flex items-center gap-2">
+									<div
+										style="width: 10px; height: 10px; border-radius: 2px; background: {modelColors[m.model] ?? 'var(--accent)'}; flex-shrink: 0;"
+									></div>
+									<span class="font-mono" style="font-size: 13px; color: var(--text-secondary); flex: 1;">
+										{m.model.toLowerCase()}
+									</span>
+									<span class="font-mono" style="font-size: 13px; color: var(--text-muted); text-align: right; white-space: nowrap;">
+										{m.count} sessions
+									</span>
+									<span class="font-mono" style="font-size: 13px; color: var(--text-faint); width: 38px; text-align: right;">
+										{m.percentage}%
+									</span>
+								</div>
+							{/each}
+						</div>
+					{:else}
+						<div style="color: var(--text-faint); font-size: 12px;">No model data available</div>
+					{/if}
 				</div>
 			</div>
 		</div>
-	</CollapsibleGroup>
-
-	<!-- Group 3: Rhythm — Time Distribution -->
-	<CollapsibleGroup
-		title="Rhythm"
-		open={expandedGroups.has('rhythm')}
-		onOpenChange={() => toggleGroup('rhythm')}
-	>
-		{#snippet icon()}
-			<div class="p-1.5 bg-[var(--bg-subtle)] rounded-md">
-				<Clock size={14} class="text-[var(--text-muted)]" />
-			</div>
-		{/snippet}
-		{#snippet metadata()}
-			<div class="flex items-center gap-4 text-[11px] text-[var(--text-muted)]">
-				<span>
-					Peak: <span class="font-mono text-[var(--text-secondary)]"
-						>{formatPeakHours(analytics.peak_hours)}</span
-					>
-				</span>
-			</div>
-		{/snippet}
-
-		<div class="space-y-2.5">
-			<!-- Morning -->
-			<div class="flex items-center gap-3">
-				<span class="text-[11px] text-[var(--text-muted)] w-20 shrink-0">06:00–12:00</span>
-				<div
-					class="relative flex-1 h-1.5 bg-[var(--bg-muted)] rounded-full overflow-hidden"
-				>
-					<div
-						class="absolute top-0 left-0 h-full bg-[var(--accent)] rounded-full"
-						style="width: {analytics.time_distribution.morning_pct}%"
-					></div>
-				</div>
-				<span class="text-[11px] font-mono text-[var(--text-secondary)] w-20 text-right">
-					{formatHoursFromPct(analytics.time_distribution.morning_pct)} ({analytics.time_distribution.morning_pct.toFixed(
-						0
-					)}%)
-				</span>
-			</div>
-
-			<!-- Afternoon -->
-			<div class="flex items-center gap-3">
-				<span class="text-[11px] text-[var(--text-muted)] w-20 shrink-0">12:00–18:00</span>
-				<div
-					class="relative flex-1 h-1.5 bg-[var(--bg-muted)] rounded-full overflow-hidden"
-				>
-					<div
-						class="absolute top-0 left-0 h-full bg-[var(--accent)] rounded-full"
-						style="width: {analytics.time_distribution.afternoon_pct}%"
-					></div>
-				</div>
-				<span class="text-[11px] font-mono text-[var(--text-secondary)] w-20 text-right">
-					{formatHoursFromPct(analytics.time_distribution.afternoon_pct)} ({analytics.time_distribution.afternoon_pct.toFixed(
-						0
-					)}%)
-				</span>
-			</div>
-
-			<!-- Evening -->
-			<div class="flex items-center gap-3">
-				<span class="text-[11px] text-[var(--text-muted)] w-20 shrink-0">18:00–24:00</span>
-				<div
-					class="relative flex-1 h-1.5 bg-[var(--bg-muted)] rounded-full overflow-hidden"
-				>
-					<div
-						class="absolute top-0 left-0 h-full bg-[var(--accent)] rounded-full"
-						style="width: {analytics.time_distribution.evening_pct}%"
-					></div>
-				</div>
-				<span class="text-[11px] font-mono text-[var(--text-secondary)] w-20 text-right">
-					{formatHoursFromPct(analytics.time_distribution.evening_pct)} ({analytics.time_distribution.evening_pct.toFixed(
-						0
-					)}%)
-				</span>
-			</div>
-
-			<!-- Night -->
-			<div class="flex items-center gap-3">
-				<span class="text-[11px] text-[var(--text-muted)] w-20 shrink-0">00:00–06:00</span>
-				<div
-					class="relative flex-1 h-1.5 bg-[var(--bg-muted)] rounded-full overflow-hidden"
-				>
-					<div
-						class="absolute top-0 left-0 h-full bg-[var(--accent)] rounded-full"
-						style="width: {analytics.time_distribution.night_pct}%"
-					></div>
-				</div>
-				<span class="text-[11px] font-mono text-[var(--text-secondary)] w-20 text-right">
-					{formatHoursFromPct(analytics.time_distribution.night_pct)} ({analytics.time_distribution.night_pct.toFixed(
-						0
-					)}%)
-				</span>
-			</div>
-
-			<!-- Footer -->
-			<div
-				class="mt-3 pt-2 border-t border-[var(--border)] flex items-center gap-4 text-[11px] text-[var(--text-muted)]"
-			>
-				<span
-					>Total: <span class="font-mono text-[var(--text-secondary)]"
-						>{(analytics.total_duration_seconds / 3600).toFixed(0)}h</span
-					></span
-				>
-			</div>
-		</div>
-	</CollapsibleGroup>
 	{/if}
 </div>

--- a/frontend/src/routes/commands/+page.svelte
+++ b/frontend/src/routes/commands/+page.svelte
@@ -281,7 +281,7 @@
 >
 
 	<!-- ── Page Header ──────────────────────────────────────────────────────── -->
-	<div class="flex-shrink-0" style="padding: 0 24px; background: var(--bg-base);">
+	<div class="flex-shrink-0" style="padding: 32px 24px 0; background: var(--bg-base);">
 		<PageHeader
 			title="Commands"
 			iconName="commands"

--- a/frontend/src/routes/commands/+page.svelte
+++ b/frontend/src/routes/commands/+page.svelte
@@ -1,56 +1,42 @@
 <script lang="ts">
+	import {
+		Search,
+		Zap,
+		Sparkles,
+		Info,
+		TrendingUp,
+		LayoutGrid,
+		LayoutList,
+		ChevronRight
+	} from 'lucide-svelte';
 	import { tick, onMount } from 'svelte';
 	import { navigating } from '$app/stores';
 	import { browser } from '$app/environment';
 	import { replaceState, beforeNavigate } from '$app/navigation';
-	import {
-		Terminal,
-		Search,
-		Zap,
-		Play,
-		Sparkles,
-		FileText,
-		Puzzle,
-		ExternalLink,
-		ChevronsUpDown,
-		ChevronsDownUp
-	} from 'lucide-svelte';
-	import { listNavigation } from '$lib/actions/listNavigation';
 	import PageHeader from '$lib/components/layout/PageHeader.svelte';
-	import StatsGrid from '$lib/components/StatsGrid.svelte';
-	import SegmentedControl from '$lib/components/ui/SegmentedControl.svelte';
-	import CollapsibleGroup from '$lib/components/ui/CollapsibleGroup.svelte';
-	import CommandUsageCard from '$lib/components/commands/CommandUsageCard.svelte';
-	import CommandUsageTable from '$lib/components/commands/CommandUsageTable.svelte';
-	import UsageAnalytics from '$lib/components/charts/UsageAnalytics.svelte';
-	import SkeletonBox from '$lib/components/skeleton/SkeletonBox.svelte';
-	import SkeletonText from '$lib/components/skeleton/SkeletonText.svelte';
-	import { getCommandCategoryColorVars, getCommandCategoryLabel, getCommandChartHex, getPluginColorVars } from '$lib/utils';
-	import type { CommandUsage, CommandCategory, StatItem } from '$lib/api-types';
+	import KarmaIcon from '$lib/components/icons/Icon.svelte';
+	import StackedAreaChart from '$lib/components/charts/StackedAreaChart.svelte';
+	import { getCommandCategoryColorVars, getCommandCategoryLabel, getPluginColorVars } from '$lib/utils';
+	import { API_BASE } from '$lib/config';
+	import type { CommandUsage, UsageTrendResponse } from '$lib/api-types';
 
 	let { data } = $props();
 
-	// Loading state: navigating TO this page from elsewhere
-	let isPageLoading = $derived(!!$navigating && $navigating.to?.route.id === '/commands');
-
-	// Helper: read initial URL param safely (SSR-safe)
 	function initParam(key: string, fallback: string): string {
 		if (browser) return new URLSearchParams(window.location.search).get(key) ?? fallback;
 		return fallback;
 	}
 
-	// View state — initialized from URL
-	let activeView = $state<'groups' | 'table' | 'analytics'>(
-		initParam('view', 'groups') as 'groups' | 'table' | 'analytics'
+	let activeView = $state<'overview' | 'analytics'>(
+		(initParam('view', 'overview') as 'overview' | 'analytics')
 	);
-
-	// Filter state — initialized from URL
 	let searchQuery = $state(initParam('search', ''));
-	let selectedFilter = $state<'all' | 'builtin' | 'bundled' | 'plugin' | 'user'>(
-		initParam('filter', 'all') as 'all' | 'builtin' | 'bundled' | 'plugin' | 'user'
+	let selectedFilter = $state<'all' | 'builtin' | 'plugin' | 'user'>(
+		(initParam('filter', 'all') as 'all' | 'builtin' | 'plugin' | 'user')
 	);
+	let selectedGroup = $state<string | null>(null);
+	let commandsView = $state<'list' | 'grid'>('list');
 
-	// Sync view/filter/search to URL
 	$effect(() => {
 		if (!browser) return;
 		const v = activeView;
@@ -58,7 +44,7 @@
 		const s = searchQuery;
 		tick().then(() => {
 			const url = new URL(window.location.href);
-			if (v !== 'groups') url.searchParams.set('view', v);
+			if (v !== 'overview') url.searchParams.set('view', v);
 			else url.searchParams.delete('view');
 			if (f !== 'all') url.searchParams.set('filter', f);
 			else url.searchParams.delete('filter');
@@ -68,197 +54,195 @@
 		});
 	});
 
-	const filterOptions = [
-		{ label: 'All', value: 'all' },
-		{ label: 'Built-in', value: 'builtin' },
-		{ label: 'Bundled', value: 'bundled' },
-		{ label: 'Plugin', value: 'plugin' },
-		{ label: 'User', value: 'user' }
-	];
+	// ── Base data ──────────────────────────────────────────────────────────────
+	let allCommands = $derived<CommandUsage[]>(data.usage || []);
 
-	const viewTabs = [
-		{ label: 'By Category', value: 'groups' },
-		{ label: 'All Commands', value: 'table' },
-		{ label: 'Usage Analytics', value: 'analytics' }
-	];
-
-	// Compute stats for hero section
-	let stats = $derived.by<StatItem[]>(() => {
-		const usage = data.usage || [];
-		const totalCommands = usage.length;
-		const totalUses = usage.reduce((sum: number, cmd: CommandUsage) => sum + (cmd.count ?? 0), 0);
-		const builtinCount = usage.filter(
-			(c: CommandUsage) => c.category === 'builtin_command'
-		).length;
-		const pluginCount = usage.filter(
-			(c: CommandUsage) =>
-				c.category === 'plugin_command' || c.category === 'plugin_skill'
-		).length;
-		const userCount = usage.filter(
-			(c: CommandUsage) =>
-				c.category === 'user_command' || c.category === 'custom_skill'
-		).length;
-
-		return [
-			{
-				title: 'Total Commands',
-				value: totalCommands,
-				icon: Terminal,
-				color: 'blue'
-			},
-			{
-				title: 'Total Uses',
-				value: totalUses.toLocaleString(),
-				icon: Play,
-				color: 'purple'
-			},
-			{
-				title: 'Built-in',
-				value: builtinCount,
-				icon: Zap,
-				color: 'teal'
-			},
-			{
-				title: 'Plugin',
-				value: pluginCount,
-				icon: Puzzle,
-				color: 'green'
-			},
-			{
-				title: 'User',
-				value: userCount,
-				icon: FileText,
-				color: 'orange'
-			}
-		];
-	});
-
-	// Filter commands by search query and type
-	let filteredCommands = $derived.by(() => {
-		let commands = data.usage || [];
-
-		// Filter by type
-		if (selectedFilter === 'builtin') {
-			commands = commands.filter((c: CommandUsage) => c.category === 'builtin_command');
-		} else if (selectedFilter === 'bundled') {
-			commands = commands.filter((c: CommandUsage) => c.category === 'bundled_skill');
-		} else if (selectedFilter === 'plugin') {
-			commands = commands.filter(
-				(c: CommandUsage) =>
-					c.category === 'plugin_command' || c.category === 'plugin_skill'
-			);
-		} else if (selectedFilter === 'user') {
-			commands = commands.filter(
-				(c: CommandUsage) =>
-					c.category === 'user_command' || c.category === 'custom_skill'
-			);
-		}
-
-		// Filter by search query
-		if (searchQuery.trim()) {
-			const query = searchQuery.toLowerCase();
-			commands = commands.filter(
-				(c: CommandUsage) =>
-					c.name.toLowerCase().includes(query) ||
-					(c.description && c.description.toLowerCase().includes(query)) ||
-					(c.plugin && c.plugin.toLowerCase().includes(query))
-			);
-		}
-
-		return commands;
-	});
-
-	// Group commands by category for display, with dynamic plugin grouping
+	// ── Grouping ───────────────────────────────────────────────────────────────
 	interface CommandGroup {
 		key: string;
 		label: string;
-		icon: typeof Terminal;
 		commands: CommandUsage[];
 		pluginName: string | null;
+		category: string;
 	}
-
-	// Priority order for non-plugin categories
-	const categoryPriority: Record<string, number> = {
-		builtin_command: 0,
-		bundled_skill: 1,
-		// plugin groups go here (priority 2)
-		custom_skill: 3,
-		user_command: 4
-	};
-
-	const categoryIcons: Record<string, typeof Terminal> = {
-		builtin_command: Terminal,
-		bundled_skill: Sparkles,
-		custom_skill: Zap,
-		user_command: FileText
-	};
 
 	let groupedCommands = $derived.by<CommandGroup[]>(() => {
-		const commands = filteredCommands;
-		const groups: Map<string, CommandGroup> = new Map();
-
-		for (const cmd of commands) {
+		const groups = new Map<string, CommandGroup>();
+		for (const cmd of allCommands) {
 			const cat = cmd.category ?? 'user_command';
-			let groupKey: string;
-			let groupLabel: string;
-			let groupIcon: typeof Terminal;
-			let pluginName: string | null = null;
-
-			if ((cat === 'plugin_command' || cat === 'plugin_skill') && cmd.plugin) {
-				groupKey = `plugin:${cmd.plugin}`;
-				groupLabel = cmd.plugin;
-				groupIcon = Puzzle;
-				pluginName = cmd.plugin;
+			let key: string, label: string, pluginName: string | null = null, category: string;
+			if (cat === 'builtin_command') {
+				key = 'builtin_command'; label = 'Built-in Commands'; category = 'builtin_command';
+			} else if ((cat === 'plugin_command' || cat === 'plugin_skill') && cmd.plugin) {
+				key = `plugin:${cmd.plugin}`; label = cmd.plugin; pluginName = cmd.plugin; category = 'plugin_command';
+			} else if (cat === 'user_command') {
+				key = 'user_command'; label = 'User Commands'; category = 'user_command';
+			} else if (cat === 'custom_skill') {
+				key = 'custom_skill'; label = 'Custom'; category = 'custom_skill';
+			} else if (cat === 'bundled_skill') {
+				key = 'bundled_skill'; label = 'Bundled'; category = 'bundled_skill';
 			} else {
-				groupKey = cat;
-				groupLabel = getCommandCategoryLabel(cat);
-				groupIcon = categoryIcons[cat] ?? Terminal;
+				key = cat; label = getCommandCategoryLabel(cat); pluginName = null; category = cat;
 			}
-
-			if (!groups.has(groupKey)) {
-				groups.set(groupKey, {
-					key: groupKey,
-					label: groupLabel,
-					icon: groupIcon,
-					commands: [],
-					pluginName
-				});
-			}
-			groups.get(groupKey)!.commands.push(cmd);
+			if (!groups.has(key)) groups.set(key, { key, label, commands: [], pluginName, category });
+			groups.get(key)!.commands.push(cmd);
 		}
-
-		// Sort: fixed categories by priority, plugin groups alphabetically in between
-		return Array.from(groups.values()).sort((a, b) => {
-			const aPriority = categoryPriority[a.key] ?? 2;
-			const bPriority = categoryPriority[b.key] ?? 2;
-			if (aPriority !== bPriority) return aPriority - bPriority;
-			return a.label.localeCompare(b.label);
-		});
+		return Array.from(groups.values());
 	});
 
-	// Track which groups are expanded — initialized from URL param `expanded`
-	function initExpandedGroups(): Set<string> {
-		if (browser) {
-			const param = new URLSearchParams(window.location.search).get('expanded');
-			if (param) return new Set(param.split(',').filter(Boolean));
+	// ── Left panel: sorted by total uses desc ─────────────────────────────────
+	let leftPanelGroups = $derived.by(() => {
+		return [...groupedCommands]
+			.filter(g => {
+				if (selectedFilter === 'builtin') return g.category === 'builtin_command';
+				if (selectedFilter === 'plugin') return g.category === 'plugin_command';
+				if (selectedFilter === 'user') return g.category === 'user_command' || g.category === 'custom_skill';
+				return true;
+			})
+			.sort((a, b) => {
+				const aTotal = a.commands.reduce((sum, c) => sum + c.count, 0);
+				const bTotal = b.commands.reduce((sum, c) => sum + c.count, 0);
+				return bTotal - aTotal;
+			});
+	});
+
+	// ── Stats ──────────────────────────────────────────────────────────────────
+	let totalUses = $derived(allCommands.reduce((sum, c) => sum + c.count, 0));
+	let activeCommandsCount = $derived(allCommands.filter(c => c.count > 0).length);
+	let totalCommandsCount = $derived(allCommands.length);
+	let neverUsedCount = $derived(allCommands.filter(c => c.count === 0).length);
+	let globalMax = $derived(
+		allCommands.length > 0 ? Math.max(...allCommands.map(c => c.count), 1) : 1
+	);
+
+	// ── Right panel: active commands, filtered + sorted ───────────────────────
+	let rightPanelCommands = $derived.by(() => {
+		let commands = allCommands.filter(c => c.count > 0);
+
+		if (selectedGroup !== null) {
+			const grp = groupedCommands.find(g => g.key === selectedGroup);
+			if (grp) commands = commands.filter(c => grp.commands.some(gc => gc.name === c.name));
 		}
-		return new Set(['builtin_command']);
-	}
-	let expandedGroups = $state<Set<string>>(initExpandedGroups());
-	let previousExpandedGroups = $state<Set<string> | null>(null);
 
-	function syncExpandedToUrl() {
-		if (!browser) return;
-		tick().then(() => {
-			const url = new URL(window.location.href);
-			const keys = Array.from(expandedGroups);
-			if (keys.length > 0) url.searchParams.set('expanded', keys.join(','));
-			else url.searchParams.delete('expanded');
-			replaceState(url.toString(), {});
-		});
+		if (selectedFilter === 'builtin') commands = commands.filter(c => c.category === 'builtin_command');
+		else if (selectedFilter === 'plugin') commands = commands.filter(c => c.category === 'plugin_command' || c.category === 'plugin_skill');
+		else if (selectedFilter === 'user') commands = commands.filter(c => c.category === 'user_command' || c.category === 'custom_skill');
+
+		if (searchQuery.trim()) {
+			const q = searchQuery.toLowerCase();
+			commands = commands.filter(c =>
+				c.name.toLowerCase().includes(q) ||
+				(c.description && c.description.toLowerCase().includes(q)) ||
+				(c.plugin && c.plugin.toLowerCase().includes(q))
+			);
+		}
+
+		return commands.slice().sort((a, b) => b.count - a.count);
+	});
+
+	// ── Analytics derived ─────────────────────────────────────────────────────
+	let analyticsTotalUses = $derived(rightPanelCommands.reduce((sum, c) => sum + c.count, 0));
+	let trendRange = $state<'7d' | '30d' | '90d'>('90d');
+	let trendData = $state<UsageTrendResponse | null>(null);
+	let trendLoading = $state(false);
+	let trendRangeUserOverride = $state(false);
+
+	const periodMap: Record<'7d' | '30d' | '90d', string> = { '7d': 'week', '30d': 'month', '90d': 'quarter' };
+
+	$effect(() => {
+		if (!browser || activeView !== 'analytics') return;
+		trendLoading = true;
+		const url = new URL(`${API_BASE}/commands/usage/trend`);
+		url.searchParams.set('period', periodMap[trendRange]);
+		fetch(url)
+			.then(r => r.json())
+			.then(d => {
+				trendData = d;
+				if (!trendRangeUserOverride) {
+					const total = (d as UsageTrendResponse)?.total ?? 0;
+					if (total === 0 && trendRange === '90d') trendRange = '30d';
+					else if (total === 0 && trendRange === '30d') trendRange = '7d';
+				}
+			})
+			.catch(() => {})
+			.finally(() => { trendLoading = false; });
+	});
+
+	// ── Session reach ─────────────────────────────────────────────────────────
+	let sessionReachCommands = $derived(
+		rightPanelCommands.slice().sort((a, b) => (b.session_count ?? 0) - (a.session_count ?? 0)).slice(0, 8)
+	);
+	let sessionReachMax = $derived(sessionReachCommands.length > 0 ? (sessionReachCommands[0].session_count ?? 1) : 1);
+
+	// ── Insight banner ────────────────────────────────────────────────────────
+	let insightText = $derived.by(() => {
+		if (rightPanelCommands.length === 0) return null;
+		const top = rightPanelCommands[0];
+		const topSession = sessionReachCommands[0];
+		return {
+			active: rightPanelCommands.length,
+			topName: top.name,
+			topCount: top.count,
+			topBySessionName: topSession?.name ?? top.name,
+			topBySessionCount: topSession?.session_count ?? 0
+		};
+	});
+
+	// ── Color helpers ──────────────────────────────────────────────────────────
+	function getGroupColors(group: CommandGroup) {
+		if (group.pluginName) return getPluginColorVars(group.pluginName);
+		return getCommandCategoryColorVars(group.category);
 	}
 
-	// Scroll save/restore
+	function getCmdColors(cmd: CommandUsage) {
+		const cat = cmd.category ?? 'user_command';
+		if ((cat === 'plugin_command' || cat === 'plugin_skill') && cmd.plugin) return getPluginColorVars(cmd.plugin);
+		return getCommandCategoryColorVars(cat);
+	}
+
+	function getSourceBadgeLabel(cmd: CommandUsage): string {
+		const cat = cmd.category ?? 'user_command';
+		if (cmd.plugin) return cmd.plugin;
+		return getCommandCategoryLabel(cat);
+	}
+
+	// ── getGroupFor for StackedAreaChart ──────────────────────────────────────
+	function getGroupFor(name: string): { key: string; label: string; color: string } | null {
+		const cmd = allCommands.find(c => c.name === name);
+		if (!cmd) return null;
+		const cat = cmd.category ?? 'user_command';
+		if ((cat === 'plugin_command' || cat === 'plugin_skill') && cmd.plugin) {
+			const colors = getPluginColorVars(cmd.plugin);
+			return { key: `plugin:${cmd.plugin}`, label: cmd.plugin, color: colors.color };
+		}
+		const colors = getCommandCategoryColorVars(cat);
+		return { key: cat, label: getCommandCategoryLabel(cat), color: colors.color };
+	}
+
+	// ── Compact date helper ───────────────────────────────────────────────────
+	function shortDate(ts: string | null | undefined): string {
+		if (!ts) return '—';
+		const date = new Date(ts);
+		const diffMs = Date.now() - date.getTime();
+		const diffMins = Math.floor(diffMs / 60000);
+		const diffHours = Math.floor(diffMins / 60);
+		const diffDays = Math.floor(diffHours / 24);
+		if (diffMins < 1) return 'now';
+		if (diffMins < 60) return `${diffMins}m`;
+		if (diffHours < 24) return `${diffHours}h`;
+		if (diffDays < 7) return `${diffDays}d`;
+		return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+	}
+
+	let coverageOpen = $state(false);
+
+	function toggleGroup(group: CommandGroup) {
+		const key = group.key;
+		if (selectedGroup === key) selectedGroup = null;
+		else selectedGroup = key;
+	}
+
+	// ── Scroll save/restore ───────────────────────────────────────────────────
 	const SCROLL_KEY = 'commands_scroll';
 
 	beforeNavigate(({ to }) => {
@@ -274,345 +258,513 @@
 		const saved = sessionStorage.getItem(SCROLL_KEY);
 		if (saved !== null) {
 			sessionStorage.removeItem(SCROLL_KEY);
-			const y = Number(saved);
-			requestAnimationFrame(() => window.scrollTo({ top: y, behavior: 'instant' }));
+			requestAnimationFrame(() => window.scrollTo({ top: Number(saved), behavior: 'instant' }));
 		}
 	});
 
-	// Auto-expand groups when searching
-	$effect(() => {
-		const hasSearch = searchQuery.trim().length > 0;
-
-		if (hasSearch) {
-			if (previousExpandedGroups === null) {
-				previousExpandedGroups = new Set(expandedGroups);
-			}
-			if (groupedCommands.length > 0) {
-				expandedGroups = new Set(groupedCommands.map((g) => g.key));
-			}
-		} else {
-			if (previousExpandedGroups !== null) {
-				expandedGroups = previousExpandedGroups;
-				previousExpandedGroups = null;
-			}
-		}
-	});
-
-	function toggleGroup(key: string) {
-		if (expandedGroups.has(key)) {
-			expandedGroups.delete(key);
-		} else {
-			expandedGroups.add(key);
-		}
-		expandedGroups = new Set(expandedGroups);
-		syncExpandedToUrl();
-	}
-
-	let allExpanded = $derived(
-		groupedCommands.length > 0 && groupedCommands.every((g) => expandedGroups.has(g.key))
-	);
-
-	function toggleAllGroups() {
-		if (allExpanded) {
-			expandedGroups = new Set();
-		} else {
-			expandedGroups = new Set(groupedCommands.map((g) => g.key));
-		}
-		syncExpandedToUrl();
-	}
-
-	// Calculate max usage for progress bars
-	let maxUsage = $derived(
-		filteredCommands.length > 0 ? Math.max(...filteredCommands.map((c: CommandUsage) => c.count)) : 100
-	);
-
-	// Build a category lookup from command data for analytics filtering
-	let commandCategoryMap = $derived.by(() => {
-		const map = new Map<string, string>();
-		for (const cmd of data.usage || []) {
-			map.set(cmd.name, cmd.category ?? 'user_command');
-		}
-		return map;
-	});
-
-	let excludeFn = $derived.by(() => {
-		if (selectedFilter === 'all') return undefined;
-		if (selectedFilter === 'builtin') {
-			return (name: string) => commandCategoryMap.get(name) !== 'builtin_command';
-		}
-		if (selectedFilter === 'bundled') {
-			return (name: string) => commandCategoryMap.get(name) !== 'bundled_skill';
-		}
-		if (selectedFilter === 'plugin') {
-			return (name: string) => {
-				const cat = commandCategoryMap.get(name);
-				return cat !== 'plugin_command' && cat !== 'plugin_skill';
-			};
-		}
-		// 'user' — only user_command and custom_skill
-		return (name: string) => {
-			const cat = commandCategoryMap.get(name);
-			return cat !== 'user_command' && cat !== 'custom_skill';
-		};
-	});
-
-	let hasCommands = $derived((data.usage || []).length > 0);
-	let hasFilteredCommands = $derived(filteredCommands.length > 0);
+	let isPageLoading = $derived(!!$navigating && $navigating.to?.route.id === '/commands');
 </script>
 
-<div class="space-y-8">
-	{#if isPageLoading}
-		<!-- Loading Skeleton -->
-		<div class="space-y-8" role="status" aria-busy="true" aria-label="Loading commands...">
-			<!-- Header skeleton -->
-			<div>
-				<div class="flex items-center gap-2 mb-2">
-					<SkeletonText width="70px" size="xs" />
-					<span class="text-[var(--text-muted)]">/</span>
-					<SkeletonText width="80px" size="xs" />
-				</div>
-				<div class="flex items-center gap-3">
-					<SkeletonBox width="32px" height="32px" rounded="lg" />
-					<SkeletonText width="140px" size="xl" />
-				</div>
-			</div>
+{#if isPageLoading}
+	<div class="-mx-6 -my-8 flex items-center justify-center" style="height: calc(100vh - 56px);">
+		<div class="flex flex-col items-center gap-3">
+			<Zap size={32} class="text-[var(--accent)] animate-pulse" />
+			<span class="text-sm text-[var(--text-muted)]">Loading commands…</span>
+		</div>
+	</div>
+{:else}
 
-			<!-- Stats skeleton -->
-			<div class="rounded-2xl p-8 border border-[var(--border)] bg-[var(--bg-subtle)]">
-				<div class="grid grid-cols-5 gap-6">
-					{#each Array(5) as _}
-						<div class="space-y-2">
-							<SkeletonText width="80px" size="xs" />
-							<SkeletonText width="50px" size="lg" />
+<!-- ── Full-bleed split-view container ────────────────────────────────────── -->
+<div
+	class="-mx-6 -my-8 flex flex-col"
+	style="{activeView === 'overview' ? 'height: calc(100vh - 56px); overflow: hidden;' : ''}"
+>
+
+	<!-- ── Page Header ──────────────────────────────────────────────────────── -->
+	<div class="flex-shrink-0" style="padding: 0 24px; background: var(--bg-base);">
+		<PageHeader
+			title="Commands"
+			iconName="commands"
+			iconColor="--nav-red"
+			breadcrumbs={[{ label: 'Dashboard', href: '/' }, { label: 'Commands' }]}
+			subtitle="Which commands are pulling their weight?"
+		/>
+	</div>
+
+	<!-- Filter bar — always visible -->
+	<div
+		class="flex flex-shrink-0 items-center"
+		style="padding: 8px 12px; gap: 10px; {activeView === 'analytics' ? 'position: sticky; top: 56px; z-index: 10; background: var(--bg-base); border-bottom: 1px solid var(--border-subtle);' : ''}"
+	>
+		<!-- Left group: view tabs — fixed width matching left panel -->
+		<div
+			class="flex rounded-lg p-0.5 flex-shrink-0"
+			style="width: 280px; background: var(--bg-muted);"
+			role="tablist"
+			aria-label="View"
+		>
+			{#each ([['overview', 'Overview'], ['analytics', 'Analytics']] as const) as [val, lbl]}
+				<button
+					role="tab"
+					aria-selected={activeView === val}
+					onclick={() => activeView = val}
+					class="flex-1 rounded-md transition-all"
+					style="
+						padding: 4px 8px;
+						font-size: 11px;
+						font-weight: {activeView === val ? '600' : '500'};
+						color: {activeView === val ? 'var(--bg-base)' : 'var(--text-secondary)'};
+						background: {activeView === val ? 'var(--text-primary)' : 'transparent'};
+					"
+				>{lbl}</button>
+			{/each}
+		</div>
+
+		<!-- Right group: type chips + search -->
+		<div class="flex items-center gap-2 flex-1">
+			<div class="flex items-center gap-1.5">
+				{#each ([['all', 'All'], ['builtin', 'Built-in'], ['plugin', 'Plugin'], ['user', 'User']] as const) as [val, lbl]}
+					<button
+						onclick={() => selectedFilter = val}
+						class="rounded-full transition-all"
+						style="
+							padding: 4px 12px;
+							font-size: 11px;
+							font-weight: {selectedFilter === val ? '600' : '500'};
+							color: {selectedFilter === val ? 'var(--accent)' : 'var(--text-secondary)'};
+							background: {selectedFilter === val ? 'var(--accent-muted)' : 'transparent'};
+							border: {selectedFilter === val ? '1.5px solid var(--accent-subtle)' : '1px solid var(--border)'};
+						"
+					>{lbl}</button>
+				{/each}
+			</div>
+			<div class="relative ml-auto">
+				<Search class="absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" size={12} style="color: var(--text-faint);" />
+				<input
+					type="text"
+					bind:value={searchQuery}
+					aria-label="Search commands"
+					placeholder="Search commands…"
+					style="width: 180px; padding: 4px 10px 4px 26px; font-size: 12px; background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 8px; color: var(--text-primary); outline: none;"
+					data-search-input
+				/>
+			</div>
+		</div>
+	</div>
+
+	{#if activeView === 'overview'}
+	<!-- Split view -->
+	<div class="flex flex-1 min-h-0 overflow-hidden" style="padding: 0 12px 12px; gap: 10px;">
+
+		<!-- ── Left Panel: Source Coverage ────────────────────────────────────── -->
+		<div
+			class="flex-shrink-0 flex flex-col"
+			style="width: 280px; background: var(--bg-base); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; align-self: flex-start;"
+		>
+			<!-- Panel header — accordion trigger -->
+			<button
+				class="w-full text-left flex-shrink-0 transition-colors hover:bg-[var(--bg-subtle)]"
+				style="border-bottom: 1px solid {coverageOpen ? 'var(--border-subtle)' : 'transparent'}; padding: 14px 16px 12px;"
+				onclick={() => coverageOpen = !coverageOpen}
+			>
+				<div class="flex items-center justify-between mb-2">
+					<span style="font-size: 10px; font-weight: 700; color: var(--nav-red); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace;">
+						Source Coverage
+					</span>
+					<div style="color: var(--text-faint); transition: transform 0.2s; transform: rotate({coverageOpen ? 90 : 0}deg);">
+						<ChevronRight size={13} />
+					</div>
+				</div>
+				<!-- Stats: fill full width -->
+				<div class="flex items-center w-full">
+					<div class="flex flex-col flex-1 items-center">
+						<span style="font-size: 22px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: var(--text-primary); letter-spacing: -1px;">{totalUses.toLocaleString()}</span>
+						<span style="font-size: 9px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.06em;">uses</span>
+					</div>
+					<div style="width: 1px; height: 32px; background: var(--border);"></div>
+					<div class="flex flex-col flex-1 items-center">
+						<span style="font-size: 22px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: var(--text-primary); letter-spacing: -1px;">{activeCommandsCount}<span style="font-size: 13px; font-weight: 500; color: var(--text-faint);">/{totalCommandsCount}</span></span>
+						<span style="font-size: 9px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.06em;">active</span>
+					</div>
+					{#if neverUsedCount > 0}
+						<div style="width: 1px; height: 32px; background: var(--border);"></div>
+						<div class="flex flex-col flex-1 items-center">
+							<span style="font-size: 22px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: var(--nav-orange); letter-spacing: -1px;">{neverUsedCount}</span>
+							<span style="font-size: 9px; color: var(--nav-orange); text-transform: uppercase; letter-spacing: 0.06em; opacity: 0.8;">unused</span>
 						</div>
-					{/each}
+					{/if}
 				</div>
-			</div>
+			</button>
 
-			<!-- Filter bar skeleton -->
-			<div class="flex items-center justify-between">
-				<div class="flex items-center gap-3">
-					<SkeletonBox width="240px" height="36px" rounded="lg" />
-					<SkeletonBox width="280px" height="32px" rounded="lg" />
-				</div>
-				<SkeletonBox width="200px" height="36px" rounded="lg" />
-			</div>
-
-			<!-- Card grid skeleton -->
-			<div class="space-y-4">
-				{#each Array(2) as _}
-					<div>
-						<div class="flex items-center gap-2 mb-4">
-							<SkeletonBox width="28px" height="28px" rounded="md" />
-							<SkeletonText width="120px" size="sm" />
-							<SkeletonText width="60px" size="xs" />
+			<!-- Group rows — only when accordion is open -->
+			{#if coverageOpen}
+			<div class="flex-1 overflow-y-auto">
+				{#each leftPanelGroups as group}
+					{@const colors = getGroupColors(group)}
+					{@const groupTotal = group.commands.reduce((sum, c) => sum + c.count, 0)}
+					{@const pct = totalUses > 0 ? Math.round((groupTotal / totalUses) * 100) : 0}
+					{@const isSelected = selectedGroup === group.key}
+					<div
+						role="button"
+						tabindex="0"
+						onclick={() => toggleGroup(group)}
+						onkeydown={(e) => e.key === 'Enter' && toggleGroup(group)}
+						class="border-b cursor-pointer group/row transition-colors"
+						style="
+							padding: 10px 20px;
+							border-color: var(--border-subtle);
+							background: {isSelected ? 'var(--accent-muted)' : 'transparent'};
+							border-left: {isSelected ? '2px solid var(--accent)' : '2px solid transparent'};
+						"
+					>
+						<!-- Name row -->
+						<div class="flex items-center justify-between gap-2" style="margin-bottom: 6px;">
+							<span class="flex-1 min-w-0 truncate" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;">
+								{group.label}
+							</span>
+							<div class="flex items-center gap-1.5 flex-shrink-0">
+								{#if groupTotal === Math.max(...leftPanelGroups.map(g => g.commands.reduce((s, c) => s + c.count, 0)))}
+									<TrendingUp size={10} style="color: var(--nav-orange);" />
+								{/if}
+								<span style="font-size: 12px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: var(--text-secondary);">
+									{pct}%
+								</span>
+							</div>
 						</div>
-						<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-							{#each Array(3) as _}
-								<div class="p-4 rounded-xl border border-[var(--border)] bg-[var(--bg-base)] space-y-3">
-									<div class="flex items-center gap-3">
-										<SkeletonBox width="36px" height="36px" rounded="lg" />
-										<div class="flex-1 space-y-1.5">
-											<SkeletonText width="120px" size="sm" />
-											<SkeletonText width="60px" size="xs" />
-										</div>
-										<SkeletonBox width="40px" height="24px" rounded="full" />
-									</div>
-									<SkeletonBox width="100%" height="6px" rounded="full" />
-								</div>
-							{/each}
+
+						<!-- Bar + count -->
+						<div class="flex items-center gap-2">
+							<div class="flex-1" style="height: 3px; border-radius: 2px; background: var(--bg-muted); overflow: hidden;">
+								<div style="height: 100%; border-radius: 2px; width: {pct}%; background: {colors.color}; opacity: 0.6;"></div>
+							</div>
+							<span style="font-size: 10px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace; flex-shrink: 0;">
+								{groupTotal.toLocaleString()}
+							</span>
 						</div>
 					</div>
 				{/each}
 			</div>
-		</div>
-	{:else}
 
-	<!-- Page Header -->
-	<PageHeader
-		title="Commands"
-		iconName="commands"
-		iconColor="--nav-red"
-		breadcrumbs={[{ label: 'Dashboard', href: '/' }, { label: 'Commands' }]}
-		subtitle="Track command usage analytics across all sessions"
-	/>
-
-	<!-- Hero Stats -->
-	{#if hasCommands}
-		<div
-			class="relative overflow-hidden rounded-2xl p-8 border border-[var(--border)]"
-			style="background: linear-gradient(135deg, rgba(59, 130, 246, 0.02) 0%, rgba(59, 130, 246, 0.06) 100%);"
-		>
-			<div
-				class="absolute -top-24 -right-24 w-96 h-96 bg-blue-500/5 rounded-full blur-3xl pointer-events-none"
-			></div>
-			<div
-				class="absolute -bottom-24 -left-24 w-64 h-64 bg-teal-500/3 rounded-full blur-3xl pointer-events-none"
-			></div>
-			<div class="relative">
-				<StatsGrid {stats} columns={5} />
-			</div>
-		</div>
-	{/if}
-
-	<!-- Filters Row -->
-	<div
-		class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4"
-		use:listNavigation
-	>
-		<div class="flex items-center gap-3 flex-wrap">
-			<SegmentedControl options={viewTabs} bind:value={activeView} />
-			<SegmentedControl options={filterOptions} bind:value={selectedFilter} size="sm" />
-		</div>
-
-		{#if activeView !== 'analytics'}
-			<div class="flex items-center gap-3 w-full sm:w-auto">
-				<div class="relative flex-1 sm:flex-initial">
-					<Search
-						class="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)]"
-						size={16}
-					/>
-					<input
-						type="text"
-						bind:value={searchQuery}
-						aria-label="Search commands"
-						placeholder="Search commands..."
-						class="
-							pl-9 pr-4 py-2
-							bg-[var(--bg-base)]
-							border border-[var(--border)]
-							rounded-lg text-sm
-							focus:outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent)]/20
-							w-full sm:w-64
-							transition-all
-							text-[var(--text-primary)]
-							placeholder:text-[var(--text-faint)]
-						"
-						data-search-input
-					/>
-				</div>
-
-				{#if activeView === 'groups' && groupedCommands.length > 1}
-					<button
-						onclick={toggleAllGroups}
-						class="
-							flex items-center gap-1.5 px-3 py-2
-							text-sm font-medium
-							text-[var(--text-secondary)]
-							hover:text-[var(--text-primary)]
-							bg-[var(--bg-base)]
-							border border-[var(--border)]
-							rounded-lg
-							transition-all
-							hover:bg-[var(--bg-subtle)]
-							whitespace-nowrap
-						"
-						title={allExpanded ? 'Collapse all groups' : 'Expand all groups'}
-					>
-						{#if allExpanded}
-							<ChevronsDownUp size={16} />
-							<span class="hidden sm:inline">Collapse All</span>
-						{:else}
-							<ChevronsUpDown size={16} />
-							<span class="hidden sm:inline">Expand All</span>
-						{/if}
+			<!-- Footer -->
+			<div class="flex-shrink-0 border-t flex items-center justify-between" style="padding: 10px 16px; border-color: var(--border-subtle);">
+				<span style="font-size: 10px; color: var(--text-faint);">Sorted by total uses</span>
+				{#if selectedGroup !== null}
+					<button onclick={() => selectedGroup = null} style="font-size: 10px; color: var(--accent); font-weight: 600;">
+						Clear ×
 					</button>
 				{/if}
 			</div>
-		{/if}
-	</div>
-
-	<!-- Content Area -->
-	{#if activeView === 'analytics'}
-		<UsageAnalytics
-			endpoint="/commands/usage/trend"
-			itemLabel="Commands"
-			colorFn={getCommandChartHex}
-			excludeItemFn={excludeFn}
-			itemLinkPrefix="/commands/"
-			itemDisplayFn={(name) => '/' + name}
-		/>
-	{:else if !hasCommands}
-		<div
-			class="text-center py-20 bg-[var(--bg-subtle)] rounded-2xl border border-dashed border-[var(--border)]"
-		>
-			<Terminal class="mx-auto text-[var(--text-muted)] mb-3" size={48} />
-			<p class="text-[var(--text-secondary)] font-medium">No commands found</p>
-			<p class="text-sm text-[var(--text-muted)] mt-1">
-				Command usage data will appear here once you start using commands in Claude Code
-			</p>
+			{/if}
 		</div>
-	{:else if !hasFilteredCommands}
-		<div
-			class="text-center py-20 bg-[var(--bg-subtle)] rounded-2xl border border-dashed border-[var(--border)]"
-		>
-			<Search class="mx-auto text-[var(--text-muted)] mb-3" size={48} />
-			<p class="text-[var(--text-secondary)] font-medium">No matching commands</p>
-			<p class="text-sm text-[var(--text-muted)] mt-1">
-				Try adjusting your search or filter
-			</p>
-		</div>
-	{:else if activeView === 'table'}
-		<CommandUsageTable commands={filteredCommands} />
-	{:else}
-		<!-- Grouped Command Display (By Category) -->
-		<div class="space-y-4">
-			{#each groupedCommands as group (group.key)}
-				{@const groupColors = group.pluginName
-					? getPluginColorVars(group.pluginName)
-					: getCommandCategoryColorVars(group.key)}
-				<CollapsibleGroup
-					title={group.label}
-					open={expandedGroups.has(group.key)}
-					onOpenChange={() => toggleGroup(group.key)}
-				>
-					{#snippet icon()}
-						{@const Icon = group.icon}
-						<div
-							class="p-1.5 rounded-md"
-							style="background-color: {groupColors.subtle};"
-						>
-							<Icon size={14} style="color: {groupColors.color};" />
-						</div>
-					{/snippet}
-					{#snippet metadata()}
-						<div class="flex items-center gap-3">
-							<span class="text-xs text-[var(--text-muted)] tabular-nums">
-								{group.commands.length} command{group.commands.length !== 1 ? 's' : ''}
-							</span>
-							{#if group.pluginName}
-								<a
-									href="/plugins/{encodeURIComponent(group.pluginName)}"
-									class="
-										inline-flex items-center gap-1 px-2 py-0.5
-										text-[10px] font-medium
-										text-[var(--accent)] hover:text-[var(--text-primary)]
-										bg-[var(--accent-subtle)] hover:bg-[var(--bg-muted)]
-										rounded-full
-										transition-colors
-									"
-									onclick={(e) => e.stopPropagation()}
-									title="View plugin"
-								>
-									<Puzzle size={10} />
-									View plugin
-									<ExternalLink size={9} />
-								</a>
-							{/if}
-						</div>
-					{/snippet}
 
+		<!-- ── Right Panel: Top Commands Leaderboard ───────────────────────────── -->
+		<div class="flex-1 flex flex-col overflow-hidden min-w-0" style="background: var(--bg-base); border: 1px solid var(--border); border-radius: 12px;">
+
+			<!-- Panel header -->
+			<div
+				class="flex-shrink-0 flex items-center justify-between border-b"
+				style="padding: 14px 16px 12px; background: var(--bg-base); border-color: var(--border);"
+			>
+				<div>
+					<div style="font-size: 10px; font-weight: 700; color: var(--nav-red); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace; margin-bottom: 3px;">Top Commands</div>
+					<div style="font-size: 11px; color: var(--text-faint);">
+						{#if selectedGroup !== null}
+							{@const grp = leftPanelGroups.find(g => g.key === selectedGroup)}
+							{rightPanelCommands.length} commands · {grp?.label ?? selectedGroup}
+						{:else}
+							{rightPanelCommands.length} active commands ranked by usage
+						{/if}
+					</div>
+				</div>
+
+				<!-- List/Grid toggle -->
+				<div class="flex rounded-md overflow-hidden" style="border: 1px solid var(--border);">
+					<button
+						onclick={() => commandsView = 'list'}
+						style="padding: 5px 8px; background: {commandsView === 'list' ? 'var(--bg-muted)' : 'transparent'}; color: {commandsView === 'list' ? 'var(--text-primary)' : 'var(--text-faint)'}; display: flex; align-items: center;"
+						title="List view"
+					><LayoutList size={13} /></button>
+					<button
+						onclick={() => commandsView = 'grid'}
+						style="padding: 5px 8px; background: {commandsView === 'grid' ? 'var(--bg-muted)' : 'transparent'}; color: {commandsView === 'grid' ? 'var(--text-primary)' : 'var(--text-faint)'}; display: flex; align-items: center; border-left: 1px solid var(--border);"
+						title="Grid view"
+					><LayoutGrid size={13} /></button>
+				</div>
+			</div>
+
+			<!-- Table container -->
+			<div class="flex-1 overflow-y-auto">
+				{#if rightPanelCommands.length === 0}
+					<div class="flex flex-col items-center justify-center h-full gap-3">
+						<Search size={36} style="color: var(--text-faint);" />
+						<p style="font-size: 13px; color: var(--text-secondary); font-weight: 500;">No matching commands</p>
+						<p style="font-size: 11px; color: var(--text-faint);">Try adjusting filters or search</p>
+					</div>
+				{:else if commandsView === 'list'}
+					<!-- Column headers -->
 					<div
-						class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 stagger-children"
+						class="grid sticky top-0 border-b"
+						style="background: var(--bg-base); border-color: var(--border); grid-template-columns: 32px 1fr 160px 100px 56px 64px 72px; padding: 10px 12px 8px;"
 					>
-						{#each group.commands as command (command.name)}
-							<CommandUsageCard {command} {maxUsage} />
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; text-align: center;">#</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase;">Command</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase;">Source</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; padding: 0 8px;">Usage</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; text-align: right;">Uses</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; text-align: right;">Sessions</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; text-align: right;">Last used</div>
+					</div>
+
+					<!-- Command rows -->
+					{#each rightPanelCommands as cmd, i (cmd.name)}
+						{@const displayName = '/' + cmd.name}
+						{@const barWidth = Math.round((cmd.count / globalMax) * 100)}
+						{@const sourceBadge = getSourceBadgeLabel(cmd)}
+						{@const colors = getCmdColors(cmd)}
+						{@const cat = cmd.category ?? 'user_command'}
+						{@const useColor = selectedFilter === 'plugin' && (cat === 'plugin_command' || cat === 'plugin_skill')}
+						<a
+							href="/commands/{encodeURIComponent(cmd.name)}"
+							class="grid border-b transition-colors hover:bg-[var(--bg-subtle)] no-underline"
+							style="grid-template-columns: 32px 1fr 160px 100px 56px 64px 72px; padding: 8px 12px; border-color: var(--border-subtle); align-items: center;"
+						>
+							<div style="font-size: 11px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace; text-align: center;">{i + 1}</div>
+							<div class="min-w-0 pr-3">
+								<span class="truncate block" style="font-size: 13px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;" title={displayName}>{displayName}</span>
+							</div>
+							<div class="min-w-0">
+								{#if useColor && cmd.plugin}
+									<span class="truncate block rounded" style="font-size: 10px; font-weight: 700; font-family: 'JetBrains Mono', monospace; padding: 2px 7px; color: var(--bg-base); background: {colors.color}; display: inline-block; max-width: 100%;" title={cmd.plugin}>{cmd.plugin}</span>
+								{:else}
+									<span class="truncate block" style="font-size: 11px; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace;" title={sourceBadge}>{sourceBadge}</span>
+								{/if}
+							</div>
+							<div style="padding: 0 8px;">
+								<div style="background: var(--bg-muted); height: 4px; border-radius: 2px; overflow: hidden;">
+									<div style="height: 100%; border-radius: 2px; width: {barWidth}%; background: {useColor ? colors.color : 'var(--nav-red)'}; opacity: 0.7;"></div>
+								</div>
+							</div>
+							<div style="font-size: 13px; font-weight: 700; font-family: 'JetBrains Mono', monospace; text-align: right; color: {useColor ? colors.color : 'var(--text-primary)'};">{cmd.count}</div>
+							<div style="font-size: 12px; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace; text-align: right;">{cmd.session_count ?? 0}</div>
+							<div style="font-size: 11px; font-weight: 500; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace; text-align: right;">{shortDate(cmd.last_used)}</div>
+						</a>
+					{/each}
+				{:else}
+					<!-- Grid view -->
+					<div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 8px; padding: 12px;">
+						{#each rightPanelCommands as cmd, i (cmd.name)}
+							{@const displayName = '/' + cmd.name}
+							{@const barWidth = Math.round((cmd.count / globalMax) * 100)}
+							{@const sourceBadge = getSourceBadgeLabel(cmd)}
+							{@const colors = getCmdColors(cmd)}
+							{@const cat = cmd.category ?? 'user_command'}
+							{@const useColor = selectedFilter === 'plugin' && (cat === 'plugin_command' || cat === 'plugin_skill')}
+							<a
+								href="/commands/{encodeURIComponent(cmd.name)}"
+								class="flex flex-col no-underline rounded-lg transition-all"
+								style="padding: 14px 14px 12px; gap: 6px;
+									border: 1px solid {useColor ? colors.subtle : 'var(--border-subtle)'};
+									background: {useColor ? colors.subtle : 'var(--bg-subtle)'};"
+								onmouseenter={(e) => { (e.currentTarget as HTMLElement).style.borderColor = useColor ? colors.color : 'var(--border)'; (e.currentTarget as HTMLElement).style.background = useColor ? colors.subtle : 'var(--bg-base)'; }}
+								onmouseleave={(e) => { (e.currentTarget as HTMLElement).style.borderColor = useColor ? colors.subtle : 'var(--border-subtle)'; (e.currentTarget as HTMLElement).style.background = useColor ? colors.subtle : 'var(--bg-subtle)'; }}
+							>
+								<!-- Count — hero -->
+								<div style="font-size: 28px; font-weight: 800; font-family: 'JetBrains Mono', monospace; letter-spacing: -1px; line-height: 1;
+									color: {useColor ? colors.color : 'var(--nav-red)'};">
+									{cmd.count}
+								</div>
+
+								<!-- Command name -->
+								<div class="min-w-0" style="margin-top: 2px;">
+									<span class="block truncate" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;" title={displayName}>{displayName}</span>
+								</div>
+
+								<!-- Bar -->
+								<div style="background: var(--bg-muted); height: 3px; border-radius: 2px; overflow: hidden; margin-top: 4px;">
+									<div style="height: 100%; border-radius: 2px; width: {barWidth}%; background: {useColor ? colors.color : 'var(--nav-red)'}; opacity: 0.7;"></div>
+								</div>
+
+								<!-- Footer: source · last used -->
+								<div class="flex items-center justify-between" style="margin-top: 2px; gap: 4px;">
+									{#if useColor && cmd.plugin}
+										<span
+											class="truncate rounded"
+											style="font-size: 10px; font-weight: 700; font-family: 'JetBrains Mono', monospace; padding: 2px 7px; color: var(--bg-base); background: {colors.color}; flex-shrink: 1; min-width: 0;"
+											title={cmd.plugin}
+										>{cmd.plugin}</span>
+									{:else}
+										<span style="font-size: 10px; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace;" class="truncate">{sourceBadge}</span>
+									{/if}
+									<span class="flex items-center gap-1 flex-shrink-0" style="color: var(--text-faint);">
+										<svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+										<span style="font-size: 10px; font-weight: 500; font-family: 'JetBrains Mono', monospace;">{shortDate(cmd.last_used)}</span>
+									</span>
+								</div>
+							</a>
 						{/each}
 					</div>
-				</CollapsibleGroup>
-			{/each}
+				{/if}
+			</div>
 		</div>
-	{/if}
+
+	</div>
+
+	{:else}
+
+	<!-- Analytics view -->
+	<div style="padding: 18px 24px 64px; display: flex; flex-direction: column; gap: 14px;">
+
+		<!-- Insight banner -->
+		{#if insightText}
+			<div class="flex items-center gap-3 rounded-lg" style="padding: 10px 16px; background: linear-gradient(135deg, var(--accent-muted), color-mix(in oklch, var(--accent-muted), var(--bg-subtle) 50%)); border: 1px solid var(--accent-subtle);">
+				<Sparkles size={14} style="color: var(--accent); flex-shrink: 0;" />
+				<span style="font-size: 12px; color: var(--text-primary); line-height: 1.5;">
+					<strong>{insightText.active} active commands</strong> · /{insightText.topName} leads with {insightText.topCount} uses · /{insightText.topBySessionName} spans {insightText.topBySessionCount} sessions
+				</span>
+			</div>
+		{/if}
+
+		<!-- Stacked area chart -->
+		<div class="rounded-lg" style="padding: 16px 18px; background: var(--bg-base); border: 1px solid var(--border);">
+			<StackedAreaChart
+				{trendData}
+				loading={trendLoading}
+				range={trendRange}
+				onRangeChange={(r) => { trendRangeUserOverride = true; trendRange = r; }}
+				{getGroupFor}
+				label="Command Uses Over Time"
+			/>
+		</div>
+
+		<!-- Bottom row: Session Reach + Cost -->
+		<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 14px; align-items: start;">
+
+			<!-- Session Reach panel -->
+			<div class="rounded-lg" style="padding: 16px 18px; background: var(--bg-base); border: 1px solid var(--border);">
+				<div style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace; margin-bottom: 2px;">Session Reach</div>
+				<div style="font-size: 11px; color: var(--text-faint); margin-bottom: 14px;">which commands are embedded in your workflow</div>
+
+				{#if sessionReachCommands.length === 0}
+					<div style="color: var(--text-faint); font-size: 12px; padding: 12px 0;">No data</div>
+				{:else}
+					<!-- Column headers -->
+					<div style="display: grid; grid-template-columns: 1fr 80px 44px; gap: 8px; padding: 0 4px; margin-bottom: 6px;">
+						<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase;">Command</div>
+						<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase; text-align: center;">sessions</div>
+						<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase; text-align: right;">reach</div>
+					</div>
+					<div style="border-top: 1px solid var(--border-subtle); padding-top: 4px;">
+						{#each sessionReachCommands as cmd}
+							{@const colors = getCmdColors(cmd)}
+							{@const sessions = cmd.session_count ?? 0}
+							{@const barPct = Math.round((sessions / sessionReachMax) * 100)}
+							{@const reachPct = analyticsTotalUses > 0 ? Math.round((sessions / analyticsTotalUses) * 100) : 0}
+							<a
+								href="/commands/{encodeURIComponent(cmd.name)}"
+								class="no-underline"
+								style="display: grid; grid-template-columns: 1fr 80px 44px; gap: 8px; align-items: center; padding: 5px 4px; border-radius: 4px; cursor: pointer;"
+								onmouseenter={(e) => (e.currentTarget as HTMLElement).style.background = 'var(--bg-subtle)'}
+								onmouseleave={(e) => (e.currentTarget as HTMLElement).style.background = 'transparent'}
+							>
+								<div class="flex items-center gap-1.5 min-w-0">
+									<div style="width: 5px; height: 5px; border-radius: 50%; background: {colors.color}; flex-shrink: 0;"></div>
+									<span class="truncate" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;" title={'/' + cmd.name}>/{cmd.name}</span>
+								</div>
+								<div style="background: var(--bg-muted); height: 5px; border-radius: 3px; overflow: hidden;">
+									<div style="height: 100%; border-radius: 3px; width: {barPct}%; background: var(--accent);"></div>
+								</div>
+								<div style="font-size: 10px; font-weight: 700; color: {reachPct >= 30 ? 'var(--accent)' : 'var(--text-faint)'}; text-align: right; font-family: 'JetBrains Mono', monospace;">{sessions}</div>
+							</a>
+						{/each}
+					</div>
+					<div style="margin-top: 10px; border-top: 1px solid var(--border-subtle); padding-top: 8px; font-size: 10px; color: var(--text-faint); line-height: 1.5;">
+						Sessions count how many unique conversations used each command — a high count means it's woven into your day-to-day
+					</div>
+				{/if}
+			</div>
+
+			<!-- Cost estimation panel -->
+			{#if true}
+				{@const avgTokens = 500}
+				{@const pricePerMTok = 3.00}
+				{@const top5 = rightPanelCommands.slice(0, 5)}
+				{@const top5Total = top5.reduce((s, c) => s + c.count, 0)}
+				{@const allTotal = analyticsTotalUses}
+				{@const costMax = top5.length > 0 ? top5[0].count : 1}
+				{@const otherCount = allTotal - top5Total}
+				{@const estTotalCost = (allTotal * avgTokens * pricePerMTok) / 1_000_000}
+				{@const perInv = allTotal > 0 ? (estTotalCost / allTotal) : 0}
+			<div class="rounded-lg" style="padding: 16px 18px; background: var(--bg-base); border: 1px solid var(--border);">
+				<div style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace; margin-bottom: 2px;">Estimated Cost</div>
+				<div style="font-size: 11px; color: var(--text-faint); margin-bottom: 12px;">across {allTotal} uses this period</div>
+
+				<!-- Hero total -->
+				<div class="flex items-baseline gap-2" style="margin-bottom: 4px;">
+					<span style="font-size: 32px; font-weight: 700; color: var(--text-primary); font-family: 'JetBrains Mono', monospace; letter-spacing: -1.5px;">~${estTotalCost < 0.01 ? estTotalCost.toFixed(4) : estTotalCost.toFixed(2)}</span>
+					<span style="font-size: 12px; color: var(--text-faint);">total</span>
+				</div>
+				<div style="font-size: 11px; color: var(--text-secondary); margin-bottom: 14px; font-family: 'JetBrains Mono', monospace;">~${perInv.toFixed(4)} per use avg</div>
+
+				<!-- Callout -->
+				<div class="flex gap-2 rounded" style="padding: 7px 10px; margin-bottom: 14px; background: var(--nav-orange-subtle); border: 1px solid color-mix(in oklch, var(--nav-orange) 30%, transparent);">
+					<Info size={12} style="color: var(--nav-orange); flex-shrink: 0; margin-top: 1px;" />
+					<span style="font-size: 10px; color: var(--nav-orange); line-height: 1.5;">Using ~500 tokens/use avg · actual cost varies by model and command complexity</span>
+				</div>
+
+				<!-- Column headers -->
+				<div style="display: grid; grid-template-columns: 1fr 1fr 40px 68px; gap: 10px; padding: 0 4px; margin-bottom: 6px;">
+					<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase;">Command</div>
+					<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase;">Cost share</div>
+					<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase; text-align: right;">%</div>
+					<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase; text-align: right;">Est. cost</div>
+				</div>
+
+				{#each top5 as cmd}
+					{@const cmdCost = (cmd.count * avgTokens * pricePerMTok) / 1_000_000}
+					{@const pct = allTotal > 0 ? Math.round((cmd.count / allTotal) * 100) : 0}
+					{@const barPct = Math.round((cmd.count / costMax) * 100)}
+					<a
+						href="/commands/{encodeURIComponent(cmd.name)}"
+						class="no-underline"
+						style="display: grid; grid-template-columns: 1fr 1fr 40px 68px; gap: 10px; align-items: center; padding: 7px 4px; border-radius: 5px; cursor: pointer;"
+						onmouseenter={(e) => (e.currentTarget as HTMLElement).style.background = 'color-mix(in oklch, var(--nav-orange) 6%, transparent)'}
+						onmouseleave={(e) => (e.currentTarget as HTMLElement).style.background = 'transparent'}
+					>
+						<div class="truncate" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;" title={'/' + cmd.name}>/{cmd.name}</div>
+						<div style="background: color-mix(in oklch, var(--nav-orange) 15%, transparent); height: 7px; border-radius: 4px; overflow: hidden;">
+							<div style="background: var(--nav-orange); width: {barPct}%; height: 7px;"></div>
+						</div>
+						<div style="font-size: 11px; color: var(--text-faint); text-align: right; font-family: 'JetBrains Mono', monospace;">{pct}%</div>
+						<div style="font-size: 12px; font-weight: 700; color: var(--text-primary); text-align: right; font-family: 'JetBrains Mono', monospace;">~${cmdCost.toFixed(3)}</div>
+					</a>
+				{/each}
+
+				{#if otherCount > 0}
+					{@const otherCost = (otherCount * avgTokens * pricePerMTok) / 1_000_000}
+					{@const otherPct = Math.round((otherCount / allTotal) * 100)}
+					{@const otherBarPct = Math.round((otherCount / costMax) * 100)}
+					<div style="display: grid; grid-template-columns: 1fr 1fr 40px 68px; gap: 10px; align-items: center; padding: 7px 4px; border-top: 1px dashed var(--border-subtle); margin-top: 2px;">
+						<div style="font-size: 11px; color: var(--text-faint); font-style: italic;">{rightPanelCommands.length - 5} other commands</div>
+						<div style="background: var(--bg-muted); height: 7px; border-radius: 4px; overflow: hidden;">
+							<div style="background: var(--text-faint); width: {Math.min(otherBarPct, 100)}%; height: 7px; opacity: 0.5;"></div>
+						</div>
+						<div style="font-size: 11px; color: var(--text-faint); text-align: right; font-family: 'JetBrains Mono', monospace;">{otherPct}%</div>
+						<div style="font-size: 12px; font-weight: 600; color: var(--text-faint); text-align: right; font-family: 'JetBrains Mono', monospace;">~${otherCost.toFixed(3)}</div>
+					</div>
+				{/if}
+
+				<div style="margin-top: 12px; border-top: 1px solid var(--border-subtle); padding-top: 8px; font-size: 10px; color: var(--text-faint); line-height: 1.6;">
+					~{avgTokens} tokens/use · Sonnet ${pricePerMTok}/MTok · actual cost varies by model &amp; command
+				</div>
+			</div>
+			{/if}
+
+		</div>
+
+	</div>
 
 	{/if}
+
 </div>
+
+{/if}

--- a/frontend/src/routes/cron/+page.svelte
+++ b/frontend/src/routes/cron/+page.svelte
@@ -261,19 +261,29 @@
 	</PageHeader>
 
 	<!-- Stat strip — reacts to the source toggle -->
-	<div class="stats-wrap">
+	<div style="display: flex; gap: 10px; margin-bottom: 22px;">
 		{#if cronSource === 'system'}
-			<StatsGrid columns={3} stats={[
-				{ title: 'Crontab entries', value: systemSummary?.count ?? 0, icon: TerminalSquare, color: 'purple' },
-				{ title: 'Claude-related', value: (systemSummary?.byOrigin['claude-skill'] ?? 0) + (systemSummary?.byOrigin['claude'] ?? 0), icon: Clock, color: 'green', description: 'skills + ~/.claude scripts' },
-				{ title: 'User & system', value: (systemSummary?.byOrigin['user'] ?? 0) + (systemSummary?.byOrigin['system'] ?? 0), icon: Archive, color: 'gray' }
-			]} />
+			{#each [
+				{ label: 'Crontab entries', value: systemSummary?.count ?? 0, accent: false },
+				{ label: 'Claude-related', value: (systemSummary?.byOrigin['claude-skill'] ?? 0) + (systemSummary?.byOrigin['claude'] ?? 0), accent: false },
+				{ label: 'User & system', value: (systemSummary?.byOrigin['user'] ?? 0) + (systemSummary?.byOrigin['system'] ?? 0), accent: false },
+			] as stat}
+				<div style="background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 10px; padding: 14px 20px; display: flex; align-items: baseline; gap: 10px;">
+					<span style="font-size: 32px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: var(--text-primary); line-height: 1;">{stat.value}</span>
+					<span style="font-size: 14px; color: var(--text-muted);">{stat.label}</span>
+				</div>
+			{/each}
 		{:else}
-			<StatsGrid columns={3} stats={[
-				{ title: 'Total tracked', value: counts.total, icon: Clock, color: 'purple' },
-				{ title: 'Likely active', value: counts.active, icon: Activity, color: 'green', description: 'inferred from TTL' },
-				{ title: 'Expired or deleted', value: counts.inactive, icon: Archive, color: 'gray' }
-			]} />
+			{#each [
+				{ label: 'Total tracked', value: counts.total, accent: false },
+				{ label: 'Likely active', value: counts.active, accent: true },
+				{ label: 'Expired or deleted', value: counts.inactive, accent: false },
+			] as stat}
+				<div style="background: var(--bg-subtle); border: 1px solid {stat.accent && stat.value > 0 ? 'rgba(42,138,80,0.3)' : 'var(--border)'}; border-radius: 10px; padding: 14px 20px; display: flex; align-items: baseline; gap: 10px;">
+					<span style="font-size: 32px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: {stat.accent && stat.value > 0 ? '#2A8A50' : 'var(--text-primary)'}; line-height: 1;">{stat.value}</span>
+					<span style="font-size: 14px; color: var(--text-muted);">{stat.label}</span>
+				</div>
+			{/each}
 		{/if}
 	</div>
 
@@ -566,21 +576,10 @@
 	.page-wrap {
 		max-width: 1120px;
 		margin: 0 auto;
-		padding: 32px 32px 80px;
+		padding: 0 32px 80px;
 		display: flex;
 		flex-direction: column;
 		gap: 0;
-	}
-
-	/* ── Stat strip ────────────────────────────────────────────────────────── */
-	.stats-wrap {
-		position: relative;
-		overflow: hidden;
-		border-radius: 16px;
-		padding: 24px;
-		border: 1px solid var(--border);
-		background: linear-gradient(135deg, rgba(var(--accent-rgb), 0.02) 0%, rgba(var(--accent-rgb), 0.06) 100%);
-		margin-bottom: 22px;
 	}
 
 	/* ── Source segmented toggle ───────────────────────────────────────────── */

--- a/frontend/src/routes/cron/+page.svelte
+++ b/frontend/src/routes/cron/+page.svelte
@@ -261,29 +261,19 @@
 	</PageHeader>
 
 	<!-- Stat strip — reacts to the source toggle -->
-	<div style="display: flex; gap: 10px; margin-bottom: 22px;">
+	<div class="stats-wrap">
 		{#if cronSource === 'system'}
-			{#each [
-				{ label: 'Crontab entries', value: systemSummary?.count ?? 0, accent: false },
-				{ label: 'Claude-related', value: (systemSummary?.byOrigin['claude-skill'] ?? 0) + (systemSummary?.byOrigin['claude'] ?? 0), accent: false },
-				{ label: 'User & system', value: (systemSummary?.byOrigin['user'] ?? 0) + (systemSummary?.byOrigin['system'] ?? 0), accent: false },
-			] as stat}
-				<div style="background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 10px; padding: 14px 20px; display: flex; align-items: baseline; gap: 10px;">
-					<span style="font-size: 32px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: var(--text-primary); line-height: 1;">{stat.value}</span>
-					<span style="font-size: 14px; color: var(--text-muted);">{stat.label}</span>
-				</div>
-			{/each}
+			<StatsGrid columns={3} stats={[
+				{ title: 'Crontab entries', value: systemSummary?.count ?? 0, icon: TerminalSquare, color: 'purple' },
+				{ title: 'Claude-related', value: (systemSummary?.byOrigin['claude-skill'] ?? 0) + (systemSummary?.byOrigin['claude'] ?? 0), icon: Clock, color: 'green', description: 'skills + ~/.claude scripts' },
+				{ title: 'User & system', value: (systemSummary?.byOrigin['user'] ?? 0) + (systemSummary?.byOrigin['system'] ?? 0), icon: Archive, color: 'gray' }
+			]} />
 		{:else}
-			{#each [
-				{ label: 'Total tracked', value: counts.total, accent: false },
-				{ label: 'Likely active', value: counts.active, accent: true },
-				{ label: 'Expired or deleted', value: counts.inactive, accent: false },
-			] as stat}
-				<div style="background: var(--bg-subtle); border: 1px solid {stat.accent && stat.value > 0 ? 'rgba(42,138,80,0.3)' : 'var(--border)'}; border-radius: 10px; padding: 14px 20px; display: flex; align-items: baseline; gap: 10px;">
-					<span style="font-size: 32px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: {stat.accent && stat.value > 0 ? '#2A8A50' : 'var(--text-primary)'}; line-height: 1;">{stat.value}</span>
-					<span style="font-size: 14px; color: var(--text-muted);">{stat.label}</span>
-				</div>
-			{/each}
+			<StatsGrid columns={3} stats={[
+				{ title: 'Total tracked', value: counts.total, icon: Clock, color: 'purple' },
+				{ title: 'Likely active', value: counts.active, icon: Activity, color: 'green', description: 'inferred from TTL' },
+				{ title: 'Expired or deleted', value: counts.inactive, icon: Archive, color: 'gray' }
+			]} />
 		{/if}
 	</div>
 
@@ -580,6 +570,17 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0;
+	}
+
+	/* ── Stat strip ────────────────────────────────────────────────────────── */
+	.stats-wrap {
+		position: relative;
+		overflow: hidden;
+		border-radius: 16px;
+		padding: 24px;
+		border: 1px solid var(--border);
+		background: linear-gradient(135deg, rgba(var(--accent-rgb), 0.02) 0%, rgba(var(--accent-rgb), 0.06) 100%);
+		margin-bottom: 22px;
 	}
 
 	/* ── Source segmented toggle ───────────────────────────────────────────── */

--- a/frontend/src/routes/hooks/+page.server.ts
+++ b/frontend/src/routes/hooks/+page.server.ts
@@ -1,13 +1,124 @@
 import { API_BASE } from '$lib/config';
 import { fetchWithFallback } from '$lib/utils/api-fetch';
-import type { HooksOverview } from '$lib/api-types';
+import type { HooksOverview, LiveSessionSummary } from '$lib/api-types';
 
-export async function load({ fetch }) {
-	const data = await fetchWithFallback<HooksOverview>(fetch, `${API_BASE}/hooks`, {
-		sources: [],
-		event_summaries: [],
-		registrations: [],
-		stats: { total_sources: 0, total_registrations: 0, blocking_hooks: 0 }
-	});
-	return { hooks: data };
+export interface HookActivity {
+	// A: per event type — ISO timestamp of most recent session that had this as last_hook
+	lastSeenByEvent: Record<string, string>;
+	// B: SessionEnd reason breakdown + total session count
+	endReasons: Record<string, number>;
+	totalSessions: number;
+	// C: subagent stats across tracked sessions (SubagentStart/SubagentStop)
+	subagentStats: {
+		totalInvocations: number; // from analytics tools_used.Agent (all-time)
+		trackedTotal: number; // from live session files (recent)
+		sessionsWithAgents: number;
+		byType: Record<string, number>;
+	};
+	// D: recent notification messages (Notification / PermissionRequest hooks)
+	recentNotifications: Array<{
+		message: string;
+		sessionId: string;
+		slug: string | null;
+		projectEncodedName: string | null;
+		updatedAt: string;
+	}>;
+	// Live pulse: event type currently active in a LIVE session
+	activePulseEvent: string | null;
+}
+
+export async function load({ fetch, url }) {
+	const [hooks, liveSessions, analytics] = await Promise.all([
+		fetchWithFallback<HooksOverview>(fetch, `${API_BASE}/hooks`, {
+			sources: [],
+			event_summaries: [],
+			registrations: [],
+			stats: { total_sources: 0, total_registrations: 0, blocking_hooks: 0 }
+		}),
+		fetchWithFallback<{ sessions: LiveSessionSummary[] }>(
+			fetch,
+			`${API_BASE}/live-sessions?limit=100`,
+			{ sessions: [] }
+		),
+		fetchWithFallback<{ total_sessions: number; tools_used: Record<string, number> }>(
+			fetch,
+			`${API_BASE}/analytics`,
+			{ total_sessions: 0, tools_used: {} }
+		)
+	]);
+
+	const sessions = liveSessions.sessions ?? [];
+
+	// A: last seen per event type
+	const lastSeenByEvent: Record<string, string> = {};
+	for (const s of sessions) {
+		if (s.last_hook && s.updated_at) {
+			const existing = lastSeenByEvent[s.last_hook];
+			if (!existing || s.updated_at > existing) {
+				lastSeenByEvent[s.last_hook] = s.updated_at;
+			}
+		}
+	}
+
+	// B: end reasons + total sessions
+	const endReasons: Record<string, number> = {};
+	for (const s of sessions) {
+		if (s.end_reason) {
+			endReasons[s.end_reason] = (endReasons[s.end_reason] ?? 0) + 1;
+		}
+	}
+	const totalSessions = analytics.total_sessions ?? 0;
+
+	// C: subagent stats
+	let trackedTotal = 0;
+	let sessionsWithAgents = 0;
+	const byType: Record<string, number> = {};
+	for (const s of sessions) {
+		const count = s.total_subagent_count ?? 0;
+		if (count > 0) {
+			sessionsWithAgents++;
+			trackedTotal += count;
+		}
+		for (const sub of Object.values(s.subagents ?? {})) {
+			const t = (sub as { agent_type?: string }).agent_type ?? 'unknown';
+			byType[t] = (byType[t] ?? 0) + 1;
+		}
+	}
+
+	// D: notification messages
+	const recentNotifications = sessions
+		.filter((s) => s.last_notification_message)
+		.sort((a, b) => (b.updated_at > a.updated_at ? 1 : -1))
+		.slice(0, 5)
+		.map((s) => ({
+			message: s.last_notification_message!,
+			sessionId: s.session_id,
+			slug: s.slug,
+			projectEncodedName: s.project_encoded_name ?? null,
+			updatedAt: s.updated_at
+		}));
+
+	// Live pulse: find LIVE session's last_hook
+	const liveSession = sessions.find((s) => s.state === 'LIVE');
+	const activePulseEvent = liveSession?.last_hook ?? null;
+
+	const hookActivity: HookActivity = {
+		lastSeenByEvent,
+		endReasons,
+		totalSessions,
+		subagentStats: {
+			totalInvocations: analytics.tools_used?.Agent ?? 0,
+			trackedTotal,
+			sessionsWithAgents,
+			byType
+		},
+		recentNotifications,
+		activePulseEvent
+	};
+
+	return {
+		hooks,
+		hookActivity,
+		initialEvent: url.searchParams.get('event')
+	};
 }

--- a/frontend/src/routes/hooks/+page.svelte
+++ b/frontend/src/routes/hooks/+page.svelte
@@ -97,10 +97,10 @@
 	function selectEvent(eventType: string) {
 		selectedEventType = eventType;
 		drawerOpen = true;
-		if (typeof history !== 'undefined') {
-			const url = new URL(location.href);
+		if (typeof window !== 'undefined') {
+			const url = new URL(window.location.href);
 			url.searchParams.set('event', eventType);
-			history.replaceState({}, '', url);
+			window.history.replaceState({}, '', url);
 		}
 	}
 

--- a/frontend/src/routes/hooks/+page.svelte
+++ b/frontend/src/routes/hooks/+page.svelte
@@ -1,77 +1,152 @@
+<svelte:head>
+	<link
+		href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap"
+		rel="stylesheet"
+	/>
+</svelte:head>
+
 <script lang="ts">
-	import {
-		Webhook,
-		FolderOpen,
-		ShieldAlert,
-		ChevronsUpDown,
-		ChevronsDownUp,
-		Puzzle
-	} from 'lucide-svelte';
+	import type { HookEventSummary, HookEventDetail } from '$lib/api-types';
+	import type { HookActivity } from './+page.server';
+	import { API_BASE } from '$lib/config';
 	import PageHeader from '$lib/components/layout/PageHeader.svelte';
-	import StatsGrid from '$lib/components/StatsGrid.svelte';
-	import SegmentedControl from '$lib/components/ui/SegmentedControl.svelte';
-	import CollapsibleGroup from '$lib/components/ui/CollapsibleGroup.svelte';
-	import HookEventNode from '$lib/components/hooks/HookEventNode.svelte';
-	import HookScriptCard from '$lib/components/hooks/HookScriptCard.svelte';
-	import type { StatItem, HookEventSummary } from '$lib/api-types';
-	import { getHookSourceColorVars } from '$lib/utils';
+	import { Search } from 'lucide-svelte';
 
 	let { data } = $props();
 
-	// View mode state
-	let viewMode = $state<'timeline' | 'sources'>('timeline');
+	// ── State ────────────────────────────────────────────────────────────────
+	let activeTab = $state<'timeline' | 'source'>('timeline');
+	let searchQuery = $state('');
+	let schemaExpanded = $state(false);
+	let rightPanelEl = $state<HTMLElement | null>(null);
 
-	// Stats for hero section
-	let stats = $derived<StatItem[]>([
-		{
-			title: 'Sources',
-			value: data.hooks.stats.total_sources.toLocaleString(),
-			icon: FolderOpen,
-			color: 'orange'
-		},
-		{
-			title: 'Registrations',
-			value: data.hooks.stats.total_registrations.toLocaleString(),
-			icon: Webhook,
-			color: 'blue'
-		},
-		{
-			title: 'Can Block',
-			value: data.hooks.stats.blocking_hooks.toLocaleString(),
-			icon: ShieldAlert,
-			color: 'orange'
+	// Selected event — init from URL param only; landing shown when nothing selected
+	let selectedEventType = $state<string | null>(data.initialEvent ?? null);
+	let drawerOpenInit = !!(data.initialEvent);
+
+	// Lazy-loaded detail (schema_info + related_events)
+	let detailData = $state<HookEventDetail | null>(null);
+	let detailLoading = $state(false);
+
+	// Drawer state
+	let drawerOpen = $state(drawerOpenInit);
+
+	function closeDrawer() {
+		drawerOpen = false;
+	}
+
+	// Script source viewer
+	let expandedScript = $state<string | null>(null);
+	let scriptContent = $state<string | null>(null);
+	let scriptLoading = $state(false);
+	let scriptCopied = $state(false);
+
+	async function copyScript() {
+		if (!scriptContent) return;
+		await navigator.clipboard.writeText(scriptContent);
+		scriptCopied = true;
+		setTimeout(() => (scriptCopied = false), 1800);
+	}
+
+	async function toggleScript(filename: string) {
+		if (expandedScript === filename) { expandedScript = null; scriptContent = null; return; }
+		expandedScript = filename;
+		scriptContent = null;
+		scriptLoading = true;
+		try {
+			const res = await fetch(`${API_BASE}/hooks/scripts/${encodeURIComponent(filename)}`);
+			if (res.ok) {
+				const d = await res.json();
+				scriptContent = d.content ?? '# (no content)';
+			}
+		} catch { scriptContent = '# error loading file'; }
+		finally { scriptLoading = false; }
+	}
+
+	$effect(() => {
+		const et = selectedEventType;
+		schemaExpanded = false;
+		expandedScript = null;
+		scriptContent = null;
+		if (!et) return;
+		loadDetail(et);
+	});
+
+	// Close drawer on Escape
+	$effect(() => {
+		function onKey(e: KeyboardEvent) {
+			if (e.key === 'Escape' && drawerOpen) closeDrawer();
 		}
-	]);
+		window.addEventListener('keydown', onKey);
+		return () => window.removeEventListener('keydown', onKey);
+	});
 
-	// Phase ordering for timeline view
+	async function loadDetail(eventType: string) {
+		detailLoading = true;
+		detailData = null;
+		try {
+			const res = await fetch(`${API_BASE}/hooks/${encodeURIComponent(eventType)}`);
+			if (res.ok) detailData = (await res.json()) as HookEventDetail;
+		} catch {
+			// silent
+		} finally {
+			detailLoading = false;
+		}
+	}
+
+	function selectEvent(eventType: string) {
+		selectedEventType = eventType;
+		drawerOpen = true;
+		if (typeof history !== 'undefined') {
+			const url = new URL(location.href);
+			url.searchParams.set('event', eventType);
+			history.replaceState({}, '', url);
+		}
+	}
+
+	// ── Derived ──────────────────────────────────────────────────────────────
+	let selectedEvent = $derived(
+		selectedEventType
+			? (data.hooks.event_summaries.find((e) => e.event_type === selectedEventType) ?? null)
+			: null
+	);
+
+	let relatedPrev = $derived(
+		detailData?.related_events.find((e) => e.position === 'previous') ?? null
+	);
+	let relatedNext = $derived(
+		detailData?.related_events.find((e) => e.position === 'next') ?? null
+	);
+
 	const PHASE_ORDER = [
 		'Session Lifecycle',
 		'User Input',
 		'Tool Lifecycle',
 		'Agent Lifecycle',
 		'Context & Permissions',
-		'Session End',
-		'Setup'
+		'System',
+		'Setup',
+		'Unknown'
 	];
 
-	// Group events by phase
 	interface PhaseGroup {
 		phase: string;
 		events: HookEventSummary[];
 	}
 
 	let eventsByPhase = $derived.by<PhaseGroup[]>(() => {
-		const grouped = new Map<string, HookEventSummary[]>();
+		const q = searchQuery.toLowerCase();
+		const filtered = q
+			? data.hooks.event_summaries.filter((e) => e.event_type.toLowerCase().includes(q))
+			: data.hooks.event_summaries;
 
-		for (const event of data.hooks.event_summaries) {
-			const phase = event.phase || 'Other';
-			if (!grouped.has(phase)) {
-				grouped.set(phase, []);
-			}
-			grouped.get(phase)!.push(event);
+		const grouped = new Map<string, HookEventSummary[]>();
+		for (const ev of filtered) {
+			const phase = ev.phase || 'Unknown';
+			if (!grouped.has(phase)) grouped.set(phase, []);
+			grouped.get(phase)!.push(ev);
 		}
 
-		// Sort by phase order
 		const result: PhaseGroup[] = [];
 		for (const phase of PHASE_ORDER) {
 			if (grouped.has(phase)) {
@@ -79,232 +154,1173 @@
 				grouped.delete(phase);
 			}
 		}
-
-		// Add any remaining phases not in the order
-		for (const [phase, events] of grouped.entries()) {
-			result.push({ phase, events });
-		}
-
+		for (const [phase, events] of grouped) result.push({ phase, events });
 		return result;
 	});
 
-	// Track expanded state for timeline events
-	let expandedEvents = $state<Set<string>>(new Set());
+	interface SourceGroup {
+		source: (typeof data.hooks.sources)[number];
+		events: HookEventSummary[];
+	}
 
-	function toggleEvent(eventType: string) {
-		if (expandedEvents.has(eventType)) {
-			expandedEvents.delete(eventType);
-		} else {
-			expandedEvents.add(eventType);
+	let eventsBySource = $derived.by<SourceGroup[]>(() => {
+		const q = searchQuery.toLowerCase();
+		return data.hooks.sources
+			.map((source) => {
+				const events = source.event_types_covered
+					.map((et) => data.hooks.event_summaries.find((e) => e.event_type === et))
+					.filter((e): e is HookEventSummary => !!e)
+					.filter((e) => !q || e.event_type.toLowerCase().includes(q));
+				return { source, events };
+			})
+			.filter((g) => g.events.length > 0);
+	});
+
+	// ── Helpers ───────────────────────────────────────────────────────────────
+	function dotColor(ev: HookEventSummary): string {
+		const has = ev.total_registrations > 0;
+		if (has && ev.can_block) return 'var(--error)';
+		if (has) return 'var(--accent)';
+		if (ev.can_block) return 'rgba(209,78,43,0.25)';
+		return 'var(--border)';
+	}
+
+	function sourceHexColor(sourceType: string, sourceName: string): string {
+		if (sourceType === 'global') return '#E87C3A';
+		const known: Record<string, string> = {
+			plannotator: '#3A8A66',
+			superpowers: '#4A7EBB'
+		};
+		if (known[sourceName]) return known[sourceName];
+		const palette = ['#7C3AED', '#3A8A66', '#4A7EBB', '#E87C3A', '#6B5BF5', '#2A8A50'];
+		let hash = 0;
+		for (let i = 0; i < sourceName.length; i++) hash = (hash * 31 + sourceName.charCodeAt(i)) >>> 0;
+		return palette[hash % palette.length];
+	}
+
+	function isSymlink(sourceName: string, filename: string | null | undefined): boolean {
+		if (!filename) return false;
+		for (const src of data.hooks.sources) {
+			if (src.source_name === sourceName) {
+				return src.scripts.find((s) => s.filename === filename)?.is_symlink ?? false;
+			}
 		}
-		expandedEvents = new Set(expandedEvents);
+		return false;
 	}
 
-	let allEventsExpanded = $derived(
-		data.hooks.event_summaries.length > 0 &&
-			data.hooks.event_summaries.every((e) => expandedEvents.has(e.event_type))
-	);
-
-	function expandAllEvents() {
-		expandedEvents = new Set(data.hooks.event_summaries.map((e) => e.event_type));
+	function langLabel(lang: string): string {
+		const map: Record<string, string> = {
+			python: 'Python',
+			javascript: 'JavaScript',
+			typescript: 'TypeScript',
+			bash: 'Shell',
+			shell: 'Shell'
+		};
+		return map[lang.toLowerCase()] ?? lang;
 	}
 
-	function collapseAllEvents() {
-		expandedEvents = new Set();
+	function timeAgo(isoTs: string | undefined): string | null {
+		if (!isoTs) return null;
+		const diff = Date.now() - new Date(isoTs).getTime();
+		const m = Math.floor(diff / 60000);
+		if (m < 1) return 'just now';
+		if (m < 60) return `${m}m ago`;
+		const h = Math.floor(m / 60);
+		if (h < 24) return `${h}h ago`;
+		return `${Math.floor(h / 24)}d ago`;
 	}
 
-	function toggleAllEvents() {
-		if (allEventsExpanded) {
-			collapseAllEvents();
-		} else {
-			expandAllEvents();
-		}
-	}
+	const activity = data.hookActivity as HookActivity;
 
-	// Track expanded state for source groups
-	let expandedSources = $state<Set<string>>(new Set());
-
-	function toggleSource(sourceId: string) {
-		if (expandedSources.has(sourceId)) {
-			expandedSources.delete(sourceId);
-		} else {
-			expandedSources.add(sourceId);
-		}
-		expandedSources = new Set(expandedSources);
-	}
-
-	let hasHooks = $derived(data.hooks.sources.length > 0 || data.hooks.event_summaries.length > 0);
+	// B: SessionEnd reason display labels
+	const END_REASON_LABELS: Record<string, string> = {
+		prompt_input_exit: 'Exit command',
+		clear: 'Clear',
+		logout: 'Logout',
+		other: 'Other',
+		session_handoff: 'Session handoff',
+		stuck_starting: 'Stuck starting'
+	};
 </script>
 
-<div class="space-y-8">
+<style>
+	@keyframes live-pulse {
+		0%, 100% { opacity: 1; transform: scale(1); }
+		50% { opacity: 0.4; transform: scale(0.7); }
+	}
+	.live-pulse {
+		animation: live-pulse 1.6s ease-in-out infinite;
+	}
+	.script-btn {
+		cursor: pointer;
+		text-decoration: underline dotted;
+		text-underline-offset: 2px;
+		color: var(--text-secondary);
+		background: none; border: none; padding: 0;
+		font-family: 'DM Mono', 'JetBrains Mono', monospace;
+		font-size: 11px;
+	}
+	.script-btn:hover { color: var(--accent); }
+</style>
+
+<!-- Full-bleed container -->
+<div class="-mx-6 -my-8" style="background: var(--bg-base); min-height: 100vh;">
 	<!-- Page Header -->
-	<PageHeader
-		title="Hooks"
-		iconName="hooks"
-		iconColor="--nav-cyan"
-		breadcrumbs={[{ label: 'Dashboard', href: '/' }, { label: 'Hooks' }]}
-		subtitle="Hook scripts intercepting your Claude Code sessions"
-	/>
+	<div style="padding: 32px 32px 0;">
+		<PageHeader
+			title="Hooks"
+			iconName="hooks"
+			iconColor="--nav-cyan"
+			breadcrumbs={[{ label: 'Dashboard', href: '/' }, { label: 'Hooks' }]}
+			subtitle="Hook scripts intercepting your Claude Code sessions"
+		/>
+	</div>
 
-	<!-- Hero Stats -->
-	{#if hasHooks}
+	<!-- Filter bar -->
+	<div
+		class="flex items-center"
+		style="padding: 10px 32px; gap: 12px;"
+	>
+		<!-- Tab toggle -->
 		<div
-			class="relative overflow-hidden rounded-2xl p-8 border border-[var(--border)]"
-			style="background: linear-gradient(135deg, rgba(217, 119, 6, 0.02) 0%, rgba(217, 119, 6, 0.06) 100%);"
+			class="flex rounded-lg p-0.5 flex-shrink-0"
+			style="background: var(--bg-muted);"
+			role="tablist"
+			aria-label="View"
 		>
-			<div
-				class="absolute -top-24 -right-24 w-96 h-96 bg-orange-500/5 rounded-full blur-3xl pointer-events-none"
-			></div>
-			<div
-				class="absolute -bottom-24 -left-24 w-64 h-64 bg-amber-500/3 rounded-full blur-3xl pointer-events-none"
-			></div>
-			<div class="relative">
-				<StatsGrid {stats} columns={3} />
-			</div>
-		</div>
-	{/if}
-
-	<!-- View Switcher -->
-	{#if hasHooks}
-		<div class="flex items-center justify-between">
-			<SegmentedControl
-				options={[
-					{ label: 'Event Timeline', value: 'timeline' },
-					{ label: 'By Source', value: 'sources' }
-				]}
-				bind:value={viewMode}
-			/>
-
-			{#if viewMode === 'timeline' && data.hooks.event_summaries.length > 0}
+			{#each ([['timeline', 'Event Timeline'], ['source', 'By Source']] as const) as [val, lbl]}
 				<button
-					onclick={toggleAllEvents}
-					class="
-						flex items-center gap-1.5 px-3 py-2
-						text-sm font-medium
-						text-[var(--text-secondary)]
-						hover:text-[var(--text-primary)]
-						bg-[var(--bg-base)]
-						border border-[var(--border)]
-						rounded-lg
-						transition-all
-						hover:bg-[var(--bg-subtle)]
+					role="tab"
+					aria-selected={activeTab === val}
+					onclick={() => (activeTab = val)}
+					class="rounded-md transition-all"
+					style="
+						padding: 6px 16px;
+						font-size: 12px;
+						font-weight: {activeTab === val ? '600' : '500'};
+						color: {activeTab === val ? 'var(--bg-base)' : 'var(--text-secondary)'};
+						background: {activeTab === val ? 'var(--text-primary)' : 'transparent'};
 					"
-					title={allEventsExpanded ? 'Collapse all events' : 'Expand all events'}
-				>
-					{#if allEventsExpanded}
-						<ChevronsDownUp size={16} />
-						<span>Collapse All</span>
-					{:else}
-						<ChevronsUpDown size={16} />
-						<span>Expand All</span>
-					{/if}
-				</button>
+				>{lbl}</button>
+			{/each}
+		</div>
+
+		<!-- Search -->
+		<div class="relative ml-auto">
+			<Search class="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none" size={13} style="color: var(--text-faint);" />
+			<input
+				type="text"
+				bind:value={searchQuery}
+				aria-label="Search events"
+				placeholder="Search events…"
+				style="width: 200px; padding: 6px 12px 6px 30px; font-size: 12px; background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 8px; color: var(--text-primary); outline: none;"
+			/>
+		</div>
+	</div>
+
+	<!-- Main landing content -->
+	<div style="padding: 32px 32px 64px;">
+		<!-- Stats + notifications row -->
+		<div style="display: flex; align-items: flex-start; gap: 24px; margin-bottom: 36px;">
+			<!-- Stat pills -->
+			<div style="display: flex; flex-direction: column; gap: 8px; flex-shrink: 0;">
+				{#each [
+					{ label: 'Sources', value: data.hooks.stats.total_sources, accent: false },
+					{ label: 'Registrations', value: data.hooks.stats.total_registrations, accent: false },
+					{ label: 'Blocking', value: data.hooks.stats.blocking_hooks, accent: true },
+				] as stat}
+					<div style="
+						background: var(--bg-subtle);
+						border: 1px solid {stat.accent && stat.value > 0 ? 'rgba(209,78,43,0.3)' : 'var(--border)'};
+						border-radius: 10px; padding: 14px 20px;
+						display: flex; align-items: baseline; gap: 10px;
+					">
+						<span style="font-size: 32px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: {stat.accent && stat.value > 0 ? 'var(--error)' : 'var(--text-primary)'}; line-height: 1;">{stat.value}</span>
+						<span style="font-size: 14px; color: var(--text-muted);">{stat.label}</span>
+					</div>
+				{/each}
+			</div>
+
+			<!-- Recent notifications (front row) -->
+			{#if activity.recentNotifications.length > 0}
+				<div style="flex: 1; min-width: 0;">
+					<div style="font-size: 10px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-muted); margin-bottom: 10px;">Recent notifications</div>
+					<div style="display: flex; flex-direction: column; gap: 6px;">
+						{#each activity.recentNotifications as notif}
+							{@const href = notif.projectEncodedName && notif.slug ? `/projects/${notif.projectEncodedName}/${notif.slug}` : null}
+							<div style="background: var(--bg-subtle); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 7px; padding: 10px 14px;">
+								<p style="font-size: 12px; color: var(--text-primary); margin: 0 0 5px; line-height: 1.5;">{notif.message}</p>
+								<div style="display: flex; gap: 8px; align-items: center;">
+									{#if href}
+										<a {href} style="font-size: 10px; font-family: 'DM Mono', monospace; color: var(--accent); text-decoration: none;" onmouseenter={(e) => (e.currentTarget.style.textDecoration = 'underline')} onmouseleave={(e) => (e.currentTarget.style.textDecoration = 'none')}>
+											{notif.slug ?? notif.sessionId.slice(0, 8)}
+										</a>
+									{:else}
+										<span style="font-size: 10px; font-family: 'DM Mono', monospace; color: var(--text-muted);">{notif.sessionId.slice(0, 8)}</span>
+									{/if}
+									<span style="font-size: 10px; color: var(--text-muted);">{timeAgo(notif.updatedAt)}</span>
+								</div>
+							</div>
+						{/each}
+					</div>
+				</div>
 			{/if}
 		</div>
-	{/if}
 
-	<!-- Content Area -->
-	{#if !hasHooks}
-		<div
-			class="text-center py-20 bg-[var(--bg-subtle)] rounded-2xl border border-dashed border-[var(--border)]"
-		>
-			<Webhook class="mx-auto text-[var(--text-muted)] mb-3" size={48} />
-			<p class="text-[var(--text-secondary)] font-medium">No hooks found</p>
-			<p class="text-sm text-[var(--text-muted)] mt-1">
-				Hook scripts will appear here once you configure them
-			</p>
-		</div>
-	{:else if viewMode === 'timeline'}
-		<!-- Timeline View -->
-		<div class="space-y-8">
-			{#each eventsByPhase as phaseGroup}
-				<div>
-					<!-- Phase Header -->
-					<h2
-						class="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-4"
-					>
-						{phaseGroup.phase}
-					</h2>
-
-					<!-- Events in this phase -->
-					<div class="space-y-0">
-						{#each phaseGroup.events as event (event.event_type)}
-							<HookEventNode
-								{event}
-								open={expandedEvents.has(event.event_type)}
-								onToggle={() => toggleEvent(event.event_type)}
-							/>
+		<!-- Event groups -->
+		{#if activeTab === 'timeline'}
+			{#each eventsByPhase as group}
+				{#if group.events.length > 0}
+					<div style="margin-bottom: 32px;">
+						<div style="font-size: 10px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-muted); margin-bottom: 10px; padding-left: 2px;">
+							{group.phase}
+						</div>
+						<div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 8px;">
+							{#each group.events as ev (ev.event_type)}
+								{@const isSelected = ev.event_type === selectedEventType && drawerOpen}
+								{@const isPulsing = activity.activePulseEvent === ev.event_type}
+								{@const lastSeen = timeAgo(activity.lastSeenByEvent[ev.event_type])}
+								<button
+									onclick={() => selectEvent(ev.event_type)}
+									style="
+										display: flex; flex-direction: column; gap: 6px;
+										padding: 14px 16px;
+										background: var(--bg-base);
+										border: 1.5px solid {isSelected ? 'var(--accent)' : 'var(--border)'};
+										border-radius: 9px; cursor: pointer; text-align: left;
+										opacity: {ev.total_registrations === 0 ? 0.45 : 1};
+										transition: border-color 0.12s, box-shadow 0.12s;
+										box-shadow: {isSelected ? '0 0 0 3px rgba(107,91,245,0.1)' : 'none'};
+									"
+									onmouseenter={(e) => {
+										if (!isSelected) (e.currentTarget as HTMLElement).style.borderColor = 'color-mix(in srgb, var(--accent) 50%, var(--border))';
+									}}
+									onmouseleave={(e) => {
+										if (!isSelected) (e.currentTarget as HTMLElement).style.borderColor = 'var(--border)';
+									}}
+								>
+									<!-- Top row: dot + name + count -->
+									<div style="display: flex; align-items: center; gap: 7px;">
+										<span
+											class={isPulsing ? 'live-pulse' : ''}
+											style="width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; background: {isPulsing ? '#22c55e' : dotColor(ev)};"
+										></span>
+										<span style="
+											flex: 1; font-size: 12px; font-family: 'DM Mono', 'JetBrains Mono', monospace;
+											font-weight: 500; color: {isSelected ? 'var(--accent)' : 'var(--text-primary)'};
+											overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+										">{ev.event_type}</span>
+										{#if ev.can_block}
+											<svg width="9" height="9" viewBox="0 0 10 10" fill="none" style="flex-shrink:0;">
+												<path d="M5 1.5L9 8H1L5 1.5Z" fill="var(--error)" />
+											</svg>
+										{/if}
+										{#if ev.total_registrations > 0}
+											<span style="font-size: 11px; font-family: 'DM Mono', monospace; color: {ev.can_block ? 'var(--error)' : 'var(--accent)'}; font-weight: 600; flex-shrink: 0;">{ev.total_registrations}</span>
+										{/if}
+									</div>
+									<!-- Bottom row: description + last seen -->
+									{#if ev.description || lastSeen}
+										<div style="display: flex; align-items: center; justify-content: space-between; gap: 8px;">
+											{#if ev.description}
+												<span style="font-size: 10.5px; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1;">{ev.description}</span>
+											{/if}
+											{#if lastSeen}
+												<span style="font-size: 9.5px; color: var(--text-muted); flex-shrink: 0; white-space: nowrap;">{lastSeen}</span>
+											{/if}
+										</div>
+									{/if}
+								</button>
+							{/each}
+						</div>
+					</div>
+				{/if}
+			{/each}
+		{:else}
+			<!-- By Source mode -->
+			{#each eventsBySource as group (group.source.source_id)}
+				{@const color = sourceHexColor(group.source.source_type, group.source.source_name)}
+				<div style="margin-bottom: 32px;">
+					<div style="display: flex; align-items: center; gap: 10px; margin-bottom: 10px;">
+						<span style="font-size: 10px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: {color};">
+							{group.source.source_name}
+						</span>
+						<span style="font-size: 10px; color: var(--text-muted); background: var(--bg-base); border: 1px solid var(--border); padding: 2px 8px; border-radius: 3px;">
+							{group.source.total_registrations} hooks · {group.source.source_type}
+						</span>
+					</div>
+					<div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 8px;">
+						{#each group.events as ev (ev.event_type)}
+							{@const isSelected = ev.event_type === selectedEventType && drawerOpen}
+							{@const isPulsing = activity.activePulseEvent === ev.event_type}
+							{@const lastSeen = timeAgo(activity.lastSeenByEvent[ev.event_type])}
+							<button
+								onclick={() => selectEvent(ev.event_type)}
+								style="
+									display: flex; flex-direction: column; gap: 6px;
+									padding: 14px 16px;
+									background: var(--bg-base);
+									border: 1.5px solid {isSelected ? color : 'var(--border)'};
+									border-left: 3px solid {color};
+									border-radius: 9px; cursor: pointer; text-align: left;
+									opacity: {ev.total_registrations === 0 ? 0.45 : 1};
+									transition: border-color 0.12s;
+								"
+								onmouseenter={(e) => {
+									if (!isSelected) (e.currentTarget as HTMLElement).style.borderColor = color;
+								}}
+								onmouseleave={(e) => {
+									if (!isSelected) (e.currentTarget as HTMLElement).style.borderColor = 'var(--border)';
+								}}
+							>
+								<div style="display: flex; align-items: center; gap: 7px;">
+									<span
+										class={isPulsing ? 'live-pulse' : ''}
+										style="width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; background: {isPulsing ? '#22c55e' : dotColor(ev)};"
+									></span>
+									<span style="flex: 1; font-size: 12px; font-family: 'DM Mono', 'JetBrains Mono', monospace; font-weight: 500; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+										{ev.event_type}
+									</span>
+									{#if ev.can_block}
+										<svg width="9" height="9" viewBox="0 0 10 10" fill="none" style="flex-shrink:0;">
+											<path d="M5 1.5L9 8H1L5 1.5Z" fill="var(--error)" />
+										</svg>
+									{/if}
+									{#if ev.total_registrations > 0}
+										<span style="font-size: 11px; font-family: 'DM Mono', monospace; color: var(--accent); font-weight: 600; flex-shrink: 0;">{ev.total_registrations}</span>
+									{/if}
+								</div>
+								{#if ev.description || lastSeen}
+									<div style="display: flex; align-items: center; justify-content: space-between; gap: 8px;">
+										{#if ev.description}
+											<span style="font-size: 10.5px; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1;">{ev.description}</span>
+										{/if}
+										{#if lastSeen}
+											<span style="font-size: 9.5px; color: var(--text-muted); flex-shrink: 0; white-space: nowrap;">{lastSeen}</span>
+										{/if}
+									</div>
+								{/if}
+							</button>
 						{/each}
 					</div>
 				</div>
 			{/each}
-		</div>
-	{:else}
-		<!-- By Source View -->
-		<div class="space-y-4">
-			{#each data.hooks.sources as source (source.source_id)}
-				{@const sourceColors = getHookSourceColorVars(
-					source.source_type,
-					source.source_name
-				)}
-				<CollapsibleGroup
-					title={source.source_name}
-					open={expandedSources.has(source.source_id)}
-					onOpenChange={() => toggleSource(source.source_id)}
-					accentColor={sourceColors.color}
-				>
-					{#snippet icon()}
+		{/if}
+
+	</div>
+
+	<!-- Drawer backdrop -->
+	{#if drawerOpen}
+		<div
+			role="button"
+			tabindex="-1"
+			aria-label="Close drawer"
+			onclick={closeDrawer}
+			onkeydown={(e) => e.key === 'Enter' && closeDrawer()}
+			style="position: fixed; inset: 0; background: rgba(0,0,0,0.18); z-index: 40; backdrop-filter: blur(1px); cursor: default;"
+		></div>
+	{/if}
+
+	<!-- Event detail drawer -->
+	<div
+		bind:this={rightPanelEl}
+		aria-modal="true"
+		role="dialog"
+		style="
+			position: fixed; right: 0; top: 56px;
+			height: calc(100vh - 56px); width: 440px;
+			background: var(--bg-base);
+			border-left: 1px solid var(--border);
+			box-shadow: -12px 0 40px rgba(0,0,0,0.12);
+			z-index: 50; overflow-y: auto;
+			transform: translateX({drawerOpen ? '0' : '100%'});
+			transition: transform 0.24s cubic-bezier(0.4, 0, 0.2, 1);
+		"
+	>
+		{#if selectedEvent}
+			<div style="padding: 24px 28px 48px;">
+				<!-- Drawer header -->
+				<div style="display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 18px;">
+					<div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap; flex: 1; min-width: 0;">
+						<h2 style="font-size: 20px; font-weight: 700; letter-spacing: -0.02em; font-family: 'DM Mono', 'JetBrains Mono', monospace; color: var(--text-primary); margin: 0;">
+							{selectedEvent.event_type}
+						</h2>
+						{#if selectedEvent.phase}
+							<span style="font-size: 11px; font-weight: 500; color: var(--text-secondary); background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 4px; padding: 3px 8px; flex-shrink: 0;">
+								{selectedEvent.phase}
+							</span>
+						{/if}
+						{#if selectedEvent.can_block}
+							<span style="display: inline-flex; align-items: center; gap: 4px; font-size: 10px; font-weight: 700; color: var(--error); background: var(--error-subtle); border: 1px solid rgba(209,78,43,0.25); border-radius: 4px; padding: 3px 8px; flex-shrink: 0;">
+								<svg width="8" height="8" viewBox="0 0 10 10" fill="none"><path d="M5 1L9 8.5H1L5 1Z" fill="var(--error)" /></svg>
+								CAN BLOCK
+							</span>
+						{/if}
+					</div>
+					<button
+						onclick={closeDrawer}
+						aria-label="Close"
+						style="flex-shrink: 0; margin-left: 12px; margin-top: 2px; background: none; border: none; cursor: pointer; color: var(--text-muted); padding: 4px; border-radius: 4px; line-height: 1; font-size: 18px;"
+					>✕</button>
+				</div>
+
+				<!-- Description -->
+					{#if selectedEvent.description}
 						<div
-							class="p-1.5 rounded-md"
-							style="background-color: {sourceColors.subtle}; color: {sourceColors.color};"
+							style="
+								background: var(--bg-base);
+								border: 1px solid var(--border);
+								border-radius: 6px;
+								padding: 11px 16px;
+								margin-bottom: 28px;
+							"
 						>
-							{#if source.source_type === 'plugin'}
-								<Puzzle size={14} />
+							<p
+								style="font-size: 13px; font-style: italic; color: var(--text-secondary); line-height: 1.6; margin: 0;"
+							>
+								{selectedEvent.description}
+							</p>
+						</div>
+					{/if}
+
+					<!-- Registrations section -->
+					<div style="margin-bottom: 28px;">
+						<div style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px;">
+							<span
+								style="
+									font-size: 11px; font-weight: 700; letter-spacing: 0.08em;
+									text-transform: uppercase; color: var(--text-primary);
+								"
+							>
+								Registrations
+							</span>
+							<span
+								style="
+									font-size: 11px; font-weight: 700;
+									padding: 2px 8px; border-radius: 4px;
+									background: {selectedEvent.total_registrations > 0 ? 'var(--accent)' : 'var(--bg-muted)'};
+									color: {selectedEvent.total_registrations > 0 ? '#fff' : 'var(--text-muted)'};
+								"
+							>
+								{selectedEvent.total_registrations}
+							</span>
+						</div>
+
+						{#if selectedEvent.total_registrations === 0}
+							<div
+								style="
+									border: 1.5px dashed var(--border);
+									border-radius: 8px; padding: 32px 24px;
+									text-align: center;
+								"
+							>
+								<p
+									style="font-size: 13px; color: var(--text-secondary); font-weight: 500; margin: 0 0 4px;"
+								>
+									No active registrations
+								</p>
+								<p style="font-size: 11px; color: var(--text-muted); margin: 0;">
+									This event has no registered handlers
+								</p>
+								{#if selectedEvent.can_block}
+									<p
+										style="font-size: 11px; color: var(--error); margin: 12px 0 0; font-weight: 500;"
+									>
+										This hook can block execution when registered
+									</p>
+								{/if}
+							</div>
+						{:else}
+							<div style="display: flex; flex-direction: column; gap: 10px;">
+								{#each selectedEvent.registrations as reg}
+									{@const color = sourceHexColor(reg.source_type, reg.source_name)}
+									{@const symlink = isSymlink(reg.source_name, reg.script_filename)}
+									<div
+										style="
+											background: var(--bg-base);
+											border: 1px solid var(--border);
+											border-left: 3px solid {color};
+											border-radius: 7px;
+											padding: 14px 16px;
+										"
+									>
+										<!-- Card header -->
+										<div
+											style="
+												display: flex; align-items: center; gap: 8px;
+												flex-wrap: wrap;
+												margin-bottom: 12px;
+											"
+										>
+											<span
+												style="font-size: 13px; font-weight: 600; color: var(--text-primary);"
+											>
+												{reg.source_name}
+											</span>
+											<span
+												style="
+													font-size: 10px; font-weight: 500;
+													padding: 2px 7px; border-radius: 3px;
+													{reg.source_type === 'global'
+														? 'background: rgba(232,124,58,0.1); color: #C07030; border: 1px solid rgba(232,124,58,0.3);'
+														: 'background: rgba(74,126,187,0.1); color: #4A7EBB; border: 1px solid rgba(74,126,187,0.3);'}
+												"
+											>
+												{reg.source_type}
+											</span>
+											{#if reg.script_filename}
+												<span style="color: var(--text-muted); font-size: 11px;">·</span>
+												<button
+													class="script-btn"
+													onclick={() => toggleScript(reg.script_filename!)}
+													title="View source"
+												>
+													{reg.script_filename}
+												</button>
+												<span
+													style="
+														font-size: 10px; font-weight: 500;
+														padding: 2px 7px; border-radius: 3px;
+														{reg.script_language.toLowerCase() === 'python'
+															? 'background: rgba(59,115,172,0.1); color: #3B73AC;'
+															: 'background: var(--bg-muted); color: var(--text-muted);'}
+													"
+												>
+													{langLabel(reg.script_language)}
+												</span>
+												{#if symlink}
+													<span
+														style="font-size: 10px; color: var(--text-muted); font-style: italic;"
+													>
+														symlink
+													</span>
+												{/if}
+											{/if}
+										</div>
+
+										<!-- Command -->
+										<div style="margin-bottom: 10px;">
+											<span
+												style="
+													display: block;
+													font-size: 9px; font-weight: 700;
+													letter-spacing: 0.12em; text-transform: uppercase;
+													color: var(--text-muted);
+													margin-bottom: 5px;
+												"
+											>
+												Command
+											</span>
+											<div style="position: relative;">
+												<pre
+													style="
+														font-family: 'DM Mono', 'JetBrains Mono', monospace;
+														font-size: 11px; color: var(--text-secondary);
+														background: var(--bg-subtle);
+														border: 1px solid var(--border);
+														border-radius: 4px; padding: 9px 40px 9px 12px;
+														margin: 0; word-break: break-all; white-space: pre-wrap;
+													">{reg.command}</pre>
+												<button
+													onclick={async () => {
+														await navigator.clipboard.writeText(reg.command);
+														const btn = document.activeElement as HTMLElement;
+														const orig = btn.textContent;
+														btn.textContent = '✓';
+														setTimeout(() => { if (btn) btn.textContent = orig; }, 1600);
+													}}
+													title="Copy command"
+													style="
+														position: absolute; top: 6px; right: 6px;
+														background: var(--bg-base); border: 1px solid var(--border);
+														border-radius: 4px; padding: 3px 6px;
+														cursor: pointer; font-size: 10px; color: var(--text-muted);
+														line-height: 1;
+													"
+												>⎘</button>
+											</div>
+										</div>
+
+										<!-- Meta row -->
+										<div
+											style="display: flex; align-items: center; gap: 14px; flex-wrap: wrap;"
+										>
+											{#if reg.timeout_ms}
+												<span
+													style="display: flex; align-items: center; gap: 4px; font-size: 11px; color: var(--text-muted);"
+												>
+													<svg width="11" height="11" viewBox="0 0 11 11" fill="none">
+														<circle
+															cx="5.5"
+															cy="5.5"
+															r="4.5"
+															stroke="currentColor"
+															stroke-width="1.2"
+														/>
+														<path
+															d="M5.5 3v2.5l1.5 1"
+															stroke="currentColor"
+															stroke-width="1.2"
+															stroke-linecap="round"
+														/>
+													</svg>
+													timeout:
+													<span
+														style="font-family: 'DM Mono', 'JetBrains Mono', monospace; color: var(--text-secondary);"
+													>
+														{reg.timeout_ms}ms
+													</span>
+												</span>
+											{/if}
+											{#if reg.matcher && reg.matcher !== '*'}
+												<span style="font-size: 11px; color: var(--text-muted);">
+													matcher:
+													<span
+														style="font-family: 'DM Mono', 'JetBrains Mono', monospace; color: var(--text-secondary);"
+													>
+														{reg.matcher}
+													</span>
+												</span>
+											{/if}
+											{#if reg.can_block}
+												<span
+													style="font-size: 11px; color: var(--error); font-weight: 500;"
+												>
+													can block execution
+												</span>
+											{/if}
+										</div>
+
+										<!-- Script source viewer -->
+										{#if reg.script_filename && expandedScript === reg.script_filename}
+											<div style="margin-top: 12px; border-top: 1px solid var(--border); padding-top: 12px;">
+												<div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 6px;">
+													<span style="font-size: 9px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-muted);">
+														Source
+													</span>
+													<button
+														onclick={() => { expandedScript = null; scriptContent = null; }}
+														style="font-size: 10px; color: var(--text-muted); background: none; border: none; cursor: pointer; padding: 0;"
+													>
+														collapse ↑
+													</button>
+												</div>
+												{#if scriptLoading}
+													<div style="font-size: 11px; color: var(--text-muted); padding: 8px 0;">Loading…</div>
+												{:else if scriptContent}
+													<div style="position: relative;">
+														<pre style="
+															font-family: 'DM Mono', 'JetBrains Mono', monospace;
+															font-size: 10.5px; line-height: 1.6;
+															color: var(--text-secondary);
+															background: var(--bg-subtle);
+															border: 1px solid var(--border);
+															border-radius: 5px;
+															padding: 12px 14px;
+															margin: 0;
+															overflow-x: auto;
+															white-space: pre;
+															max-height: 400px;
+															overflow-y: auto;
+														">{scriptContent}</pre>
+														<button
+															onclick={copyScript}
+															title="Copy to clipboard"
+															style="
+																position: absolute; top: 7px; right: 7px;
+																background: var(--bg-base); border: 1px solid var(--border);
+																border-radius: 5px; padding: 4px 8px;
+																cursor: pointer; display: flex; align-items: center; gap: 4px;
+																font-size: 10px; color: {scriptCopied ? '#22c55e' : 'var(--text-muted)'};
+																transition: color 0.15s, border-color 0.15s;
+															"
+														>
+															{#if scriptCopied}
+																<svg width="11" height="11" viewBox="0 0 12 12" fill="none">
+																	<path d="M2 6l3 3 5-5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+																</svg>
+																copied
+															{:else}
+																<svg width="11" height="11" viewBox="0 0 12 12" fill="none">
+																	<rect x="4" y="1" width="7" height="7" rx="1.2" stroke="currentColor" stroke-width="1.2"/>
+																	<path d="M8 8v1.8A1.2 1.2 0 016.8 11H1.2A1.2 1.2 0 010 9.8V4.2A1.2 1.2 0 011.2 3H3" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+																</svg>
+																copy
+															{/if}
+														</button>
+													</div>
+												{/if}
+											</div>
+										{/if}
+									</div>
+								{/each}
+							</div>
+						{/if}
+					</div>
+
+					<!-- ── Contextual Activity Panels ──────────────────────────────── -->
+
+					<!-- B: SessionEnd — reason breakdown -->
+					{#if selectedEvent.event_type === 'SessionEnd'}
+						<div style="margin-bottom: 28px;">
+							<div style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px;">
+								<span style="font-size: 11px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-primary);">
+									Session Activity
+								</span>
+							</div>
+							<div style="background: var(--bg-base); border: 1px solid var(--border); border-radius: 8px; padding: 16px 18px;">
+								<div style="display: flex; align-items: baseline; gap: 6px; margin-bottom: 12px;">
+									<span style="font-size: 28px; font-weight: 700; color: var(--text-primary); font-family: 'JetBrains Mono', monospace; line-height: 1;">
+										{activity.totalSessions.toLocaleString()}
+									</span>
+									<span style="font-size: 12px; color: var(--text-muted);">total sessions ended</span>
+								</div>
+								{#if Object.keys(activity.endReasons).length > 0}
+									<div style="font-size: 10px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-muted); margin-bottom: 8px;">
+										End reasons (tracked sessions)
+									</div>
+									<div style="display: flex; flex-direction: column; gap: 6px;">
+										{#each Object.entries(activity.endReasons).sort((a, b) => b[1] - a[1]) as [reason, count]}
+											{@const label = END_REASON_LABELS[reason] ?? reason}
+											{@const max = Math.max(...Object.values(activity.endReasons))}
+											<div style="display: flex; align-items: center; gap: 8px;">
+												<span style="font-size: 11px; color: var(--text-secondary); min-width: 120px;">{label}</span>
+												<div style="flex: 1; height: 4px; background: var(--bg-muted); border-radius: 2px; overflow: hidden;">
+													<div style="height: 100%; width: {(count / max) * 100}%; background: var(--accent); border-radius: 2px;"></div>
+												</div>
+												<span style="font-size: 11px; font-family: 'JetBrains Mono', monospace; color: var(--text-muted); min-width: 16px; text-align: right;">{count}</span>
+											</div>
+										{/each}
+									</div>
+								{:else}
+									<p style="font-size: 12px; color: var(--text-muted); margin: 0;">No end reasons recorded in tracked sessions yet.</p>
+								{/if}
+							</div>
+						</div>
+					{/if}
+
+					<!-- C: SubagentStart / SubagentStop — invocation stats -->
+					{#if selectedEvent.event_type === 'SubagentStart' || selectedEvent.event_type === 'SubagentStop'}
+						<div style="margin-bottom: 28px;">
+							<div style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px;">
+								<span style="font-size: 11px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-primary);">
+									Subagent Activity
+								</span>
+							</div>
+							<div style="background: var(--bg-base); border: 1px solid var(--border); border-radius: 8px; padding: 16px 18px;">
+								<div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; margin-bottom: {Object.keys(activity.subagentStats.byType).length > 0 ? '16px' : '0'};">
+									<div>
+										<div style="font-size: 22px; font-weight: 700; color: var(--text-primary); font-family: 'JetBrains Mono', monospace; line-height: 1;">
+											{activity.subagentStats.totalInvocations.toLocaleString()}
+										</div>
+										<div style="font-size: 11px; color: var(--text-muted); margin-top: 3px;">all-time spawns</div>
+									</div>
+									<div>
+										<div style="font-size: 22px; font-weight: 700; color: var(--text-primary); font-family: 'JetBrains Mono', monospace; line-height: 1;">
+											{activity.subagentStats.trackedTotal}
+										</div>
+										<div style="font-size: 11px; color: var(--text-muted); margin-top: 3px;">in tracked sessions</div>
+									</div>
+									<div>
+										<div style="font-size: 22px; font-weight: 700; color: var(--text-primary); font-family: 'JetBrains Mono', monospace; line-height: 1;">
+											{activity.subagentStats.sessionsWithAgents}
+										</div>
+										<div style="font-size: 11px; color: var(--text-muted); margin-top: 3px;">sessions with agents</div>
+									</div>
+								</div>
+								{#if Object.keys(activity.subagentStats.byType).length > 0}
+									<div style="border-top: 1px solid var(--border); padding-top: 12px;">
+										<div style="font-size: 10px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-muted); margin-bottom: 8px;">
+											By type
+										</div>
+										<div style="display: flex; flex-wrap: wrap; gap: 6px;">
+											{#each Object.entries(activity.subagentStats.byType).sort((a, b) => b[1] - a[1]) as [type, count]}
+												<span style="font-size: 11px; padding: 3px 10px; background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 4px; color: var(--text-secondary);">
+													{type} <span style="font-family: 'JetBrains Mono', monospace; color: var(--accent);">{count}</span>
+												</span>
+											{/each}
+										</div>
+									</div>
+								{/if}
+							</div>
+						</div>
+					{/if}
+
+					<!-- D: Notification / PermissionRequest — recent messages -->
+					{#if selectedEvent.event_type === 'Notification' || selectedEvent.event_type === 'PermissionRequest'}
+						<div style="margin-bottom: 28px;">
+							<div style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px;">
+								<span style="font-size: 11px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-primary);">
+									Recent Messages
+								</span>
+							</div>
+							{#if activity.recentNotifications.length > 0}
+								<div style="display: flex; flex-direction: column; gap: 8px;">
+									{#each activity.recentNotifications as notif}
+										{@const href = notif.projectEncodedName && notif.slug ? `/projects/${notif.projectEncodedName}/${notif.slug}` : null}
+										<div style="background: var(--bg-base); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 7px; padding: 10px 14px;">
+											<p style="font-size: 12px; color: var(--text-primary); margin: 0 0 6px; line-height: 1.5;">{notif.message}</p>
+											<div style="display: flex; align-items: center; gap: 8px;">
+												{#if href}
+													<a {href} style="font-size: 10px; font-family: 'DM Mono', 'JetBrains Mono', monospace; color: var(--accent); text-decoration: none;" onmouseenter={(e) => (e.currentTarget.style.textDecoration = 'underline')} onmouseleave={(e) => (e.currentTarget.style.textDecoration = 'none')}>
+														{notif.slug}
+													</a>
+												{:else}
+													<span style="font-size: 10px; font-family: 'DM Mono', monospace; color: var(--text-muted);">{notif.sessionId.slice(0, 8)}</span>
+												{/if}
+												<span style="font-size: 10px; color: var(--text-muted);">{timeAgo(notif.updatedAt)}</span>
+											</div>
+										</div>
+									{/each}
+								</div>
 							{:else}
-								<FolderOpen size={14} />
+								<div style="border: 1.5px dashed var(--border); border-radius: 8px; padding: 20px 24px; text-align: center;">
+									<p style="font-size: 12px; color: var(--text-muted); margin: 0;">No notification messages in tracked sessions.</p>
+								</div>
 							{/if}
 						</div>
-					{/snippet}
-					{#snippet metadata()}
-						<div class="flex items-center gap-3">
-							<span class="text-xs text-[var(--text-muted)] tabular-nums">
-								{source.total_registrations} registration{source.total_registrations !==
-								1
-									? 's'
-									: ''}
-							</span>
-							<span class="text-xs text-[var(--text-muted)] tabular-nums">
-								{source.event_types_covered.length} event type{source
-									.event_types_covered.length !== 1
-									? 's'
-									: ''}
-							</span>
-							{#if source.blocking_hooks_count > 0}
+					{/if}
+
+					<!-- Event Schema (collapsible, lazy-loaded) -->
+					{#if detailLoading}
+						<div
+							style="
+								background: var(--bg-base); border: 1px solid var(--border);
+								border-radius: 8px; padding: 13px 18px;
+								font-size: 11px; color: var(--text-muted);
+								margin-bottom: 28px;
+							"
+						>
+							Loading schema…
+						</div>
+					{:else if detailData?.schema_info}
+						{@const schema = detailData.schema_info}
+						<div
+							style="
+								background: var(--bg-base);
+								border: 1px solid var(--border);
+								border-radius: 8px; overflow: hidden;
+								margin-bottom: 28px;
+							"
+						>
+							<!-- Toggle row -->
+							<button
+								onclick={() => (schemaExpanded = !schemaExpanded)}
+								style="
+									width: 100%; display: flex; align-items: center; justify-content: space-between;
+									padding: 13px 18px; cursor: pointer;
+									background: transparent; border: none; text-align: left;
+								"
+							>
 								<span
-									class="
-										px-2 py-0.5
-										text-[10px] font-semibold uppercase tracking-wider
-										bg-[var(--error-subtle)] text-[var(--error)]
-										rounded-full
+									style="
+										font-size: 11px; font-weight: 700; letter-spacing: 0.08em;
+										text-transform: uppercase; color: var(--text-primary);
 									"
 								>
-									{source.blocking_hooks_count} blocking
+									Event Schema
 								</span>
+								<span
+									style="
+										font-size: 16px; color: var(--text-muted);
+										display: inline-block;
+										transform: {schemaExpanded ? 'rotate(90deg)' : 'rotate(0deg)'};
+										transition: transform 0.18s ease;
+									"
+								>
+									›
+								</span>
+							</button>
+
+							{#if schemaExpanded}
+								<div
+									style="
+										border-top: 1px solid var(--border);
+										padding: 18px 18px 20px;
+									"
+								>
+									<!-- Input Fields -->
+									{#if schema.input_fields.length > 0}
+										<div style="margin-bottom: 18px;">
+											<div
+												style="
+													font-size: 10px; font-weight: 600; letter-spacing: 0.1em;
+													text-transform: uppercase; color: var(--text-muted);
+													margin-bottom: 8px;
+												"
+											>
+												Input Fields
+											</div>
+											<div
+												style="border: 1px solid var(--border); border-radius: 5px; overflow: hidden;"
+											>
+												<div
+													style="
+														display: grid; grid-template-columns: 100px 72px 58px 1fr;
+														padding: 6px 12px;
+														background: var(--bg-subtle);
+														border-bottom: 1px solid var(--border);
+													"
+												>
+													{#each ['Field', 'Type', 'Required', 'Description'] as h}
+														<span
+															style="font-size: 10px; font-weight: 600; color: var(--text-muted);"
+															>{h}</span
+														>
+													{/each}
+												</div>
+												{#each schema.input_fields as field}
+													<div
+														style="
+															display: grid; grid-template-columns: 100px 72px 58px 1fr;
+															padding: 9px 12px;
+															border-bottom: 1px solid var(--border);
+															align-items: start;
+														"
+													>
+														<span
+															style="font-family: 'DM Mono', 'JetBrains Mono', monospace; font-size: 11px; font-weight: 500; color: var(--text-primary);"
+															>{field.name}</span
+														>
+														<span
+															style="font-family: 'DM Mono', 'JetBrains Mono', monospace; font-size: 11px; color: var(--accent);"
+															>{field.type}</span
+														>
+														<span>
+															{#if field.required}
+																<span
+																	style="font-size: 10px; font-weight: 600; background: rgba(42,138,80,0.1); color: #2A8A50; border-radius: 3px; padding: 2px 7px;"
+																	>required</span
+																>
+															{:else}
+																<span
+																	style="font-size: 10px; font-weight: 600; background: var(--bg-subtle); color: var(--text-muted); border-radius: 3px; padding: 2px 7px;"
+																	>optional</span
+																>
+															{/if}
+														</span>
+														<span
+															style="font-size: 11px; color: var(--text-secondary); line-height: 1.5;"
+															>{field.description || '—'}</span
+														>
+													</div>
+												{/each}
+											</div>
+										</div>
+									{/if}
+
+									<!-- Output Fields -->
+									{#if schema.output_fields.length > 0}
+										<div style="margin-bottom: 18px;">
+											<div
+												style="
+													font-size: 10px; font-weight: 600; letter-spacing: 0.1em;
+													text-transform: uppercase; color: var(--text-muted);
+													margin-bottom: 8px;
+												"
+											>
+												Output Fields
+											</div>
+											<div
+												style="border: 1px solid var(--border); border-radius: 5px; overflow: hidden;"
+											>
+												<div
+													style="display: grid; grid-template-columns: 100px 72px 58px 1fr; padding: 6px 12px; background: var(--bg-subtle); border-bottom: 1px solid var(--border);"
+												>
+													{#each ['Field', 'Type', 'Required', 'Description'] as h}
+														<span
+															style="font-size: 10px; font-weight: 600; color: var(--text-muted);"
+															>{h}</span
+														>
+													{/each}
+												</div>
+												{#each schema.output_fields as field}
+													<div
+														style="display: grid; grid-template-columns: 100px 72px 58px 1fr; padding: 9px 12px; border-bottom: 1px solid var(--border); align-items: start;"
+													>
+														<span
+															style="font-family: 'DM Mono', 'JetBrains Mono', monospace; font-size: 11px; font-weight: 500; color: var(--text-primary);"
+															>{field.name}</span
+														>
+														<span
+															style="font-family: 'DM Mono', 'JetBrains Mono', monospace; font-size: 11px; color: var(--accent);"
+															>{field.type}</span
+														>
+														<span>
+															{#if field.required}
+																<span
+																	style="font-size: 10px; font-weight: 600; background: rgba(42,138,80,0.1); color: #2A8A50; border-radius: 3px; padding: 2px 7px;"
+																	>required</span
+																>
+															{:else}
+																<span
+																	style="font-size: 10px; font-weight: 600; background: var(--bg-subtle); color: var(--text-muted); border-radius: 3px; padding: 2px 7px;"
+																	>optional</span
+																>
+															{/if}
+														</span>
+														<span
+															style="font-size: 11px; color: var(--text-secondary); line-height: 1.5;"
+															>{field.description || '—'}</span
+														>
+													</div>
+												{/each}
+											</div>
+										</div>
+									{/if}
+
+									<!-- Base Fields -->
+									{#if schema.base_fields.length > 0}
+										<div>
+											<div
+												style="
+													font-size: 10px; font-weight: 600; letter-spacing: 0.1em;
+													text-transform: uppercase; color: var(--text-muted);
+													margin-bottom: 8px;
+												"
+											>
+												Base Fields
+												<span
+													style="font-weight: 400; text-transform: none; letter-spacing: 0;"
+												>
+													— all hooks share these
+												</span>
+											</div>
+											<div
+												style="border: 1px solid var(--border); border-radius: 5px; overflow: hidden;"
+											>
+												<div
+													style="display: grid; grid-template-columns: 100px 72px 58px 1fr; padding: 6px 12px; background: var(--bg-subtle); border-bottom: 1px solid var(--border);"
+												>
+													{#each ['Field', 'Type', 'Required', 'Description'] as h}
+														<span
+															style="font-size: 10px; font-weight: 600; color: var(--text-muted);"
+															>{h}</span
+														>
+													{/each}
+												</div>
+												{#each schema.base_fields as field}
+													<div
+														style="display: grid; grid-template-columns: 100px 72px 58px 1fr; padding: 9px 12px; border-bottom: 1px solid var(--border); align-items: start;"
+													>
+														<span
+															style="font-family: 'DM Mono', 'JetBrains Mono', monospace; font-size: 11px; font-weight: 500; color: var(--text-primary);"
+															>{field.name}</span
+														>
+														<span
+															style="font-family: 'DM Mono', 'JetBrains Mono', monospace; font-size: 11px; color: var(--text-secondary);"
+															>{field.type}</span
+														>
+														<span>
+															{#if field.required}
+																<span
+																	style="font-size: 10px; font-weight: 600; background: rgba(42,138,80,0.1); color: #2A8A50; border-radius: 3px; padding: 2px 7px;"
+																	>required</span
+																>
+															{:else}
+																<span
+																	style="font-size: 10px; font-weight: 600; background: var(--bg-subtle); color: var(--text-muted); border-radius: 3px; padding: 2px 7px;"
+																	>optional</span
+																>
+															{/if}
+														</span>
+														<span
+															style="font-size: 11px; color: var(--text-secondary); line-height: 1.5;"
+															>{field.description || '—'}</span
+														>
+													</div>
+												{/each}
+											</div>
+										</div>
+									{/if}
+								</div>
 							{/if}
 						</div>
-					{/snippet}
+					{/if}
 
-					<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-						{#each source.scripts as script (script.filename)}
-							<HookScriptCard
-								{script}
-								sourceType={source.source_type}
-								sourceName={source.source_name}
-							/>
-						{/each}
-					</div>
-				</CollapsibleGroup>
-			{/each}
-		</div>
-	{/if}
+					<!-- Related Events -->
+					{#if relatedPrev || relatedNext}
+						<div>
+							<div
+								style="
+									font-size: 11px; font-weight: 700; letter-spacing: 0.08em;
+									text-transform: uppercase; color: var(--text-primary);
+									margin-bottom: 10px;
+								"
+							>
+								Related Events
+							</div>
+							<div style="display: flex; gap: 8px; flex-wrap: wrap;">
+								{#if relatedPrev}
+									<button
+										onclick={() => selectEvent(relatedPrev!.event_type)}
+										style="
+											display: flex; align-items: center; gap: 6px;
+											background: var(--bg-base);
+											border: 1px solid var(--border);
+											border-radius: 6px; padding: 9px 16px;
+											cursor: pointer;
+											transition: border-color 0.15s;
+										"
+										onmouseenter={(e) =>
+											((e.currentTarget as HTMLElement).style.borderColor =
+												'var(--accent)')}
+										onmouseleave={(e) =>
+											((e.currentTarget as HTMLElement).style.borderColor = 'var(--border)')}
+									>
+										<svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+											<path
+												d="M8.5 3L5 7l3.5 4"
+												stroke="var(--text-muted)"
+												stroke-width="1.5"
+												stroke-linecap="round"
+												stroke-linejoin="round"
+											/>
+										</svg>
+										<span
+											style="font-family: 'DM Mono', 'JetBrains Mono', monospace; font-size: 11px; font-weight: 500; color: var(--accent);"
+										>
+											{relatedPrev.event_type}
+										</span>
+									</button>
+								{/if}
+								{#if relatedNext}
+									<button
+										onclick={() => selectEvent(relatedNext!.event_type)}
+										style="
+											display: flex; align-items: center; gap: 6px;
+											background: var(--bg-base);
+											border: 1px solid var(--border);
+											border-radius: 6px; padding: 9px 16px;
+											cursor: pointer;
+											transition: border-color 0.15s;
+										"
+										onmouseenter={(e) =>
+											((e.currentTarget as HTMLElement).style.borderColor =
+												'var(--accent)')}
+										onmouseleave={(e) =>
+											((e.currentTarget as HTMLElement).style.borderColor = 'var(--border)')}
+									>
+										<span
+											style="font-family: 'DM Mono', 'JetBrains Mono', monospace; font-size: 11px; font-weight: 500; color: var(--accent);"
+										>
+											{relatedNext.event_type}
+										</span>
+										<svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+											<path
+												d="M5.5 3L9 7l-3.5 4"
+												stroke="var(--text-muted)"
+												stroke-width="1.5"
+												stroke-linecap="round"
+												stroke-linejoin="round"
+											/>
+										</svg>
+									</button>
+								{/if}
+							</div>
+						</div>
+					{/if}
+				</div>
+		{/if}
+	</div>
 </div>

--- a/frontend/src/routes/mcp/+page.svelte
+++ b/frontend/src/routes/mcp/+page.svelte
@@ -325,7 +325,7 @@
 >
 
 	<!-- ── Page Header ──────────────────────────────────────────────────────── -->
-	<div class="flex-shrink-0" style="padding: 0 24px; background: var(--bg-base);">
+	<div class="flex-shrink-0" style="padding: 32px 24px 0; background: var(--bg-base);">
 		<PageHeader
 			title="MCP Tools"
 			iconName="tools"

--- a/frontend/src/routes/mcp/+page.svelte
+++ b/frontend/src/routes/mcp/+page.svelte
@@ -1,538 +1,847 @@
 <script lang="ts">
 	import {
-		Cable,
-		Wrench,
-		Play,
-		Activity,
 		Search,
-		ChevronsUpDown,
-		ChevronsDownUp,
-		ExternalLink,
-		Puzzle
+		Sparkles,
+		Info,
+		TrendingUp,
+		ChevronRight
 	} from 'lucide-svelte';
+	import { tick } from 'svelte';
 	import { navigating } from '$app/stores';
-	import { listNavigation } from '$lib/actions/listNavigation';
+	import { browser } from '$app/environment';
+	import { replaceState } from '$app/navigation';
 	import PageHeader from '$lib/components/layout/PageHeader.svelte';
-	import SkeletonBox from '$lib/components/skeleton/SkeletonBox.svelte';
-	import SkeletonText from '$lib/components/skeleton/SkeletonText.svelte';
-	import SkeletonStatsCard from '$lib/components/skeleton/SkeletonStatsCard.svelte';
-	import StatsGrid from '$lib/components/StatsGrid.svelte';
-	import SegmentedControl from '$lib/components/ui/SegmentedControl.svelte';
-	import CollapsibleGroup from '$lib/components/ui/CollapsibleGroup.svelte';
-	import Badge from '$lib/components/ui/Badge.svelte';
-	import McpServerIcon from '$lib/components/tools/McpServerIcon.svelte';
-	import McpToolCard from '$lib/components/tools/McpToolCard.svelte';
-	import McpToolTable from '$lib/components/tools/McpToolTable.svelte';
-	import McpContextBar from '$lib/components/tools/McpContextBar.svelte';
-	import { getServerColorVars, getToolItemChartHex, parseBuiltinTool, parseMcpTool } from '$lib/utils/mcp';
-	import UsageAnalytics from '$lib/components/charts/UsageAnalytics.svelte';
-	import type { McpServer, StatItem } from '$lib/api-types';
+	import { getServerColorVars, getToolItemChartHex } from '$lib/utils/mcp';
+	import { API_BASE } from '$lib/config';
+	import type { UsageTrendResponse, McpServer, McpToolSummary } from '$lib/api-types';
 
 	let { data } = $props();
 
-	// Client-side filter state
-	let searchQuery = $state('');
-	let viewMode = $state<'servers' | 'tools' | 'analytics'>('servers');
-	let sourceFilter = $state<'all' | 'plugin' | 'standalone' | 'builtin'>('all');
+	function initParam(key: string, fallback: string): string {
+		if (browser) return new URLSearchParams(window.location.search).get(key) ?? fallback;
+		return fallback;
+	}
 
-	const viewOptions = [
-		{ label: 'By Server', value: 'servers' },
-		{ label: 'All Tools', value: 'tools' },
-		{ label: 'Usage Analytics', value: 'analytics' }
-	];
+	let activeView = $state<'overview' | 'analytics'>(
+		(initParam('view', 'overview') as 'overview' | 'analytics')
+	);
+	let searchQuery = $state(initParam('search', ''));
+	let selectedFilter = $state<'all' | 'builtin' | 'plugin' | 'standalone'>(
+		(initParam('filter', 'all') as 'all' | 'builtin' | 'plugin' | 'standalone')
+	);
+	let selectedServer = $state<string | null>(null);
 
-	const sourceOptions = [
-		{ label: 'All', value: 'all' },
-		{ label: 'Built-in', value: 'builtin' },
-		{ label: 'Plugin', value: 'plugin' },
-		{ label: 'Standalone', value: 'standalone' }
-	];
+	$effect(() => {
+		if (!browser) return;
+		const v = activeView;
+		const f = selectedFilter;
+		const s = searchQuery;
+		tick().then(() => {
+			const url = new URL(window.location.href);
+			if (v !== 'overview') url.searchParams.set('view', v);
+			else url.searchParams.delete('view');
+			if (f !== 'all') url.searchParams.set('filter', f);
+			else url.searchParams.delete('filter');
+			if (s.trim()) url.searchParams.set('search', s.trim());
+			else url.searchParams.delete('search');
+			replaceState(url.toString(), {});
+		});
+	});
 
-	// Hero stats
-	let stats = $derived<StatItem[]>([
-		{
-			title: 'Servers',
-			value: data.overview.total_servers,
-			icon: Cable,
-			color: 'teal'
-		},
-		{
-			title: 'Tools',
-			value: data.overview.total_tools,
-			icon: Wrench,
-			color: 'blue'
-		},
-		{
-			title: 'Total Calls',
-			value: data.overview.total_calls.toLocaleString(),
-			icon: Play,
-			color: 'purple'
-		},
-		{
-			title: 'Sessions',
-			value: data.overview.total_sessions,
-			icon: Activity,
-			color: 'green'
+	// ── Derived data ───────────────────────────────────────────────────────────
+	let allServers = $derived(data.overview.servers ?? []);
+	let totalCalls = $derived(data.overview.total_calls);
+
+	// Left panel: servers sorted by total_calls desc, filtered by chip
+	let leftPanelServers = $derived.by(() => {
+		let servers = allServers;
+		if (selectedFilter === 'builtin') servers = servers.filter(s => s.source === 'builtin');
+		else if (selectedFilter === 'plugin') servers = servers.filter(s => s.source === 'plugin');
+		else if (selectedFilter === 'standalone') servers = servers.filter(s => s.source === 'standalone');
+		return [...servers].sort((a, b) => b.total_calls - a.total_calls);
+	});
+
+	// All tools flattened from all servers
+	interface FlatTool {
+		tool: McpToolSummary;
+		server: McpServer;
+	}
+
+	let allToolsFlat = $derived.by<FlatTool[]>(() => {
+		const out: FlatTool[] = [];
+		for (const server of allServers) {
+			for (const tool of server.tools) {
+				out.push({ tool, server });
+			}
 		}
-	]);
+		return out.sort((a, b) => b.tool.calls - a.tool.calls);
+	});
 
-	// Filtered servers
-	let filteredServers = $derived.by(() => {
-		let servers = data.overview.servers;
+	// Right panel tools, filtered by server selection + filter chips + search
+	let rightPanelTools = $derived.by<FlatTool[]>(() => {
+		let tools = allToolsFlat;
 
-		if (sourceFilter !== 'all') {
-			servers = servers.filter((s) => s.source === sourceFilter);
+		if (selectedServer !== null) {
+			tools = tools.filter(t => t.server.name === selectedServer);
 		}
+
+		if (selectedFilter === 'builtin') tools = tools.filter(t => t.server.source === 'builtin');
+		else if (selectedFilter === 'plugin') tools = tools.filter(t => t.server.source === 'plugin');
+		else if (selectedFilter === 'standalone') tools = tools.filter(t => t.server.source === 'standalone');
 
 		if (searchQuery.trim()) {
 			const q = searchQuery.toLowerCase();
-			return servers
-				.map((server) => {
-					// Check if server name matches query (show all tools)
-					const nameMatches =
-						server.display_name.toLowerCase().includes(q) ||
-						server.name.toLowerCase().includes(q);
-
-					if (nameMatches) {
-						return server;
-					}
-
-					// Filter tools
-					const matchingTools = server.tools.filter((t) =>
-						t.name.toLowerCase().includes(q)
-					);
-
-					// Return server with filtered tools if any match
-					if (matchingTools.length > 0) {
-						return { ...server, tools: matchingTools };
-					}
-
-					return null;
-				})
-				.filter((s) => s !== null); // Remove nulls (servers with no matches)
+			tools = tools.filter(t =>
+				t.tool.name.toLowerCase().includes(q) ||
+				t.server.display_name.toLowerCase().includes(q)
+			);
 		}
 
-		return servers;
+		return tools;
 	});
 
-	// Expand/collapse state
-	let expandedServers = $state<Set<string>>(new Set());
-	let previousExpandedServers = $state<Set<string> | null>(null);
-
-	// Auto-expand/restore logic
-	$effect(() => {
-		const hasSearch = searchQuery.trim().length > 0;
-
-		if (hasSearch) {
-			if (previousExpandedServers === null) {
-				previousExpandedServers = new Set(expandedServers);
-			}
-			if (filteredServers.length > 0) {
-				expandedServers = new Set(filteredServers.map((s) => s.name));
-			}
-		} else {
-			if (previousExpandedServers !== null) {
-				expandedServers = previousExpandedServers;
-				previousExpandedServers = null;
-			}
-		}
-	});
-
-	// All sections collapsed by default — user can expand individually or use Expand All
-
-	function toggleServer(name: string) {
-		if (expandedServers.has(name)) {
-			expandedServers.delete(name);
-		} else {
-			expandedServers.add(name);
-		}
-		expandedServers = new Set(expandedServers);
-	}
-
-	let allExpanded = $derived(
-		filteredServers.length > 0 && filteredServers.every((s) => expandedServers.has(s.name))
+	let globalMax = $derived(
+		rightPanelTools.length > 0 ? Math.max(...rightPanelTools.map(t => t.tool.calls), 1) : 1
 	);
 
-	function toggleAllGroups() {
-		if (allExpanded) {
-			expandedServers = new Set();
-		} else {
-			expandedServers = new Set(filteredServers.map((s) => s.name));
-		}
-	}
+	// ── Analytics data ─────────────────────────────────────────────────────────
+	let trendRange = $state<'7d' | '30d' | '90d'>('90d');
+	let trendData = $state<UsageTrendResponse | null>(null);
+	let trendLoading = $state(false);
+	let trendRangeUserOverride = $state(false);
 
-	// Max calls across all tools (for tier badge computation)
-	let globalMaxCalls = $derived.by(() => {
-		let max = 0;
-		for (const server of data.overview.servers) {
-			for (const tool of server.tools) {
-				if (tool.calls > max) max = tool.calls;
-			}
-		}
-		return max || 100;
+	const periodMap: Record<'7d' | '30d' | '90d', string> = { '7d': 'week', '30d': 'month', '90d': 'quarter' };
+
+	$effect(() => {
+		if (!browser || activeView !== 'analytics') return;
+		trendLoading = true;
+		const url = new URL(`${API_BASE}/tools/usage/trend`);
+		url.searchParams.set('period', periodMap[trendRange]);
+		fetch(url)
+			.then(r => r.json())
+			.then(d => {
+				trendData = d;
+				if (!trendRangeUserOverride) {
+					const total = (d as UsageTrendResponse)?.total ?? 0;
+					if (total === 0 && trendRange === '90d') trendRange = '30d';
+					else if (total === 0 && trendRange === '30d') trendRange = '7d';
+				}
+			})
+			.catch(() => {})
+			.finally(() => { trendLoading = false; });
 	});
 
-	// Build a source lookup from server data for analytics filtering
-	let toolSourceMap = $derived.by(() => {
-		const map = new Map<string, string>();
-		for (const server of data.overview.servers) {
+	// Build lookup: tool full_name → { serverName, displayName, color }
+	let toolServerMap = $derived.by(() => {
+		const map = new Map<string, { serverName: string; displayName: string; color: string }>();
+		for (const server of allServers) {
+			const { color } = getServerColorVars(server.name, server.plugin_name);
 			for (const tool of server.tools) {
-				map.set(tool.full_name, server.source);
+				map.set(tool.full_name, { serverName: server.name, displayName: server.display_name, color });
 			}
 		}
 		return map;
 	});
 
-	let excludeFn = $derived.by(() => {
-		if (sourceFilter === 'all') return undefined;
-		return (name: string) => toolSourceMap.get(name) !== sourceFilter;
+	// Rebuild daily totals for the trend chart
+	let trendPoints = $derived.by(() => {
+		if (!trendData) return [];
+		return [...trendData.trend].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 	});
 
-	let hasServers = $derived(data.overview.servers.length > 0);
-	let hasFiltered = $derived(filteredServers.length > 0);
+	// ── Stacked chart helpers ─────────────────────────────────────────────────
+	function catmullRomPath(pts: {x: number, y: number}[]): string {
+		if (pts.length < 2) return '';
+		let d = `M ${pts[0].x.toFixed(1)},${pts[0].y.toFixed(1)}`;
+		for (let i = 0; i < pts.length - 1; i++) {
+			const p0 = pts[Math.max(0, i - 1)];
+			const p1 = pts[i];
+			const p2 = pts[i + 1];
+			const p3 = pts[Math.min(pts.length - 1, i + 2)];
+			const cp1x = p1.x + (p2.x - p0.x) / 6;
+			const cp1y = p1.y + (p2.y - p0.y) / 6;
+			const cp2x = p2.x - (p3.x - p1.x) / 6;
+			const cp2y = p2.y - (p3.y - p1.y) / 6;
+			d += ` C ${cp1x.toFixed(1)},${cp1y.toFixed(1)} ${cp2x.toFixed(1)},${cp2y.toFixed(1)} ${p2.x.toFixed(1)},${p2.y.toFixed(1)}`;
+		}
+		return d;
+	}
+
+	function stackedAreaPath(topPts: {x:number,y:number}[], botPts: {x:number,y:number}[] | null, baseY: number): { line: string; area: string } {
+		const line = catmullRomPath(topPts);
+		if (!botPts) {
+			const last = topPts[topPts.length - 1];
+			const first = topPts[0];
+			return { line, area: `${line} L ${last.x.toFixed(1)},${baseY} L ${first.x.toFixed(1)},${baseY} Z` };
+		}
+		const revBot = [...botPts].reverse();
+		const revLine = catmullRomPath(revBot);
+		const revFirst = revBot[0];
+		return { line, area: `${line} L ${revFirst.x.toFixed(1)},${revFirst.y.toFixed(1)} ${revLine.replace(/^M [^C]*C/, 'C')} Z` };
+	}
+
+	let stackedChartData = $derived.by(() => {
+		if (!trendData?.trend_by_item || trendPoints.length === 0) return null;
+		const dates = trendPoints.map(p => p.date);
+		const cX1 = 48, cX2 = 892, cY1 = 8, cY2 = 156;
+		const cW = cX2 - cX1, cH = cY2 - cY1;
+
+		// Group trend_by_item by server
+		const groupMap = new Map<string, { label: string; color: string; counts: number[] }>();
+		for (const [toolName, toolPts] of Object.entries(trendData.trend_by_item)) {
+			const serverInfo = toolServerMap.get(toolName);
+			if (!serverInfo) continue;
+			const key = serverInfo.serverName;
+			const color = serverInfo.color;
+			if (!groupMap.has(key)) groupMap.set(key, { label: serverInfo.displayName, color, counts: new Array(dates.length).fill(0) });
+			const ptMap = new Map(toolPts.map(p => [p.date, p.count]));
+			const g = groupMap.get(key)!;
+			dates.forEach((d, i) => { g.counts[i] += ptMap.get(d) ?? 0; });
+		}
+
+		const groups = [...groupMap.values()].sort((a, b) =>
+			b.counts.reduce((s, v) => s + v, 0) - a.counts.reduce((s, v) => s + v, 0)
+		);
+		if (groups.length === 0) return null;
+
+		const dailyTotals = dates.map((_, i) => groups.reduce((s, g) => s + g.counts[i], 0));
+		const yMax = Math.max(...dailyTotals, 1);
+		const xi = (i: number) => cX1 + (i / Math.max(dates.length - 1, 1)) * cW;
+		const yv = (v: number) => cY2 - (v / yMax) * cH;
+
+		const cumulative = new Array(dates.length).fill(0);
+		const layers = groups.map((g, idx) => {
+			const prevCum = [...cumulative];
+			dates.forEach((_, i) => { cumulative[i] += g.counts[i]; });
+			const topPts = dates.map((_, i) => ({ x: xi(i), y: yv(cumulative[i]) }));
+			const botPts = idx === 0 ? null : dates.map((_, i) => ({ x: xi(i), y: yv(prevCum[i]) }));
+			const { line, area } = stackedAreaPath(topPts, botPts, cY2);
+			return { ...g, topPts, line, area, gradId: `mcpsg${idx}` };
+		});
+
+		const peakIdx = dailyTotals.reduce((mi, v, i) => v > dailyTotals[mi] ? i : mi, 0);
+		const totalInv = dailyTotals.reduce((s, v) => s + v, 0);
+		const xIdxs = dates.length <= 7 ? dates.map((_, i) => i)
+			: [0, Math.floor(dates.length * 0.25), Math.floor(dates.length * 0.5), Math.floor(dates.length * 0.75), dates.length - 1];
+
+		return {
+			layers,
+			groups,
+			dates,
+			dailyTotals,
+			peakX: xi(peakIdx),
+			peakY: yv(dailyTotals[peakIdx]),
+			peakVal: dailyTotals[peakIdx],
+			peakDate: new Date(dates[peakIdx] + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+			totalInv,
+			avgPerDay: (totalInv / dates.length).toFixed(1),
+			yMax,
+			yTicks: [1, 0.67, 0.33, 0].map(f => ({ y: cY2 - f * cH, val: Math.round(yMax * f) })),
+			xLabels: xIdxs.map(i => ({
+				x: xi(i),
+				label: new Date(dates[i] + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+				anchor: (i === 0 ? 'start' : i === dates.length - 1 ? 'end' : 'middle') as 'start' | 'end' | 'middle'
+			})),
+			xi,
+			cX1, cX2, cY1, cY2
+		};
+	});
+
+	// ── Chart tooltip state ───────────────────────────────────────────────────
+	let chartHoverIdx = $state<number | null>(null);
+	let chartSvgEl = $state<SVGSVGElement | null>(null);
+
+	function handleChartMouseMove(e: MouseEvent) {
+		if (!stackedChartData || !chartSvgEl) return;
+		const rect = chartSvgEl.getBoundingClientRect();
+		const scaleX = 900 / rect.width;
+		const mx = (e.clientX - rect.left) * scaleX;
+		const { dates, xi, cX1, cX2 } = stackedChartData;
+		if (mx < cX1 - 10 || mx > cX2 + 10) { chartHoverIdx = null; return; }
+		let best = 0, bestDist = Infinity;
+		dates.forEach((_, i) => { const d = Math.abs(xi(i) - mx); if (d < bestDist) { bestDist = d; best = i; } });
+		chartHoverIdx = best;
+	}
+
+	let tooltipData = $derived.by(() => {
+		if (chartHoverIdx === null || !stackedChartData) return null;
+		const i = chartHoverIdx;
+		const date = new Date(stackedChartData.dates[i] + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+		const total = stackedChartData.dailyTotals[i];
+		const rows = stackedChartData.layers
+			.filter(l => l.counts[i] > 0)
+			.map(l => ({ label: l.label, count: l.counts[i], color: l.color }))
+			.sort((a, b) => b.count - a.count);
+		return { date, total, rows, x: stackedChartData.xi(i) };
+	});
+
+	// ── Session reach (analytics left panel) ─────────────────────────────────
+	let sessionReachServers = $derived(
+		[...allServers].sort((a, b) => b.session_count - a.session_count).slice(0, 8)
+	);
+	let sessionReachMax = $derived(sessionReachServers.length > 0 ? sessionReachServers[0].session_count : 1);
+
+	// ── Top by volume (analytics right panel) ────────────────────────────────
+	let topByVolume = $derived(
+		[...allServers].sort((a, b) => b.total_calls - a.total_calls).slice(0, 5)
+	);
+	let volumeMax = $derived(topByVolume.length > 0 ? topByVolume[0].total_calls : 1);
+
+	// ── Insight banner ────────────────────────────────────────────────────────
+	let topServer = $derived.by(() => {
+		if (allServers.length === 0) return null;
+		return [...allServers].sort((a, b) => b.total_calls - a.total_calls)[0];
+	});
+
+	let insightText = $derived.by(() => {
+		if (!topServer) return null;
+		const serverCount = data.overview.total_servers;
+		const toolCount = data.overview.total_tools;
+		return {
+			bold: `${serverCount} server${serverCount !== 1 ? 's' : ''} · ${toolCount} tool${toolCount !== 1 ? 's' : ''}`,
+			rest: ` · ${topServer.display_name} leads with ${topServer.total_calls.toLocaleString()} calls`
+		};
+	});
+
+	// ── Accordion state ────────────────────────────────────────────────────────
+	let coverageOpen = $state(false);
 
 	let isPageLoading = $derived(!!$navigating && $navigating.to?.route.id === '/mcp');
 </script>
 
-<div class="space-y-8">
-	{#if isPageLoading}
-		<div class="space-y-8" role="status" aria-busy="true" aria-label="Loading...">
-			<!-- Page Header skeleton -->
-			<div>
-				<div class="flex items-center gap-2 mb-2">
-					<SkeletonText width="70px" size="xs" />
-					<span class="text-[var(--text-muted)]">/</span>
-					<SkeletonText width="50px" size="xs" />
-				</div>
-				<div class="flex items-center gap-4">
-					<SkeletonBox width="48px" height="48px" rounded="lg" />
-					<div>
-						<SkeletonText width="80px" size="xl" class="mb-2" />
-						<SkeletonText width="300px" size="sm" />
-					</div>
-				</div>
-			</div>
+{#if isPageLoading}
+	<div class="-mx-6 -my-8 flex items-center justify-center" style="height: calc(100vh - 56px);">
+		<div class="flex flex-col items-center gap-3">
+			<div style="width: 28px; height: 28px; border: 2px solid var(--accent); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
+			<span class="text-sm text-[var(--text-muted)]">Loading MCP tools…</span>
+		</div>
+	</div>
+{:else}
 
-			<!-- Hero Stats skeleton -->
-			<div
-				class="relative overflow-hidden rounded-2xl p-8 border border-[var(--border)]"
-				style="background: linear-gradient(135deg, rgba(8, 145, 178, 0.02) 0%, rgba(8, 145, 178, 0.06) 100%);"
+<!-- ── Full-bleed split-view container ────────────────────────────────────── -->
+<div
+	class="-mx-6 -my-8 flex flex-col"
+	style="{activeView === 'overview' ? 'height: calc(100vh - 56px); overflow: hidden;' : ''}"
+>
+
+	<!-- ── Page Header ──────────────────────────────────────────────────────── -->
+	<div class="flex-shrink-0" style="padding: 0 24px; background: var(--bg-base);">
+		<PageHeader
+			title="MCP Tools"
+			iconName="tools"
+			iconColor="--nav-indigo"
+			breadcrumbs={[{ label: 'Dashboard', href: '/' }, { label: 'MCP Tools' }]}
+			subtitle="Which tools is Claude actually reaching for?"
+		/>
+	</div>
+
+	<!-- ── Filter bar — always visible ─────────────────────────────────────── -->
+	<div
+		class="flex flex-shrink-0 items-center"
+		style="padding: 8px 12px; gap: 10px; {activeView === 'analytics' ? 'position: sticky; top: 56px; z-index: 10; background: var(--bg-base); border-bottom: 1px solid var(--border-subtle);' : ''}"
+	>
+		<!-- Left group: view tabs — fixed width matching left panel -->
+		<div
+			class="flex rounded-lg p-0.5 flex-shrink-0"
+			style="width: 280px; background: var(--bg-muted);"
+			role="tablist"
+			aria-label="View"
+		>
+			{#each ([['overview', 'Overview'], ['analytics', 'Analytics']] as const) as [val, lbl]}
+				<button
+					role="tab"
+					aria-selected={activeView === val}
+					onclick={() => activeView = val}
+					class="flex-1 rounded-md transition-all"
+					style="
+						padding: 4px 8px;
+						font-size: 11px;
+						font-weight: {activeView === val ? '600' : '500'};
+						color: {activeView === val ? 'var(--bg-base)' : 'var(--text-secondary)'};
+						background: {activeView === val ? 'var(--text-primary)' : 'transparent'};
+					"
+				>{lbl}</button>
+			{/each}
+		</div>
+
+		<!-- Right group: source chips + search -->
+		<div class="flex items-center gap-2 flex-1">
+			<div class="flex items-center gap-1.5">
+				{#each ([['all', 'All'], ['builtin', 'Built-in'], ['plugin', 'Plugin'], ['standalone', 'Standalone']] as const) as [val, lbl]}
+					<button
+						onclick={() => selectedFilter = val}
+						class="rounded-full transition-all"
+						style="
+							padding: 4px 12px;
+							font-size: 11px;
+							font-weight: {selectedFilter === val ? '600' : '500'};
+							color: {selectedFilter === val ? 'var(--accent)' : 'var(--text-secondary)'};
+							background: {selectedFilter === val ? 'var(--accent-muted)' : 'transparent'};
+							border: {selectedFilter === val ? '1.5px solid var(--accent-subtle)' : '1px solid var(--border)'};
+						"
+					>{lbl}</button>
+				{/each}
+			</div>
+			<div class="relative ml-auto">
+				<Search class="absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" size={12} style="color: var(--text-faint);" />
+				<input
+					type="text"
+					bind:value={searchQuery}
+					aria-label="Search tools"
+					placeholder="Search tools…"
+					style="width: 180px; padding: 4px 10px 4px 26px; font-size: 12px; background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 8px; color: var(--text-primary); outline: none;"
+					data-search-input
+				/>
+			</div>
+		</div>
+	</div>
+
+	{#if activeView === 'overview'}
+	<!-- Split view -->
+	<div class="flex flex-1 min-h-0 overflow-hidden" style="padding: 0 12px 12px; gap: 10px;">
+
+		<!-- ── Left Panel: Server Coverage ────────────────────────────────────── -->
+		<div
+			class="flex-shrink-0 flex flex-col"
+			style="width: 280px; background: var(--bg-base); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; align-self: flex-start;"
+		>
+			<!-- Panel header — accordion trigger -->
+			<button
+				class="w-full text-left flex-shrink-0 transition-colors hover:bg-[var(--bg-subtle)]"
+				style="border-bottom: 1px solid {coverageOpen ? 'var(--border-subtle)' : 'transparent'}; padding: 14px 16px 12px;"
+				onclick={() => coverageOpen = !coverageOpen}
 			>
-				<div class="relative grid grid-cols-1 sm:grid-cols-4 gap-4">
-					{#each Array(4) as _}
-						<SkeletonStatsCard />
-					{/each}
-				</div>
-			</div>
-
-			<!-- Filters row skeleton -->
-			<div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-				<div class="flex items-center gap-3 flex-wrap">
-					<div class="flex gap-1">
-						{#each Array(3) as _}
-							<SkeletonBox width="100px" height="36px" rounded="lg" />
-						{/each}
-					</div>
-					<div class="flex gap-1">
-						{#each Array(4) as _}
-							<SkeletonBox width="80px" height="32px" rounded="lg" />
-						{/each}
+				<div class="flex items-center justify-between mb-2">
+					<span style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace;">
+						Server Coverage
+					</span>
+					<div style="color: var(--text-faint); transition: transform 0.2s; transform: rotate({coverageOpen ? 90 : 0}deg);">
+						<ChevronRight size={13} />
 					</div>
 				</div>
-				<div class="flex items-center gap-3">
-					<SkeletonBox width="256px" height="40px" rounded="lg" />
-					<SkeletonBox width="120px" height="40px" rounded="lg" />
+				<!-- Stats row: 3 columns -->
+				<div class="flex items-center w-full">
+					<div class="flex flex-col flex-1 items-center">
+						<span style="font-size: 22px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: var(--text-primary); letter-spacing: -1px;">{data.overview.total_calls.toLocaleString()}</span>
+						<span style="font-size: 9px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.06em;">calls</span>
+					</div>
+					<div style="width: 1px; height: 32px; background: var(--border);"></div>
+					<div class="flex flex-col flex-1 items-center">
+						<span style="font-size: 22px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: var(--text-primary); letter-spacing: -1px;">{data.overview.total_servers}</span>
+						<span style="font-size: 9px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.06em;">servers</span>
+					</div>
+					<div style="width: 1px; height: 32px; background: var(--border);"></div>
+					<div class="flex flex-col flex-1 items-center">
+						<span style="font-size: 22px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: var(--text-primary); letter-spacing: -1px;">{data.overview.total_tools}</span>
+						<span style="font-size: 9px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.06em;">tools</span>
+					</div>
 				</div>
-			</div>
+			</button>
 
-			<!-- Collapsible server groups skeleton -->
-			<div class="space-y-4">
-				{#each Array(3) as _, groupIndex}
-					<div class="border border-[var(--border)] rounded-[var(--radius-lg)] overflow-hidden bg-[var(--bg-base)]">
-						<div class="flex items-center gap-3 px-4 py-4">
-							<SkeletonBox width="16px" height="16px" rounded="sm" />
-							<SkeletonBox width="32px" height="32px" rounded="md" />
-							<SkeletonText width="160px" size="sm" />
-							<div class="flex-1"></div>
-							<SkeletonText width="80px" size="xs" />
-						</div>
-						{#if groupIndex === 0}
-							<div class="border-t border-[var(--border)] p-4">
-								<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-									{#each Array(4) as _}
-										<SkeletonBox height="100px" rounded="md" />
-									{/each}
-								</div>
+			<!-- Server rows — only when accordion is open -->
+			{#if coverageOpen}
+			<div class="flex-1 overflow-y-auto">
+				{#each leftPanelServers as server}
+					{@const colors = getServerColorVars(server.name, server.plugin_name)}
+					{@const pct = totalCalls > 0 ? Math.round((server.total_calls / totalCalls) * 100) : 0}
+					{@const isSelected = selectedServer === server.name}
+					{@const isTop = leftPanelServers[0]?.name === server.name}
+					<div
+						role="button"
+						tabindex="0"
+						onclick={() => selectedServer = isSelected ? null : server.name}
+						onkeydown={(e) => e.key === 'Enter' && (selectedServer = isSelected ? null : server.name)}
+						class="border-b cursor-pointer transition-colors"
+						style="
+							padding: 10px 20px;
+							border-color: var(--border-subtle);
+							background: {isSelected ? 'var(--accent-muted)' : 'transparent'};
+							border-left: {isSelected ? '2px solid var(--accent)' : '2px solid transparent'};
+						"
+					>
+						<!-- Name row -->
+						<div class="flex items-center justify-between gap-2" style="margin-bottom: 6px;">
+							<span class="flex-1 min-w-0 truncate" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;">
+								{server.display_name}
+							</span>
+							<div class="flex items-center gap-1.5 flex-shrink-0">
+								{#if isTop}
+									<TrendingUp size={10} style="color: var(--nav-orange);" />
+								{/if}
+								<span style="font-size: 12px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: {pct > 0 ? 'var(--text-secondary)' : 'var(--text-faint)'};">
+									{pct}%
+								</span>
 							</div>
-						{/if}
+						</div>
+						<!-- Bar + count -->
+						<div class="flex items-center gap-2">
+							<div class="flex-1" style="height: 3px; border-radius: 2px; background: var(--bg-muted); overflow: hidden;">
+								{#if server.total_calls > 0}
+									<div style="height: 100%; border-radius: 2px; width: {pct}%; background: {colors.color}; opacity: 0.7;"></div>
+								{/if}
+							</div>
+							<span style="font-size: 10px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace; flex-shrink: 0;">
+								{server.total_calls.toLocaleString()}
+							</span>
+						</div>
 					</div>
 				{/each}
 			</div>
-		</div>
-	{:else}
-	<!-- Page Header -->
-	<PageHeader
-		title="MCP Servers"
-		iconName="tools"
-		iconColor="--nav-indigo"
-		breadcrumbs={[{ label: 'Dashboard', href: '/' }, { label: 'MCP Servers' }]}
-		subtitle="MCP servers & tools connected to your Claude Code account"
-	/>
 
-	<!-- Hero Stats -->
-	{#if hasServers}
-		<div
-			class="relative overflow-hidden rounded-2xl p-8 border border-[var(--border)]"
-			style="background: linear-gradient(135deg, rgba(8, 145, 178, 0.02) 0%, rgba(8, 145, 178, 0.06) 100%);"
-		>
-			<div
-				class="absolute -top-24 -right-24 w-96 h-96 bg-cyan-500/5 rounded-full blur-3xl pointer-events-none"
-			></div>
-			<div class="relative">
-				<StatsGrid {stats} columns={4} />
-			</div>
-		</div>
-	{/if}
-
-	<!-- Filters Row -->
-	<div
-		class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4"
-		use:listNavigation
-	>
-		<div class="flex items-center gap-3 flex-wrap">
-			<SegmentedControl options={viewOptions} bind:value={viewMode} />
-			<SegmentedControl options={sourceOptions} bind:value={sourceFilter} size="sm" />
-		</div>
-
-		{#if viewMode !== 'analytics'}
-			<div class="flex items-center gap-3 w-full sm:w-auto">
-				<div class="relative flex-1 sm:flex-initial">
-					<Search
-						class="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)]"
-						size={16}
-					/>
-					<input
-						type="text"
-						bind:value={searchQuery}
-						placeholder="Search servers or tools..."
-						class="
-							pl-9 pr-4 py-2
-							bg-[var(--bg-base)]
-							border border-[var(--border)]
-							rounded-lg text-sm
-							focus:outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent)]/20
-							w-full sm:w-64
-							transition-all
-							text-[var(--text-primary)]
-							placeholder:text-[var(--text-faint)]
-						"
-						data-search-input
-					/>
-				</div>
-
-				{#if viewMode === 'servers' && filteredServers.length > 1}
-					<button
-						onclick={toggleAllGroups}
-						class="
-							flex items-center gap-1.5 px-3 py-2
-							text-sm font-medium
-							text-[var(--text-secondary)]
-							hover:text-[var(--text-primary)]
-							bg-[var(--bg-base)]
-							border border-[var(--border)]
-							rounded-lg
-							transition-all
-							hover:bg-[var(--bg-subtle)]
-							whitespace-nowrap
-						"
-						title={allExpanded ? 'Collapse all' : 'Expand all'}
-					>
-						{#if allExpanded}
-							<ChevronsDownUp size={16} />
-							<span class="hidden sm:inline">Collapse All</span>
-						{:else}
-							<ChevronsUpDown size={16} />
-							<span class="hidden sm:inline">Expand All</span>
-						{/if}
+			<!-- Footer -->
+			<div class="flex-shrink-0 border-t flex items-center justify-between" style="padding: 10px 16px; border-color: var(--border-subtle);">
+				<span style="font-size: 10px; color: var(--text-faint);">Sorted by calls</span>
+				{#if selectedServer !== null}
+					<button onclick={() => selectedServer = null} style="font-size: 10px; color: var(--accent); font-weight: 600;">
+						Clear ×
 					</button>
 				{/if}
 			</div>
-		{/if}
+			{/if}
+		</div>
+
+		<!-- ── Right Panel: Top Tools Leaderboard ──────────────────────────────── -->
+		<div class="flex-1 flex flex-col overflow-hidden min-w-0" style="background: var(--bg-base); border: 1px solid var(--border); border-radius: 12px;">
+
+			<!-- Panel header -->
+			<div
+				class="flex-shrink-0 flex items-center justify-between border-b"
+				style="padding: 14px 16px 12px; background: var(--bg-base); border-color: var(--border);"
+			>
+				<div>
+					<div style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace; margin-bottom: 3px;">Top Tools</div>
+					<div style="font-size: 11px; color: var(--text-faint);">
+						{#if selectedServer !== null}
+							{@const srv = allServers.find(s => s.name === selectedServer)}
+							{rightPanelTools.length} tools · {srv?.display_name ?? selectedServer}
+						{:else}
+							{rightPanelTools.length} tools ranked by usage
+						{/if}
+					</div>
+				</div>
+			</div>
+
+			<!-- Table container -->
+			<div class="flex-1 overflow-y-auto">
+				{#if rightPanelTools.length === 0}
+					<div class="flex flex-col items-center justify-center h-full gap-3">
+						<Search size={36} style="color: var(--text-faint);" />
+						<p style="font-size: 13px; color: var(--text-secondary); font-weight: 500;">No matching tools</p>
+						<p style="font-size: 11px; color: var(--text-faint);">Try adjusting filters or search</p>
+					</div>
+				{:else}
+					<!-- Column headers -->
+					<div
+						class="grid sticky top-0 border-b"
+						style="background: var(--bg-base); border-color: var(--border); grid-template-columns: 32px 1fr 160px 100px 56px 64px; padding: 10px 12px 8px;"
+					>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; text-align: center;">#</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase;">Tool</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase;">Server</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; padding: 0 8px;">Calls</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; text-align: right;">Calls</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; text-align: right;">Sessions</div>
+					</div>
+
+					<!-- Tool rows -->
+					{#each rightPanelTools as { tool, server }, i (tool.full_name)}
+						{@const colors = getServerColorVars(server.name, server.plugin_name)}
+						{@const barWidth = Math.round((tool.calls / globalMax) * 100)}
+						{@const useColor = selectedFilter === 'plugin' && server.source === 'plugin'}
+						<a
+							href="/mcp/{encodeURIComponent(server.name)}/{encodeURIComponent(tool.name)}"
+							class="grid border-b transition-colors hover:bg-[var(--bg-subtle)] no-underline"
+							style="grid-template-columns: 32px 1fr 160px 100px 56px 64px; padding: 8px 12px; border-color: var(--border-subtle); align-items: center;"
+						>
+							<div style="font-size: 11px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace; text-align: center;">{i + 1}</div>
+							<div class="min-w-0 pr-3">
+								<span class="truncate block" style="font-size: 13px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;" title={tool.name}>{tool.name}</span>
+							</div>
+							<div class="min-w-0">
+								{#if useColor}
+									<span class="truncate block rounded" style="font-size: 10px; font-weight: 700; font-family: 'JetBrains Mono', monospace; padding: 2px 7px; color: var(--bg-base); background: {colors.color}; display: inline-block; max-width: 100%;" title={server.display_name}>{server.display_name.length > 14 ? server.display_name.slice(0, 13) + '…' : server.display_name}</span>
+								{:else}
+									<span class="truncate block" style="font-size: 11px; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace;" title={server.display_name}>{server.display_name.length > 18 ? server.display_name.slice(0, 17) + '…' : server.display_name}</span>
+								{/if}
+							</div>
+							<div style="padding: 0 8px;">
+								<div style="background: var(--bg-muted); height: 4px; border-radius: 2px; overflow: hidden;">
+									<div style="height: 100%; border-radius: 2px; width: {barWidth}%; background: {useColor ? colors.color : 'var(--accent)'}; opacity: 0.7;"></div>
+								</div>
+							</div>
+							<div style="font-size: 13px; font-weight: 700; font-family: 'JetBrains Mono', monospace; text-align: right; color: {useColor ? colors.color : 'var(--text-primary)'};">{tool.calls}</div>
+							<div style="font-size: 12px; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace; text-align: right;">{tool.session_count}</div>
+						</a>
+					{/each}
+				{/if}
+			</div>
+		</div>
+
 	</div>
 
-	<!-- Content -->
-	{#if !hasServers}
-		<div
-			class="text-center py-20 bg-[var(--bg-subtle)] rounded-2xl border border-dashed border-[var(--border)]"
-		>
-			<Wrench class="mx-auto text-[var(--text-muted)] mb-3" size={48} />
-			<p class="text-[var(--text-secondary)] font-medium">No tools found</p>
-			<p class="text-sm text-[var(--text-muted)] mt-1">
-				Tool usage will appear here once you start using Claude Code
-			</p>
-		</div>
-	{:else if !hasFiltered}
-		<div
-			class="text-center py-20 bg-[var(--bg-subtle)] rounded-2xl border border-dashed border-[var(--border)]"
-		>
-			<Search class="mx-auto text-[var(--text-muted)] mb-3" size={48} />
-			<p class="text-[var(--text-secondary)] font-medium">No matching servers</p>
-			<p class="text-sm text-[var(--text-muted)] mt-1">
-				Try adjusting your search or source filter
-			</p>
-		</div>
-	{:else if viewMode === 'analytics'}
-		<!-- Usage Analytics View -->
-		<UsageAnalytics
-			endpoint="/tools/usage/trend"
-			itemLabel="Tools"
-			colorFn={getToolItemChartHex}
-			excludeItemFn={excludeFn}
-			itemLinkFn={(name) => {
-				const builtin = parseBuiltinTool(name);
-				if (builtin) {
-					return `/tools/${encodeURIComponent(builtin.server)}/${encodeURIComponent(builtin.shortName)}`;
-				}
-				const mcp = parseMcpTool(name);
-				if (mcp) {
-					return `/tools/${encodeURIComponent(mcp.server)}/${encodeURIComponent(mcp.shortName)}`;
-				}
-				return `/tools/${encodeURIComponent(name)}`;
-			}}
-			itemDisplayFn={(name) => {
-				if (parseBuiltinTool(name)) return name;
-				const mcp = parseMcpTool(name);
-				if (mcp) {
-					const server = mcp.server.replace(/^plugin_/, '');
-					return `${server} / ${mcp.shortName}`.replaceAll('_', ' ');
-				}
-				return name.replaceAll('_', ' ');
-			}}
-		/>
-	{:else if viewMode === 'tools'}
-		<!-- Flat Table View -->
-		<McpToolTable servers={filteredServers} />
 	{:else}
-		<!-- Grouped By Server View -->
-		<div class="space-y-4">
-			{#each filteredServers as server (server.name)}
-				{@const colorVars = getServerColorVars(server.name, server.plugin_name)}
-				<CollapsibleGroup
-					title={server.display_name}
-					open={expandedServers.has(server.name)}
-					onOpenChange={() => toggleServer(server.name)}
-					accentColor={colorVars.color}
-				>
-					{#snippet icon()}
-						<div
-							class="p-1.5 rounded-md"
-							style="background-color: {colorVars.subtle}; color: {colorVars.color};"
-						>
-							<McpServerIcon serverName={server.name} size={14} />
-						</div>
-					{/snippet}
 
-					{#snippet metadata()}
-						<div class="flex items-center gap-3">
-							<span class="text-xs text-[var(--text-muted)] tabular-nums">
-								{server.total_calls.toLocaleString()} call{server.total_calls !== 1
-									? 's'
-									: ''} · {server.session_count} session{server.session_count !==
-								1
-									? 's'
-									: ''}
-							</span>
-							{#if server.plugin_name}
-								<a
-									href="/plugins/{encodeURIComponent(server.plugin_name)}"
-									class="
-										inline-flex items-center gap-1 px-2 py-0.5
-										text-[10px] font-medium
-										hover:text-[var(--text-primary)]
-										hover:bg-[var(--bg-muted)]
-										rounded-full
-										transition-colors
-									"
-									style="color: {colorVars.color}; background-color: {colorVars.subtle};"
-									onclick={(e) => e.stopPropagation()}
-									title="View {server.plugin_name} plugin"
-								>
-									<Puzzle size={10} />
-									{server.plugin_name}
-								</a>
-							{:else}
-								<Badge variant="accent" size="sm">
-									{server.source}
-								</Badge>
+	<!-- Analytics view -->
+	<div style="padding: 18px 24px 64px; display: flex; flex-direction: column; gap: 14px;">
+
+		<!-- Insight banner -->
+		{#if insightText}
+			<div class="flex items-center gap-3 rounded-lg" style="padding: 10px 16px; background: linear-gradient(135deg, var(--accent-muted), color-mix(in oklch, var(--accent-muted), var(--bg-subtle) 50%)); border: 1px solid var(--accent-subtle);">
+				<Sparkles size={14} style="color: var(--accent); flex-shrink: 0;" />
+				<span style="font-size: 12px; color: var(--text-primary); line-height: 1.5;">
+					<strong>{insightText.bold}</strong>{insightText.rest}
+				</span>
+			</div>
+		{/if}
+
+		<!-- Stacked area chart -->
+		<div class="rounded-lg" style="padding: 16px 18px; background: var(--bg-base); border: 1px solid var(--border);">
+			<!-- Header -->
+			<div class="flex items-start justify-between" style="margin-bottom: 12px;">
+				<div>
+					<div style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace; margin-bottom: 5px;">Tool Calls Over Time</div>
+					{#if stackedChartData}
+						<div class="flex items-center gap-4">
+							<span style="font-size: 11px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace;"><span style="font-weight: 700; color: var(--text-primary);">{stackedChartData.totalInv}</span> total</span>
+							<span style="font-size: 11px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace;"><span style="font-weight: 700; color: var(--text-primary);">{stackedChartData.avgPerDay}</span>/day avg</span>
+							<span style="font-size: 11px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace;">peak <span style="font-weight: 700; color: var(--text-primary);">{stackedChartData.peakVal}</span> on {stackedChartData.peakDate}</span>
+						</div>
+					{/if}
+				</div>
+				<div class="flex items-center gap-3">
+					<!-- Legend -->
+					{#if stackedChartData}
+						<div class="flex items-center gap-2">
+							{#each stackedChartData.groups.slice(0, 4) as g}
+								<div class="flex items-center gap-1.5">
+									<div style="width: 8px; height: 8px; border-radius: 2px; background: {g.color}; flex-shrink: 0;"></div>
+									<span style="font-size: 10px; color: var(--text-faint);" class="truncate" title={g.label}>{g.label.length > 12 ? g.label.slice(0, 11) + '…' : g.label}</span>
+								</div>
+							{/each}
+							{#if stackedChartData.groups.length > 4}
+								<span style="font-size: 10px; color: var(--text-faint);">+{stackedChartData.groups.length - 4} more</span>
 							{/if}
 						</div>
-					{/snippet}
+					{/if}
+					<!-- Range tabs -->
+					<div class="flex overflow-hidden rounded" style="border: 1px solid var(--border);">
+						{#each (['7d', '30d', '90d'] as const) as r}
+							<button
+								onclick={() => { trendRangeUserOverride = true; trendRange = r; }}
+								style="padding: 4px 10px; font-size: 11px; font-weight: {trendRange === r ? '700' : '500'}; font-family: 'JetBrains Mono', monospace; background: {trendRange === r ? 'var(--accent-muted)' : 'var(--bg-subtle)'}; color: {trendRange === r ? 'var(--accent)' : 'var(--text-faint)'}; {r !== '90d' ? 'border-right: 1px solid var(--border);' : ''}"
+							>{r}</button>
+						{/each}
+					</div>
+				</div>
+			</div>
 
-					<div class="space-y-4">
-						<!-- Server-level context bar -->
-						<div class="flex items-center justify-between">
-							<McpContextBar
-								mainCalls={server.main_calls}
-								subagentCalls={server.subagent_calls}
-								accentColor={colorVars.color}
-							/>
-							<a
-								href="/mcp/{server.name}"
-								class="text-xs text-[var(--accent)] hover:underline flex items-center gap-1"
-							>
-								View details
-								<ExternalLink size={10} />
-							</a>
-						</div>
-
-						<!-- Tool Cards Grid -->
-						<div
-							class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3"
-						>
-							{#each server.tools.slice(0, 12) as tool (tool.full_name)}
-								<a
-									href="/mcp/{encodeURIComponent(
-										server.name
-									)}/{encodeURIComponent(tool.name)}"
-									class="no-underline"
-								>
-									<McpToolCard
-										{tool}
-										serverTotalCalls={server.total_calls}
-										maxCalls={globalMaxCalls}
-										accentColor={colorVars.color}
-									/>
-								</a>
+			<!-- SVG stacked area chart -->
+			{#if trendLoading && !trendData}
+				<div style="height: 188px; display: flex; align-items: center; justify-content: center;">
+					<div style="width: 18px; height: 18px; border: 2px solid var(--accent); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
+				</div>
+			{:else if !stackedChartData}
+				<div style="height: 188px; display: flex; align-items: center; justify-content: center; color: var(--text-faint); font-size: 13px;">No data for this period</div>
+			{:else}
+				<div style="position: relative;">
+					<svg
+						bind:this={chartSvgEl}
+						viewBox="0 0 900 188"
+						style="width: 100%; height: 188px; display: block; overflow: visible; cursor: crosshair;"
+						onmousemove={handleChartMouseMove}
+						onmouseleave={() => chartHoverIdx = null}
+					>
+						<defs>
+							{#each stackedChartData.layers as layer}
+								<linearGradient id={layer.gradId} x1="0" y1="0" x2="0" y2="1">
+									<stop offset="0%" stop-color={layer.color} stop-opacity="0.22" />
+									<stop offset="100%" stop-color={layer.color} stop-opacity="0.03" />
+								</linearGradient>
 							{/each}
-						</div>
+						</defs>
 
-						{#if server.tools.length > 12}
-							<a
-								href="/mcp/{server.name}"
-								class="block text-center text-sm text-[var(--accent)] hover:underline py-2"
-							>
-								+{server.tools.length - 12} more tools →
-							</a>
+						<!-- Gridlines -->
+						{#each stackedChartData.yTicks as tick}
+							<line x1={stackedChartData.cX1} y1={tick.y} x2={stackedChartData.cX2} y2={tick.y} stroke="var(--border)" stroke-width="0.5" />
+							<text x={stackedChartData.cX1 - 5} y={tick.y + 3} text-anchor="end" font-size="9" fill="var(--text-faint)" font-family="JetBrains Mono, monospace">{tick.val}</text>
+						{/each}
+						<line x1={stackedChartData.cX1} y1={stackedChartData.cY2} x2={stackedChartData.cX2} y2={stackedChartData.cY2} stroke="var(--border)" stroke-width="1" />
+
+						<!-- Area fills -->
+						{#each stackedChartData.layers as layer}
+							<path d={layer.area} fill="url(#{layer.gradId})" />
+						{/each}
+
+						<!-- Top lines per layer -->
+						{#each stackedChartData.layers as layer, i}
+							<path d={layer.line} fill="none" stroke={layer.color}
+								stroke-width={i === stackedChartData.layers.length - 1 ? 2 : 1.5}
+								stroke-opacity={i === 0 ? 0.5 : 0.8}
+								stroke-dasharray={i === 0 ? '3 3' : 'none'}
+							/>
+						{/each}
+
+						<!-- Hover crosshair -->
+						{#if chartHoverIdx !== null}
+							{@const hx = stackedChartData.xi(chartHoverIdx)}
+							<line x1={hx} y1={stackedChartData.cY1} x2={hx} y2={stackedChartData.cY2} stroke="var(--text-faint)" stroke-width="1" stroke-dasharray="3 2" opacity="0.6" />
+							{#each stackedChartData.layers as layer}
+								{@const cumY = layer.topPts?.[chartHoverIdx]?.y}
+								{#if cumY !== undefined && layer.counts[chartHoverIdx] > 0}
+									<circle cx={hx} cy={cumY} r="3.5" fill={layer.color} stroke="var(--bg-base)" stroke-width="1.5" />
+								{/if}
+							{/each}
 						{/if}
 
-						<!-- Server footer -->
+						<!-- Peak annotation -->
+						{#if chartHoverIdx !== stackedChartData.peakX}
+							<circle cx={stackedChartData.peakX} cy={stackedChartData.peakY} r="4" fill="var(--accent)" stroke="var(--bg-base)" stroke-width="2" />
+							<text x={stackedChartData.peakX} y={stackedChartData.peakY - 10} text-anchor="middle" font-size="10" fill="var(--accent)" font-family="JetBrains Mono, monospace" font-weight="bold">peak · {stackedChartData.peakVal}</text>
+						{/if}
+
+						<!-- X-axis labels -->
+						{#each stackedChartData.xLabels as xl}
+							<text x={xl.x} y="184" text-anchor={xl.anchor} font-size="9" fill="var(--text-faint)" font-family="JetBrains Mono, monospace">{xl.label}</text>
+						{/each}
+					</svg>
+
+					<!-- Tooltip -->
+					{#if tooltipData && chartHoverIdx !== null}
+						{@const svgWidth = chartSvgEl?.getBoundingClientRect().width ?? 900}
+						{@const tipX = (tooltipData.x / 900) * svgWidth}
+						{@const flipLeft = tipX > svgWidth * 0.65}
 						<div
-							class="flex items-center gap-4 text-xs text-[var(--text-faint)] pt-2 border-t border-[var(--border)]"
+							style="
+								position: absolute;
+								top: 0;
+								left: {tipX}px;
+								transform: translate({flipLeft ? 'calc(-100% - 10px)' : '10px'}, 4px);
+								pointer-events: none;
+								z-index: 20;
+								background: var(--bg-base);
+								border: 1px solid var(--border);
+								border-radius: 8px;
+								padding: 9px 12px;
+								min-width: 150px;
+								box-shadow: 0 4px 16px rgba(0,0,0,0.18);
+							"
 						>
-							<span>Source: {server.source}</span>
-							{#if server.first_used}
-								<span
-									>First: {new Date(server.first_used).toLocaleDateString()}</span
-								>
-							{/if}
-							{#if server.last_used}
-								<span>Last: {new Date(server.last_used).toLocaleDateString()}</span>
+							<div class="flex items-baseline justify-between gap-4" style="margin-bottom: 7px;">
+								<span style="font-size: 11px; font-weight: 700; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;">{tooltipData.date}</span>
+								<span style="font-size: 11px; font-weight: 700; color: var(--accent); font-family: 'JetBrains Mono', monospace;">{tooltipData.total}</span>
+							</div>
+							{#if tooltipData.rows.length > 0}
+								<div style="border-top: 1px solid var(--border-subtle); padding-top: 6px; display: flex; flex-direction: column; gap: 4px;">
+									{#each tooltipData.rows as row}
+										<div class="flex items-center justify-between gap-3">
+											<div class="flex items-center gap-1.5 min-w-0">
+												<div style="width: 7px; height: 7px; border-radius: 2px; background: {row.color}; flex-shrink: 0;"></div>
+												<span class="truncate" style="font-size: 10px; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace;" title={row.label}>{row.label.length > 16 ? row.label.slice(0, 15) + '…' : row.label}</span>
+											</div>
+											<span style="font-size: 10px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace; flex-shrink: 0;">{row.count}</span>
+										</div>
+									{/each}
+								</div>
+							{:else}
+								<div style="font-size: 10px; color: var(--text-faint); padding-top: 4px;">No activity</div>
 							{/if}
 						</div>
-					</div>
-				</CollapsibleGroup>
-			{/each}
+					{/if}
+				</div>
+			{/if}
 		</div>
+
+		<!-- Bottom row: Session Reach + Top by Volume -->
+		<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 14px; align-items: start;">
+
+			<!-- Session Reach panel -->
+			<div class="rounded-lg" style="padding: 16px 18px; background: var(--bg-base); border: 1px solid var(--border);">
+				<div style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace; margin-bottom: 2px;">Session Reach</div>
+				<div style="font-size: 11px; color: var(--text-faint); margin-bottom: 14px;">which servers appear across most sessions</div>
+
+				{#if sessionReachServers.length === 0}
+					<div style="color: var(--text-faint); font-size: 12px; padding: 12px 0;">No data</div>
+				{:else}
+					<!-- Column headers -->
+					<div style="display: grid; grid-template-columns: 1fr 80px 44px; gap: 8px; padding: 0 4px; margin-bottom: 6px;">
+						<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase;">Server</div>
+						<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase; text-align: center;">sessions</div>
+						<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase; text-align: right;">count</div>
+					</div>
+					<div style="border-top: 1px solid var(--border-subtle); padding-top: 4px;">
+						{#each sessionReachServers as server}
+							{@const colors = getServerColorVars(server.name, server.plugin_name)}
+							{@const barPct = Math.round((server.session_count / sessionReachMax) * 100)}
+							<a
+								href="/mcp/{encodeURIComponent(server.name)}"
+								class="no-underline"
+								style="display: grid; grid-template-columns: 1fr 80px 44px; gap: 8px; align-items: center; padding: 5px 4px; border-radius: 4px; cursor: pointer;"
+								onmouseenter={(e) => (e.currentTarget as HTMLElement).style.background = 'var(--bg-subtle)'}
+								onmouseleave={(e) => (e.currentTarget as HTMLElement).style.background = 'transparent'}
+							>
+								<div class="flex items-center gap-1.5 min-w-0">
+									<div style="width: 5px; height: 5px; border-radius: 50%; background: {colors.color}; flex-shrink: 0;"></div>
+									<span class="truncate" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;" title={server.display_name}>{server.display_name}</span>
+								</div>
+								<div style="background: var(--bg-muted); height: 5px; border-radius: 3px; overflow: hidden;">
+									<div style="height: 100%; border-radius: 3px; width: {barPct}%; background: var(--accent);"></div>
+								</div>
+								<div style="font-size: 10px; font-weight: 700; color: var(--text-faint); text-align: right; font-family: 'JetBrains Mono', monospace;">{server.session_count}</div>
+							</a>
+						{/each}
+					</div>
+					<div style="margin-top: 10px; border-top: 1px solid var(--border-subtle); padding-top: 8px; font-size: 10px; color: var(--text-faint); line-height: 1.5;">
+						Sessions count unique conversations that triggered each server's tools
+					</div>
+				{/if}
+			</div>
+
+			<!-- Top by Volume panel -->
+			<div class="rounded-lg" style="padding: 16px 18px; background: var(--bg-base); border: 1px solid var(--border);">
+				<div style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace; margin-bottom: 2px;">Top by Volume</div>
+				<div style="font-size: 11px; color: var(--text-faint); margin-bottom: 14px;">across {data.overview.total_calls.toLocaleString()} total calls this period</div>
+
+				{#if topByVolume.length === 0}
+					<div style="color: var(--text-faint); font-size: 12px; padding: 12px 0;">No data</div>
+				{:else}
+					<!-- Column headers -->
+					<div style="display: grid; grid-template-columns: 1fr 1fr 40px; gap: 10px; padding: 0 4px; margin-bottom: 6px;">
+						<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase;">Server</div>
+						<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase;">Call share</div>
+						<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase; text-align: right;">Calls</div>
+					</div>
+
+					{#each topByVolume as server}
+						{@const colors = getServerColorVars(server.name, server.plugin_name)}
+						{@const pct = totalCalls > 0 ? Math.round((server.total_calls / totalCalls) * 100) : 0}
+						{@const barPct = Math.round((server.total_calls / volumeMax) * 100)}
+						<a
+							href="/mcp/{encodeURIComponent(server.name)}"
+							class="no-underline"
+							style="display: grid; grid-template-columns: 1fr 1fr 40px; gap: 10px; align-items: center; padding: 7px 4px; border-radius: 5px; cursor: pointer;"
+							onmouseenter={(e) => (e.currentTarget as HTMLElement).style.background = 'color-mix(in oklch, var(--nav-indigo) 6%, transparent)'}
+							onmouseleave={(e) => (e.currentTarget as HTMLElement).style.background = 'transparent'}
+						>
+							<div class="truncate" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;" title={server.display_name}>{server.display_name}</div>
+							<div style="background: color-mix(in oklch, var(--nav-indigo) 15%, transparent); height: 7px; border-radius: 4px; overflow: hidden;">
+								<div style="background: {colors.color}; width: {barPct}%; height: 7px;"></div>
+							</div>
+							<div style="font-size: 12px; font-weight: 700; color: var(--text-primary); text-align: right; font-family: 'JetBrains Mono', monospace;">{server.total_calls.toLocaleString()}</div>
+						</a>
+					{/each}
+
+					<div style="margin-top: 12px; border-top: 1px solid var(--border-subtle); padding-top: 8px; font-size: 10px; color: var(--text-faint); line-height: 1.6;">
+						Main vs subagent calls distribution shown above
+					</div>
+				{/if}
+			</div>
+
+		</div>
+
+	</div>
+
 	{/if}
-	{/if}
+
 </div>
+
+{/if}

--- a/frontend/src/routes/skills/+page.svelte
+++ b/frontend/src/routes/skills/+page.svelte
@@ -509,7 +509,7 @@
 >
 
 	<!-- ── Page Header ──────────────────────────────────────────────────────── -->
-	<div class="flex-shrink-0" style="padding: 0 24px; background: var(--bg-base);">
+	<div class="flex-shrink-0" style="padding: 32px 24px 0; background: var(--bg-base);">
 		<PageHeader
 			title="Skills"
 			iconName="skills"

--- a/frontend/src/routes/skills/+page.svelte
+++ b/frontend/src/routes/skills/+page.svelte
@@ -1,65 +1,61 @@
 <script lang="ts">
 	import {
-		Wrench,
 		Search,
 		Zap,
-		Play,
-		Puzzle,
-		FolderOpen,
+		ExternalLink,
+		TrendingUp,
+		ArrowDownNarrowWide,
+		ChevronDown,
+		ChevronRight,
+		LayoutGrid,
+		LayoutList,
 		Sparkles,
-		ChevronsUpDown,
-		ChevronsDownUp,
-		ExternalLink
+		Info
 	} from 'lucide-svelte';
-	import { tick, onMount } from 'svelte';
+	import { tick, onMount, onDestroy } from 'svelte';
 	import { navigating } from '$app/stores';
 	import { browser } from '$app/environment';
 	import { replaceState, beforeNavigate } from '$app/navigation';
-	import { listNavigation } from '$lib/actions/listNavigation';
-	import PageHeader from '$lib/components/layout/PageHeader.svelte';
-	import SkeletonBox from '$lib/components/skeleton/SkeletonBox.svelte';
-	import SkeletonText from '$lib/components/skeleton/SkeletonText.svelte';
-	import SkeletonStatsCard from '$lib/components/skeleton/SkeletonStatsCard.svelte';
-	import SkeletonSkillCard from '$lib/components/skeleton/SkeletonSkillCard.svelte';
-	import StatsGrid from '$lib/components/StatsGrid.svelte';
-	import SegmentedControl from '$lib/components/ui/SegmentedControl.svelte';
-	import CollapsibleGroup from '$lib/components/ui/CollapsibleGroup.svelte';
-	import SkillUsageCard from '$lib/components/skills/SkillUsageCard.svelte';
 	import SkillUsageTable from '$lib/components/skills/SkillUsageTable.svelte';
-	import UsageAnalytics from '$lib/components/charts/UsageAnalytics.svelte';
-	import { getSkillGroupColorVars, getSkillCategoryColorVars, getSkillChartHex, cleanSkillName } from '$lib/utils';
-	import type { SkillUsage, StatItem } from '$lib/api-types';
+	import KarmaIcon from '$lib/components/icons/Icon.svelte';
+	import PageHeader from '$lib/components/layout/PageHeader.svelte';
+	import {
+		getPluginColorVars,
+		getSkillGroupColorVars,
+		getSkillCategoryColorVars,
+		getSkillChartHex,
+		getSkillCategoryLabel,
+		cleanSkillName
+	} from '$lib/utils';
+	import type { SkillUsage, UsageTrendResponse } from '$lib/api-types';
+	import { API_BASE } from '$lib/config';
 
-	// Server data
 	let { data } = $props();
 
-	// Helper: read initial URL param safely (SSR-safe, uses window.location directly)
 	function initParam(key: string, fallback: string): string {
 		if (browser) return new URLSearchParams(window.location.search).get(key) ?? fallback;
 		return fallback;
 	}
 
-	// View state — initialized from URL, default "By Category"
-	let activeView = $state<'groups' | 'table' | 'analytics'>(
-		(initParam('view', 'groups') as 'groups' | 'table' | 'analytics')
+	let activeView = $state<'overview' | 'analytics'>(
+		(initParam('view', 'overview') as 'overview' | 'analytics')
 	);
-
-	// Filter state — initialized from URL
 	let searchQuery = $state(initParam('search', ''));
 	let selectedFilter = $state<'all' | 'bundled' | 'plugin' | 'custom'>(
 		(initParam('filter', 'all') as 'all' | 'bundled' | 'plugin' | 'custom')
 	);
+	let selectedPlugin = $state<string | null>(null); // null = all plugins
+	let sortBy = $state<'count' | 'session_count' | 'last_used'>('count');
+	let showSortMenu = $state(false);
 
-	// Sync view/filter/layout/search state to URL params via replaceState
 	$effect(() => {
 		if (!browser) return;
-		// Read all reactive values inside $effect so Svelte tracks them
 		const v = activeView;
 		const f = selectedFilter;
 		const s = searchQuery;
 		tick().then(() => {
 			const url = new URL(window.location.href);
-			if (v !== 'groups') url.searchParams.set('view', v);
+			if (v !== 'overview') url.searchParams.set('view', v);
 			else url.searchParams.delete('view');
 			if (f !== 'all') url.searchParams.set('filter', f);
 			else url.searchParams.delete('filter');
@@ -69,177 +65,411 @@
 		});
 	});
 
-	// Filter options
-	const filterOptions = [
-		{ label: 'All', value: 'all' },
-		{ label: 'Bundled', value: 'bundled' },
-		{ label: 'Plugin', value: 'plugin' },
-		{ label: 'Custom', value: 'custom' }
-	];
+	// ── Base data ──────────────────────────────────────────────────────────────
+	let allSkills = $derived<SkillUsage[]>(data.usage || []);
 
-	// View tab options
-	const viewTabs = [
-		{ label: 'By Category', value: 'groups' },
-		{ label: 'All Skills', value: 'table' },
-		{ label: 'Usage Analytics', value: 'analytics' }
-	];
-
-	// Compute stats for hero section
-	let stats = $derived.by<StatItem[]>(() => {
-		const usage = data.usage || [];
-		const totalSkills = usage.length;
-		const totalUses = usage.reduce((sum: number, skill: SkillUsage) => sum + skill.count, 0);
-		const bundledSkills = usage.filter((s: SkillUsage) => s.category === 'bundled_skill').length;
-		const pluginSkills = usage.filter((s: SkillUsage) => s.category === 'plugin_skill').length;
-
-		return [
-			{
-				title: 'Total Skills',
-				value: totalSkills,
-				icon: Zap,
-				color: 'purple'
-			},
-			{
-				title: 'Total Uses',
-				value: totalUses.toLocaleString(),
-				icon: Play,
-				color: 'blue'
-			},
-			{
-				title: 'Bundled',
-				value: bundledSkills,
-				icon: Sparkles,
-				color: 'purple'
-			},
-			{
-				title: 'Plugin Skills',
-				value: pluginSkills,
-				icon: Puzzle,
-				color: 'green'
-			}
-		];
-	});
-
-	// Filter skills by search query and type
-	let filteredSkills = $derived.by(() => {
-		let skills = data.usage || [];
-
-		// Filter by category
-		if (selectedFilter === 'bundled') {
-			skills = skills.filter((s: SkillUsage) => s.category === 'bundled_skill');
-		} else if (selectedFilter === 'plugin') {
-			skills = skills.filter((s: SkillUsage) => s.category === 'plugin_skill');
-		} else if (selectedFilter === 'custom') {
-			skills = skills.filter((s: SkillUsage) => s.category === 'custom_skill');
-		}
-
-		// Filter by search query
-		if (searchQuery.trim()) {
-			const query = searchQuery.toLowerCase();
-			skills = skills.filter(
-				(s: SkillUsage) =>
-					s.name.toLowerCase().includes(query) ||
-					(s.plugin && s.plugin.toLowerCase().includes(query))
-			);
-		}
-
-		return skills;
-	});
-
-	// Group skills by plugin source for display
+	// ── Grouping (mirrors the original logic) ─────────────────────────────────
 	interface SkillGroup {
 		key: string;
 		label: string;
-		icon: typeof Zap;
 		skills: SkillUsage[];
 		pluginName: string | null;
+		category: string;
 	}
 
 	let groupedSkills = $derived.by<SkillGroup[]>(() => {
-		const skills = filteredSkills;
-		const groups: Map<string, SkillGroup> = new Map();
-
-		for (const skill of skills) {
-			let groupKey: string;
-			let groupLabel: string;
-			let groupIcon: typeof Zap;
-			let pluginName: string | null = null;
-
+		const groups = new Map<string, SkillGroup>();
+		for (const skill of allSkills) {
+			let key: string, label: string, pluginName: string | null = null, category: string;
 			if (skill.category === 'bundled_skill') {
-				groupKey = 'bundled_skill';
-				groupLabel = 'Bundled Skills';
-				groupIcon = Sparkles;
+				key = 'bundled_skill'; label = 'Bundled Skills'; category = 'bundled_skill';
 			} else if (skill.category === 'plugin_skill' && skill.plugin) {
-				groupKey = `plugin:${skill.plugin}`;
-				groupLabel = skill.plugin;
-				groupIcon = Puzzle;
-				pluginName = skill.plugin;
+				key = `plugin:${skill.plugin}`; label = skill.plugin; pluginName = skill.plugin; category = 'plugin_skill';
 			} else if (skill.category === 'custom_skill') {
-				groupKey = 'custom_skill';
-				groupLabel = 'Custom Skills';
-				groupIcon = FolderOpen;
+				key = 'custom_skill'; label = 'Custom Skills'; category = 'custom_skill';
+			} else if (skill.is_plugin && skill.plugin) {
+				key = `plugin:${skill.plugin}`; label = skill.plugin; pluginName = skill.plugin; category = 'plugin_skill';
 			} else {
-				// Backward compat fallback for skills without category
-				if (skill.is_plugin && skill.plugin) {
-					groupKey = `plugin:${skill.plugin}`;
-					groupLabel = skill.plugin;
-					groupIcon = Puzzle;
-					pluginName = skill.plugin;
-				} else {
-					groupKey = 'custom_skill';
-					groupLabel = 'Custom Skills';
-					groupIcon = FolderOpen;
-				}
+				key = 'custom_skill'; label = 'Custom Skills'; category = 'custom_skill';
 			}
+			if (!groups.has(key)) groups.set(key, { key, label, skills: [], pluginName, category });
+			groups.get(key)!.skills.push(skill);
+		}
+		return Array.from(groups.values());
+	});
 
-			if (!groups.has(groupKey)) {
-				groups.set(groupKey, {
-					key: groupKey,
-					label: groupLabel,
-					icon: groupIcon,
-					skills: [],
-					pluginName
-				});
+	// ── Left panel: sorted by utilization% desc, then total invocations desc ──
+	let leftPanelGroups = $derived.by(() => {
+		return [...groupedSkills]
+			.filter(g => {
+				if (selectedFilter === 'bundled') return g.category === 'bundled_skill';
+				if (selectedFilter === 'plugin') return g.category === 'plugin_skill';
+				if (selectedFilter === 'custom') return g.category === 'custom_skill';
+				return true;
+			})
+			.sort((a, b) => {
+				const aUsed = a.skills.filter(s => s.count > 0).length;
+				const bUsed = b.skills.filter(s => s.count > 0).length;
+				const aPct = a.skills.length > 0 ? aUsed / a.skills.length : 0;
+				const bPct = b.skills.length > 0 ? bUsed / b.skills.length : 0;
+				if (Math.abs(bPct - aPct) > 0.001) return bPct - aPct;
+				const aTotal = a.skills.reduce((sum, s) => sum + s.count, 0);
+				const bTotal = b.skills.reduce((sum, s) => sum + s.count, 0);
+				return bTotal - aTotal;
+			});
+	});
+
+	// ── Stats ──────────────────────────────────────────────────────────────────
+	let totalUses = $derived(allSkills.reduce((sum, s) => sum + s.count, 0));
+	let activeSkillsCount = $derived(allSkills.filter(s => s.count > 0).length);
+	let totalSkillsCount = $derived(allSkills.length);
+	let neverUsedCount = $derived(allSkills.filter(s => s.count === 0).length);
+	let topPlugin = $derived.by(() => {
+		let best: SkillGroup | null = null;
+		let bestTotal = 0;
+		for (const g of groupedSkills) {
+			const total = g.skills.reduce((sum, s) => sum + s.count, 0);
+			if (total > bestTotal) { bestTotal = total; best = g; }
+		}
+		return best ? best.label : '—';
+	});
+	let globalMax = $derived(
+		allSkills.length > 0 ? Math.max(...allSkills.map(s => s.count), 1) : 1
+	);
+
+	// ── Right panel: active skills, filtered + sorted ─────────────────────────
+	let rightPanelSkills = $derived.by(() => {
+		let skills = allSkills.filter(s => s.count > 0);
+
+		if (selectedPlugin !== null) {
+			if (selectedPlugin === 'bundled_skill') {
+				skills = skills.filter(s => s.category === 'bundled_skill');
+			} else if (selectedPlugin === 'custom_skill') {
+				skills = skills.filter(s => s.category === 'custom_skill');
+			} else {
+				skills = skills.filter(s => s.plugin === selectedPlugin);
 			}
-			groups.get(groupKey)!.skills.push(skill);
 		}
 
-		// Sort groups: bundled first, then custom, then plugins alphabetically
-		return Array.from(groups.values()).sort((a, b) => {
-			const priority: Record<string, number> = { 'bundled_skill': 0, 'custom_skill': 1 };
-			const aPriority = priority[a.key] ?? 2;
-			const bPriority = priority[b.key] ?? 2;
-			if (aPriority !== bPriority) return aPriority - bPriority;
-			return a.label.localeCompare(b.label);
+		if (selectedFilter === 'bundled') skills = skills.filter(s => s.category === 'bundled_skill');
+		else if (selectedFilter === 'plugin') skills = skills.filter(s => s.category === 'plugin_skill');
+		else if (selectedFilter === 'custom') skills = skills.filter(s => s.category === 'custom_skill');
+
+		if (searchQuery.trim()) {
+			const q = searchQuery.toLowerCase();
+			skills = skills.filter(s =>
+				s.name.toLowerCase().includes(q) ||
+				(s.plugin && s.plugin.toLowerCase().includes(q))
+			);
+		}
+
+		return skills.slice().sort((a, b) => {
+			if (sortBy === 'session_count') return (b.session_count ?? 0) - (a.session_count ?? 0);
+			if (sortBy === 'last_used') {
+				return (b.last_used ? new Date(b.last_used).getTime() : 0) -
+				       (a.last_used ? new Date(a.last_used).getTime() : 0);
+			}
+			return b.count - a.count;
 		});
 	});
 
-	// Track which groups are expanded — initialized from URL param `expanded`
-	function initExpandedGroups(): Set<string> {
-		if (browser) {
-			const param = new URLSearchParams(window.location.search).get('expanded');
-			if (param) return new Set(param.split(',').filter(Boolean));
+	// ── All Skills tab: also applies type + search filters ────────────────────
+	let filteredSkills = $derived.by(() => {
+		let skills = allSkills;
+		if (selectedFilter === 'bundled') skills = skills.filter(s => s.category === 'bundled_skill');
+		else if (selectedFilter === 'plugin') skills = skills.filter(s => s.category === 'plugin_skill');
+		else if (selectedFilter === 'custom') skills = skills.filter(s => s.category === 'custom_skill');
+		if (searchQuery.trim()) {
+			const q = searchQuery.toLowerCase();
+			skills = skills.filter(s =>
+				s.name.toLowerCase().includes(q) || (s.plugin && s.plugin.toLowerCase().includes(q))
+			);
 		}
-		return new Set(['bundled_skill']);
-	}
-	let expandedGroups = $state<Set<string>>(initExpandedGroups());
-	let previousExpandedGroups = $state<Set<string> | null>(null);
+		return skills;
+	});
 
-	// Sync expanded groups to URL (separate from the main view/filter sync)
-	function syncExpandedToUrl() {
-		if (!browser) return;
-		tick().then(() => {
-			const url = new URL(window.location.href);
-			const keys = Array.from(expandedGroups);
-			if (keys.length > 0) url.searchParams.set('expanded', keys.join(','));
-			else url.searchParams.delete('expanded');
-			replaceState(url.toString(), {});
+	// ── Analytics derived ─────────────────────────────────────────────────────
+	let analyticsTotalInvocations = $derived(rightPanelSkills.reduce((sum, s) => sum + s.count, 0));
+	let analyticsAvgPerSkill = $derived(
+		rightPanelSkills.length > 0 ? Math.round(analyticsTotalInvocations / rightPanelSkills.length) : 0
+	);
+	let analyticsTop15 = $derived(rightPanelSkills.slice(0, 15));
+	let analyticsBarMax = $derived(analyticsTop15.length > 0 ? analyticsTop15[0].count : 1);
+	let analyticsPluginBreakdown = $derived.by(() => {
+		const map = new Map<string, { label: string; count: number; color: string; subtle: string }>();
+		for (const skill of rightPanelSkills) {
+			const key = skill.plugin ?? skill.category ?? 'custom';
+			const label = skill.plugin ?? (skill.category === 'bundled_skill' ? 'built-in' : 'custom');
+			const colors = getSkillColors(skill);
+			if (!map.has(key)) map.set(key, { label, count: 0, color: colors.color, subtle: colors.subtle });
+			map.get(key)!.count += skill.count;
+		}
+		return [...map.values()].sort((a, b) => b.count - a.count);
+	});
+	let analyticsPluginTotal = $derived(analyticsPluginBreakdown.reduce((s, p) => s + p.count, 0));
+	let trendOpen = $state(true);
+	let trendRange = $state<'7d' | '30d' | '90d'>('90d');
+	let trendData = $state<UsageTrendResponse | null>(null);
+	let trendLoading = $state(false);
+	let trendRangeUserOverride = $state(false);
+
+	const periodMap: Record<'7d' | '30d' | '90d', string> = { '7d': 'week', '30d': 'month', '90d': 'quarter' };
+
+	$effect(() => {
+		if (!browser || activeView !== 'analytics') return;
+		trendLoading = true;
+		const url = new URL(`${API_BASE}/skills/usage/trend`);
+		url.searchParams.set('period', periodMap[trendRange]);
+		fetch(url)
+			.then(r => r.json())
+			.then(d => {
+				trendData = d;
+				// Auto-downgrade to highest range that has data (unless user manually chose)
+				if (!trendRangeUserOverride) {
+					const total = (d as UsageTrendResponse)?.total ?? 0;
+					if (total === 0 && trendRange === '90d') trendRange = '30d';
+					else if (total === 0 && trendRange === '30d') trendRange = '7d';
+				}
+			})
+			.catch(() => {})
+			.finally(() => { trendLoading = false; });
+	});
+
+	// Rebuild daily totals filtered by excludeFn
+	let trendPoints = $derived.by(() => {
+		if (!trendData) return [];
+		const sorted = [...trendData.trend].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+		if (!excludeFn || !trendData.trend_by_item) return sorted;
+		const dailyTotals = new Map<string, number>();
+		for (const [name, points] of Object.entries(trendData.trend_by_item)) {
+			if (excludeFn(name)) continue;
+			for (const p of points) dailyTotals.set(p.date, (dailyTotals.get(p.date) ?? 0) + p.count);
+		}
+		return sorted.map(d => ({ date: d.date, count: dailyTotals.get(d.date) ?? 0 }));
+	});
+
+	// Just a sentinel so the template knows data is ready
+	let sparklinePath = $derived(trendPoints.length >= 2 ? { W: 600, H: 180 } : null);
+
+	// ── Chart helpers ─────────────────────────────────────────────────────────
+	function catmullRomPath(pts: {x: number, y: number}[]): string {
+		if (pts.length < 2) return '';
+		let d = `M ${pts[0].x.toFixed(1)},${pts[0].y.toFixed(1)}`;
+		for (let i = 0; i < pts.length - 1; i++) {
+			const p0 = pts[Math.max(0, i - 1)];
+			const p1 = pts[i];
+			const p2 = pts[i + 1];
+			const p3 = pts[Math.min(pts.length - 1, i + 2)];
+			const cp1x = p1.x + (p2.x - p0.x) / 6;
+			const cp1y = p1.y + (p2.y - p0.y) / 6;
+			const cp2x = p2.x - (p3.x - p1.x) / 6;
+			const cp2y = p2.y - (p3.y - p1.y) / 6;
+			d += ` C ${cp1x.toFixed(1)},${cp1y.toFixed(1)} ${cp2x.toFixed(1)},${cp2y.toFixed(1)} ${p2.x.toFixed(1)},${p2.y.toFixed(1)}`;
+		}
+		return d;
+	}
+
+	function stackedAreaPath(topPts: {x:number,y:number}[], botPts: {x:number,y:number}[] | null, baseY: number): { line: string; area: string } {
+		const line = catmullRomPath(topPts);
+		if (!botPts) {
+			const last = topPts[topPts.length - 1];
+			const first = topPts[0];
+			return { line, area: `${line} L ${last.x.toFixed(1)},${baseY} L ${first.x.toFixed(1)},${baseY} Z` };
+		}
+		const revBot = [...botPts].reverse();
+		const revLine = catmullRomPath(revBot);
+		// Connect: end of top → start of reversed bottom via straight line, then smooth back
+		const last = topPts[topPts.length - 1];
+		const revFirst = revBot[0];
+		return { line, area: `${line} L ${revFirst.x.toFixed(1)},${revFirst.y.toFixed(1)} ${revLine.replace(/^M [^C]*C/, 'C')} Z` };
+	}
+
+	// ── Stacked chart data ─────────────────────────────────────────────────────
+	let stackedChartData = $derived.by(() => {
+		if (!trendData?.trend_by_item || trendPoints.length === 0) return null;
+		const dates = trendPoints.map(p => p.date);
+		const cX1 = 48, cX2 = 892, cY1 = 8, cY2 = 156;
+		const cW = cX2 - cX1, cH = cY2 - cY1;
+
+		// Group trend_by_item by plugin
+		const groupMap = new Map<string, { label: string; color: string; counts: number[] }>();
+		for (const [skillName, skillPts] of Object.entries(trendData.trend_by_item)) {
+			if (excludeFn && excludeFn(skillName)) continue;
+			const skill = allSkills.find(s => s.name === skillName);
+			if (!skill) continue;
+			const key = skill.plugin ?? (skill.category === 'bundled_skill' ? 'built-in' : 'custom');
+			const colors = getSkillColors(skill);
+			if (!groupMap.has(key)) groupMap.set(key, { label: key, color: colors.color, counts: new Array(dates.length).fill(0) });
+			const ptMap = new Map(skillPts.map(p => [p.date, p.count]));
+			const g = groupMap.get(key)!;
+			dates.forEach((d, i) => { g.counts[i] += ptMap.get(d) ?? 0; });
+		}
+
+		const groups = [...groupMap.values()].sort((a, b) =>
+			b.counts.reduce((s, v) => s + v, 0) - a.counts.reduce((s, v) => s + v, 0)
+		);
+		if (groups.length === 0) return null;
+
+		const dailyTotals = dates.map((_, i) => groups.reduce((s, g) => s + g.counts[i], 0));
+		const yMax = Math.max(...dailyTotals, 1);
+		const xi = (i: number) => cX1 + (i / Math.max(dates.length - 1, 1)) * cW;
+		const yv = (v: number) => cY2 - (v / yMax) * cH;
+
+		const cumulative = new Array(dates.length).fill(0);
+		const layers = groups.map((g, idx) => {
+			const prevCum = [...cumulative];
+			dates.forEach((_, i) => { cumulative[i] += g.counts[i]; });
+			const topPts = dates.map((_, i) => ({ x: xi(i), y: yv(cumulative[i]) }));
+			const botPts = idx === 0 ? null : dates.map((_, i) => ({ x: xi(i), y: yv(prevCum[i]) }));
+			const { line, area } = stackedAreaPath(topPts, botPts, cY2);
+			return { ...g, topPts, line, area, gradId: `sg${idx}` };
 		});
+
+		const peakIdx = dailyTotals.reduce((mi, v, i) => v > dailyTotals[mi] ? i : mi, 0);
+		const totalInv = dailyTotals.reduce((s, v) => s + v, 0);
+
+		const xIdxs = dates.length <= 7 ? dates.map((_, i) => i)
+			: [0, Math.floor(dates.length * 0.25), Math.floor(dates.length * 0.5), Math.floor(dates.length * 0.75), dates.length - 1];
+
+		return {
+			layers,
+			groups,
+			dates,
+			dailyTotals,
+			peakX: xi(peakIdx),
+			peakY: yv(dailyTotals[peakIdx]),
+			peakVal: dailyTotals[peakIdx],
+			peakDate: new Date(dates[peakIdx] + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+			totalInv,
+			avgPerDay: (totalInv / dates.length).toFixed(1),
+			yMax,
+			yTicks: [1, 0.67, 0.33, 0].map(f => ({ y: cY2 - f * cH, val: Math.round(yMax * f) })),
+			xLabels: xIdxs.map(i => ({
+				x: xi(i),
+				label: new Date(dates[i] + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+				anchor: (i === 0 ? 'start' : i === dates.length - 1 ? 'end' : 'middle') as 'start' | 'end' | 'middle'
+			})),
+			xi,
+			cX1, cX2, cY1, cY2
+		};
+	});
+
+	// ── Chart tooltip state ───────────────────────────────────────────────────
+	let chartHoverIdx = $state<number | null>(null);
+	let chartSvgEl = $state<SVGSVGElement | null>(null);
+
+	function handleChartMouseMove(e: MouseEvent) {
+		if (!stackedChartData || !chartSvgEl) return;
+		const rect = chartSvgEl.getBoundingClientRect();
+		const scaleX = 900 / rect.width;
+		const mx = (e.clientX - rect.left) * scaleX;
+		const { dates, xi, cX1, cX2 } = stackedChartData;
+		if (mx < cX1 - 10 || mx > cX2 + 10) { chartHoverIdx = null; return; }
+		// Find nearest date index
+		let best = 0, bestDist = Infinity;
+		dates.forEach((_, i) => { const d = Math.abs(xi(i) - mx); if (d < bestDist) { bestDist = d; best = i; } });
+		chartHoverIdx = best;
 	}
 
-	// Scroll save/restore
-	// Save only when navigating into a skill detail — this avoids stale keys
-	// from unrelated navigations away from /skills.
+	let tooltipData = $derived.by(() => {
+		if (chartHoverIdx === null || !stackedChartData) return null;
+		const i = chartHoverIdx;
+		const date = new Date(stackedChartData.dates[i] + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+		const total = stackedChartData.dailyTotals[i];
+		const rows = stackedChartData.layers
+			.filter(l => l.counts[i] > 0)
+			.map(l => ({ label: l.label, count: l.counts[i], color: l.color }))
+			.sort((a, b) => b.count - a.count);
+		return { date, total, rows, x: stackedChartData.xi(i) };
+	});
+
+	// ── Session reach (left analytics panel) ──────────────────────────────────
+	let sessionReachSkills = $derived(
+		rightPanelSkills.slice().sort((a, b) => (b.session_count ?? 0) - (a.session_count ?? 0)).slice(0, 8)
+	);
+	let sessionReachMax = $derived(sessionReachSkills.length > 0 ? (sessionReachSkills[0].session_count ?? 1) : 1);
+
+	// ── Insight banner ────────────────────────────────────────────────────────
+	let insightText = $derived.by(() => {
+		if (rightPanelSkills.length === 0) return null;
+		const top = rightPanelSkills[0];
+		const topName = cleanSkillName(top.name, top.is_plugin);
+		const topSession = sessionReachSkills[0];
+		const topSessionName = topSession ? cleanSkillName(topSession.name, topSession.is_plugin) : null;
+		const diverse = sessionReachSkills.length > 1 ? sessionReachSkills.find(s => s.name !== top.name) : null;
+		const diverseName = diverse ? cleanSkillName(diverse.name, diverse.is_plugin) : null;
+		if (topSessionName && diverseName && topSessionName !== topName) {
+			return { bold: `${topName} leads all invocations`, rest: ` · ${topSessionName} spans ${topSession?.session_count} sessions · ${diverseName} is your second most-reached habit` };
+		}
+		return { bold: `${rightPanelSkills.length} active skills`, rest: ` · ${topName} leads with ${top.count} invocations across ${top.session_count ?? 0} sessions` };
+	});
+
+	let excludeFn = $derived.by(() => {
+		if (selectedFilter === 'all') return undefined;
+		if (selectedFilter === 'bundled') return (name: string) => {
+			const s = allSkills.find(x => x.name === name);
+			return s?.category !== 'bundled_skill';
+		};
+		if (selectedFilter === 'plugin') return (name: string) => {
+			const s = allSkills.find(x => x.name === name);
+			return s?.category !== 'plugin_skill';
+		};
+		return (name: string) => {
+			const s = allSkills.find(x => x.name === name);
+			return s?.category !== 'custom_skill';
+		};
+	});
+
+	// ── Helpers ────────────────────────────────────────────────────────────────
+	// Compact relative date — no time component
+	function shortDate(ts: string | null): string {
+		if (!ts) return '—';
+		const date = new Date(ts);
+		const diffMs = Date.now() - date.getTime();
+		const diffMins = Math.floor(diffMs / 60000);
+		const diffHours = Math.floor(diffMins / 60);
+		const diffDays = Math.floor(diffHours / 24);
+		if (diffMins < 1) return 'now';
+		if (diffMins < 60) return `${diffMins}m`;
+		if (diffHours < 24) return `${diffHours}h`;
+		if (diffDays < 7) return `${diffDays}d`;
+		return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+	}
+
+	function getGroupColors(group: SkillGroup) {
+		if (group.key === 'bundled_skill') return getSkillCategoryColorVars('bundled_skill');
+		if (group.key === 'custom_skill') return getSkillCategoryColorVars('custom_skill');
+		return getSkillGroupColorVars(group.key);
+	}
+
+	function getSourceBadgeLabel(skill: SkillUsage): string {
+		if (skill.category === 'bundled_skill') return 'built-in';
+		if (skill.plugin) return skill.plugin;
+		return 'custom';
+	}
+
+	function getSkillColors(skill: SkillUsage) {
+		if (skill.category === 'bundled_skill') return getSkillCategoryColorVars('bundled_skill');
+		if (skill.plugin) return getPluginColorVars(skill.plugin);
+		return getSkillCategoryColorVars('custom_skill');
+	}
+
+	let coverageOpen = $state(false);
+	let skillsView = $state<'list' | 'grid'>('list');
+
+	function togglePlugin(group: SkillGroup) {
+		const key = group.pluginName ?? group.key;
+		if (selectedPlugin === key) selectedPlugin = null;
+		else selectedPlugin = key;
+	}
+
+	const sortLabels: Record<string, string> = {
+		count: 'Invocations ↓',
+		session_count: 'Sessions ↓',
+		last_used: 'Last Used'
+	};
+
+	// ── Scroll save/restore when navigating to skill detail ───────────────────
 	const SCROLL_KEY = 'skills_scroll';
 
 	beforeNavigate(({ to }) => {
@@ -247,407 +477,725 @@
 		if (to?.route.id?.startsWith('/skills/')) {
 			sessionStorage.setItem(SCROLL_KEY, String(window.scrollY));
 		} else {
-			// Navigating somewhere other than a skill detail — clear any stale key
 			sessionStorage.removeItem(SCROLL_KEY);
 		}
 	});
 
-	// Restore on mount: the component mounts AFTER the skeleton clears, which is
-	// after SvelteKit finishes navigation — afterNavigate would fire too early
-	// (before this component exists), so onMount is the reliable hook here.
 	onMount(() => {
 		const saved = sessionStorage.getItem(SCROLL_KEY);
 		if (saved !== null) {
 			sessionStorage.removeItem(SCROLL_KEY);
-			const y = Number(saved);
-			requestAnimationFrame(() => window.scrollTo({ top: y, behavior: 'instant' }));
+			requestAnimationFrame(() => window.scrollTo({ top: Number(saved), behavior: 'instant' }));
 		}
 	});
-
-	// Auto-expand groups when searching rule:
-	// 1. When entering search (query > 0), snapshot current state
-	// 2. Expand all matching groups
-	// 3. When clearing search, restore snapshot
-	$effect(() => {
-		const hasSearch = searchQuery.trim().length > 0;
-
-		if (hasSearch) {
-			// Entering search mode: Snapshot if not already done
-			if (previousExpandedGroups === null) {
-				previousExpandedGroups = new Set(expandedGroups);
-			}
-			// Force expand matches
-			if (groupedSkills.length > 0) {
-				expandedGroups = new Set(groupedSkills.map((g) => g.key));
-			}
-		} else {
-			// Exiting search mode: Restore snapshot
-			if (previousExpandedGroups !== null) {
-				expandedGroups = previousExpandedGroups;
-				previousExpandedGroups = null;
-			}
-		}
-	});
-
-	function toggleGroup(key: string) {
-		if (expandedGroups.has(key)) {
-			expandedGroups.delete(key);
-		} else {
-			expandedGroups.add(key);
-		}
-		expandedGroups = new Set(expandedGroups);
-		syncExpandedToUrl();
-	}
-
-	// Check if all groups are expanded
-	let allExpanded = $derived(
-		groupedSkills.length > 0 && groupedSkills.every((g) => expandedGroups.has(g.key))
-	);
-
-	function expandAll() {
-		expandedGroups = new Set(groupedSkills.map((g) => g.key));
-		syncExpandedToUrl();
-	}
-
-	function collapseAll() {
-		expandedGroups = new Set();
-		syncExpandedToUrl();
-	}
-
-	function toggleAllGroups() {
-		if (allExpanded) {
-			collapseAll();
-		} else {
-			expandAll();
-		}
-	}
-
-	// Calculate max usage for progress bars
-	let maxUsage = $derived(
-		filteredSkills.length > 0 ? Math.max(...filteredSkills.map((s: SkillUsage) => s.count)) : 100
-	);
-
-	// Build a plugin lookup from skill data for analytics filtering
-	let skillPluginMap = $derived.by(() => {
-		const map = new Map<string, boolean>();
-		for (const skill of (data.usage || [])) {
-			map.set(skill.name, skill.is_plugin);
-		}
-		return map;
-	});
-
-	let excludeFn = $derived.by(() => {
-		if (selectedFilter === 'all') return undefined;
-		if (selectedFilter === 'bundled') {
-			return (name: string) => {
-				const skill = (data.usage || []).find((s: SkillUsage) => s.name === name);
-				return skill?.category !== 'bundled_skill';
-			};
-		}
-		if (selectedFilter === 'plugin') {
-			return (name: string) => skillPluginMap.get(name) !== true;
-		}
-		// 'custom'
-		return (name: string) => {
-			const skill = (data.usage || []).find((s: SkillUsage) => s.name === name);
-			return skill?.category !== 'custom_skill';
-		};
-	});
-
-	// Check if we have any skills
-	let hasSkills = $derived((data.usage || []).length > 0);
-	let hasFilteredSkills = $derived(filteredSkills.length > 0);
 
 	let isPageLoading = $derived(!!$navigating && $navigating.to?.route.id === '/skills');
 </script>
 
-<div class="space-y-8">
-	{#if isPageLoading}
-		<div class="space-y-8" role="status" aria-busy="true" aria-label="Loading...">
-			<!-- Page Header skeleton -->
-			<div>
-				<div class="flex items-center gap-2 mb-2">
-					<SkeletonText width="70px" size="xs" />
-					<span class="text-[var(--text-muted)]">/</span>
-					<SkeletonText width="50px" size="xs" />
-				</div>
-				<div class="flex items-center gap-4">
-					<SkeletonBox width="48px" height="48px" rounded="lg" />
-					<div>
-						<SkeletonText width="80px" size="xl" class="mb-2" />
-						<SkeletonText width="340px" size="sm" />
-					</div>
-				</div>
-			</div>
+{#if isPageLoading}
+	<!-- Loading state: keep height so layout doesn't jump -->
+	<div class="-mx-6 -my-8 flex items-center justify-center" style="height: calc(100vh - 56px);">
+		<div class="flex flex-col items-center gap-3">
+			<Zap size={32} class="text-[var(--accent)] animate-pulse" />
+			<span class="text-sm text-[var(--text-muted)]">Loading skills…</span>
+		</div>
+	</div>
+{:else}
 
-			<!-- Hero Stats skeleton -->
-			<div
-				class="relative overflow-hidden rounded-2xl p-8 border border-[var(--border)]"
-				style="background: linear-gradient(135deg, rgba(124, 58, 237, 0.02) 0%, rgba(124, 58, 237, 0.06) 100%);"
+<!-- ── Full-bleed split-view container ────────────────────────────────────── -->
+<div
+	class="-mx-6 -my-8 flex flex-col"
+	style="{activeView === 'overview' ? 'height: calc(100vh - 56px); overflow: hidden;' : ''}"
+>
+
+	<!-- ── Page Header ──────────────────────────────────────────────────────── -->
+	<div class="flex-shrink-0" style="padding: 0 24px; background: var(--bg-base);">
+		<PageHeader
+			title="Skills"
+			iconName="skills"
+			iconColor="--nav-orange"
+			breadcrumbs={[{ label: 'Dashboard', href: '/' }, { label: 'Skills' }]}
+			subtitle="Did I get value from this skill?"
+		/>
+	</div>
+
+	<!-- ── Body ─────────────────────────────────────────────────────────────── -->
+
+	<!-- Filter bar — always visible -->
+	<div
+		class="flex flex-shrink-0 items-center"
+		style="padding: 8px 12px; gap: 10px; {activeView === 'analytics' ? 'position: sticky; top: 56px; z-index: 10; background: var(--bg-base); border-bottom: 1px solid var(--border-subtle);' : ''}"
+	>
+		<!-- Left group: view tabs — fixed width matching left panel -->
+		<div
+			class="flex rounded-lg p-0.5 flex-shrink-0"
+			style="width: 280px; background: var(--bg-muted);"
+			role="tablist"
+			aria-label="View"
+		>
+			{#each ([['overview', 'Overview'], ['analytics', 'Analytics']] as const) as [val, lbl]}
+				<button
+					role="tab"
+					aria-selected={activeView === val}
+					onclick={() => activeView = val}
+					class="flex-1 rounded-md transition-all"
+					style="
+						padding: 4px 8px;
+						font-size: 11px;
+						font-weight: {activeView === val ? '600' : '500'};
+						color: {activeView === val ? 'var(--bg-base)' : 'var(--text-secondary)'};
+						background: {activeView === val ? 'var(--text-primary)' : 'transparent'};
+					"
+				>{lbl}</button>
+			{/each}
+		</div>
+
+		<!-- Right group: type chips + search — above right panel -->
+		<div class="flex items-center gap-2 flex-1">
+			<div class="flex items-center gap-1.5">
+				{#each ([['all', 'All'], ['bundled', 'Bundled'], ['plugin', 'Plugin'], ['custom', 'Custom']] as const) as [val, lbl]}
+					<button
+						onclick={() => selectedFilter = val}
+						class="rounded-full transition-all"
+						style="
+							padding: 4px 12px;
+							font-size: 11px;
+							font-weight: {selectedFilter === val ? '600' : '500'};
+							color: {selectedFilter === val ? 'var(--accent)' : 'var(--text-secondary)'};
+							background: {selectedFilter === val ? 'var(--accent-muted)' : 'transparent'};
+							border: {selectedFilter === val ? '1.5px solid var(--accent-subtle)' : '1px solid var(--border)'};
+						"
+					>{lbl}</button>
+				{/each}
+			</div>
+			<div class="relative ml-auto">
+				<Search class="absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" size={12} style="color: var(--text-faint);" />
+				<input
+					type="text"
+					bind:value={searchQuery}
+					aria-label="Search skills"
+					placeholder="Search skills…"
+					style="width: 180px; padding: 4px 10px 4px 26px; font-size: 12px; background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 8px; color: var(--text-primary); outline: none;"
+					data-search-input
+				/>
+			</div>
+		</div>
+	</div>
+
+	{#if activeView === 'overview'}
+	<!-- Split view -->
+	<div class="flex flex-1 min-h-0 overflow-hidden" style="padding: 0 12px 12px; gap: 10px;">
+
+		<!-- ── Left Panel: Plugin Coverage ─────────────────────────────────── -->
+		<div
+			class="flex-shrink-0 flex flex-col"
+			style="width: 280px; background: var(--bg-base); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; align-self: flex-start;"
+		>
+			<!-- Panel header — accordion trigger -->
+			<button
+				class="w-full text-left flex-shrink-0 transition-colors hover:bg-[var(--bg-subtle)]"
+				style="border-bottom: 1px solid {coverageOpen ? 'var(--border-subtle)' : 'transparent'}; padding: 14px 16px 12px;"
+				onclick={() => coverageOpen = !coverageOpen}
 			>
-				<div class="relative grid grid-cols-1 sm:grid-cols-4 gap-4">
-					{#each Array(4) as _}
-						<SkeletonStatsCard />
-					{/each}
-				</div>
-			</div>
-
-			<!-- Filters row skeleton -->
-			<div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-				<div class="flex items-center gap-3 flex-wrap">
-					<div class="flex gap-1">
-						{#each Array(3) as _}
-							<SkeletonBox width="110px" height="36px" rounded="lg" />
-						{/each}
-					</div>
-					<div class="flex gap-1">
-						{#each Array(4) as _}
-							<SkeletonBox width="70px" height="32px" rounded="lg" />
-						{/each}
+				<div class="flex items-center justify-between mb-2">
+					<span style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace;">
+						Plugin Coverage
+					</span>
+					<div style="color: var(--text-faint); transition: transform 0.2s; transform: rotate({coverageOpen ? 90 : 0}deg);">
+						<ChevronRight size={13} />
 					</div>
 				</div>
-				<div class="flex items-center gap-3">
-					<SkeletonBox width="256px" height="40px" rounded="lg" />
-					<SkeletonBox width="120px" height="40px" rounded="lg" />
-				</div>
-			</div>
-
-			<!-- Grouped skill cards skeleton -->
-			<div class="space-y-4">
-				{#each Array(2) as _, groupIndex}
-					<div class="border border-[var(--border)] rounded-[var(--radius-lg)] overflow-hidden bg-[var(--bg-base)]">
-						<div class="flex items-center gap-3 px-4 py-4">
-							<SkeletonBox width="16px" height="16px" rounded="sm" />
-							<SkeletonBox width="32px" height="32px" rounded="md" />
-							<SkeletonText width="140px" size="sm" />
-							<div class="flex-1"></div>
-							<SkeletonText width="60px" size="xs" />
+				<!-- Stats: fill full width -->
+				<div class="flex items-center w-full">
+					<div class="flex flex-col flex-1 items-center">
+						<span style="font-size: 22px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: var(--text-primary); letter-spacing: -1px;">{totalUses.toLocaleString()}</span>
+						<span style="font-size: 9px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.06em;">uses</span>
+					</div>
+					<div style="width: 1px; height: 32px; background: var(--border);"></div>
+					<div class="flex flex-col flex-1 items-center">
+						<span style="font-size: 22px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: var(--text-primary); letter-spacing: -1px;">{activeSkillsCount}<span style="font-size: 13px; font-weight: 500; color: var(--text-faint);">/{totalSkillsCount}</span></span>
+						<span style="font-size: 9px; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.06em;">active</span>
+					</div>
+					{#if neverUsedCount > 0}
+						<div style="width: 1px; height: 32px; background: var(--border);"></div>
+						<div class="flex flex-col flex-1 items-center">
+							<span style="font-size: 22px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: var(--nav-orange); letter-spacing: -1px;">{neverUsedCount}</span>
+							<span style="font-size: 9px; color: var(--nav-orange); text-transform: uppercase; letter-spacing: 0.06em; opacity: 0.8;">unused</span>
 						</div>
-						{#if groupIndex === 0}
-							<div class="border-t border-[var(--border)] p-4">
-								<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-									{#each Array(6) as _}
-										<SkeletonSkillCard />
-									{/each}
-								</div>
+					{/if}
+				</div>
+			</button>
+
+			<!-- Plugin rows — only when accordion is open -->
+			{#if coverageOpen}
+			<div class="flex-1 overflow-y-auto">
+				{#each leftPanelGroups as group}
+					{@const colors = getGroupColors(group)}
+					{@const usedCount = group.skills.filter(s => s.count > 0).length}
+					{@const totalCount = group.skills.length}
+					{@const utilPct = totalCount > 0 ? Math.round((usedCount / totalCount) * 100) : 0}
+					{@const isNeverUsed = usedCount === 0}
+					{@const pluginKey = group.pluginName ?? group.key}
+					{@const isSelected = selectedPlugin === pluginKey}
+					{@const isTopPlugin = group.label === topPlugin}
+					{@const pctColor = isNeverUsed ? 'var(--text-faint)' : utilPct === 100 ? 'var(--nav-green)' : utilPct >= 50 ? 'var(--text-secondary)' : 'var(--text-faint)'}
+					<div
+						role="button"
+						tabindex="0"
+						onclick={() => togglePlugin(group)}
+						onkeydown={(e) => e.key === 'Enter' && togglePlugin(group)}
+						class="border-b cursor-pointer group/row transition-colors"
+						style="
+							padding: 10px 20px;
+							border-color: var(--border-subtle);
+							background: {isSelected ? 'var(--accent-muted)' : 'transparent'};
+							border-left: {isSelected ? '2px solid var(--accent)' : '2px solid transparent'};
+							opacity: {isNeverUsed ? 0.45 : 1};
+						"
+					>
+						<!-- Name row -->
+						<div class="flex items-center justify-between gap-2" style="margin-bottom: 6px;">
+							<span class="flex-1 min-w-0 truncate" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;">
+								{group.label}
+							</span>
+							<div class="flex items-center gap-1.5 flex-shrink-0">
+								{#if isTopPlugin}
+									<TrendingUp size={10} style="color: var(--nav-orange);" />
+								{/if}
+								{#if group.pluginName}
+									<a
+										href="/plugins/{encodeURIComponent(group.pluginName)}"
+										onclick={(e) => e.stopPropagation()}
+										class="opacity-0 group-hover/row:opacity-100 transition-opacity"
+										title="View plugin"
+										style="color: var(--text-faint);"
+									>
+										<ExternalLink size={10} />
+									</a>
+								{/if}
+								<span style="font-size: 12px; font-weight: 700; font-family: 'JetBrains Mono', monospace; color: {pctColor};">
+									{utilPct}%
+								</span>
 							</div>
-						{/if}
+						</div>
+
+						<!-- Bar + count -->
+						<div class="flex items-center gap-2">
+							<div class="flex-1" style="height: 3px; border-radius: 2px; background: var(--bg-muted); overflow: hidden;">
+								{#if !isNeverUsed}
+									<div style="height: 100%; border-radius: 2px; width: {utilPct}%; background: var(--accent); opacity: 0.5;"></div>
+								{/if}
+							</div>
+							<span style="font-size: 10px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace; flex-shrink: 0;">
+								{usedCount}/{totalCount}
+							</span>
+						</div>
 					</div>
 				{/each}
 			</div>
-		</div>
-	{:else}
-	<!-- Page Header with Breadcrumb -->
-	<PageHeader
-		title="Skills"
-		iconName="skills"
-		iconColor="--nav-orange"
-		breadcrumbs={[{ label: 'Dashboard', href: '/' }, { label: 'Skills' }]}
-		subtitle="Track skill usage analytics and browse skill files"
-	/>
 
-	<!-- Hero Stats Row with Gradient Background -->
-	{#if hasSkills}
-		<div
-			class="relative overflow-hidden rounded-2xl p-8 border border-[var(--border)]"
-			style="background: linear-gradient(135deg, rgba(124, 58, 237, 0.02) 0%, rgba(124, 58, 237, 0.06) 100%);"
-		>
-			<!-- Decorative blur elements -->
-			<div
-				class="absolute -top-24 -right-24 w-96 h-96 bg-violet-500/5 rounded-full blur-3xl pointer-events-none"
-			></div>
-			<div
-				class="absolute -bottom-24 -left-24 w-64 h-64 bg-blue-500/3 rounded-full blur-3xl pointer-events-none"
-			></div>
-
-			<!-- Stats Grid -->
-			<div class="relative">
-				<StatsGrid {stats} columns={4} />
-			</div>
-		</div>
-	{/if}
-
-	<!-- Filters Row -->
-	<div
-		class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4"
-		use:listNavigation
-	>
-		<div class="flex items-center gap-3 flex-wrap">
-			<SegmentedControl
-				options={viewTabs}
-				bind:value={activeView}
-			/>
-			<SegmentedControl options={filterOptions} bind:value={selectedFilter} size="sm" />
-		</div>
-
-		<!-- Search and Expand/Collapse Controls -->
-		{#if activeView !== 'analytics'}
-			<div class="flex items-center gap-3 w-full sm:w-auto">
-				<!-- Search Input -->
-				<div class="relative flex-1 sm:flex-initial">
-					<Search
-						class="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)]"
-						size={16}
-					/>
-					<input
-						type="text"
-						bind:value={searchQuery}
-						aria-label="Search skills"
-						placeholder="Search skills..."
-						class="
-							pl-9 pr-4 py-2
-							bg-[var(--bg-base)]
-							border border-[var(--border)]
-							rounded-lg text-sm
-							focus:outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent)]/20
-							w-full sm:w-64
-							transition-all
-							text-[var(--text-primary)]
-							placeholder:text-[var(--text-faint)]
-						"
-						data-search-input
-					/>
-				</div>
-
-				<!-- Expand/Collapse All Toggle -->
-				{#if activeView === 'groups' && groupedSkills.length > 1}
-					<button
-						onclick={toggleAllGroups}
-						class="
-							flex items-center gap-1.5 px-3 py-2
-							text-sm font-medium
-							text-[var(--text-secondary)]
-							hover:text-[var(--text-primary)]
-							bg-[var(--bg-base)]
-							border border-[var(--border)]
-							rounded-lg
-							transition-all
-							hover:bg-[var(--bg-subtle)]
-							whitespace-nowrap
-						"
-						title={allExpanded ? 'Collapse all groups' : 'Expand all groups'}
-					>
-						{#if allExpanded}
-							<ChevronsDownUp size={16} />
-							<span class="hidden sm:inline">Collapse All</span>
-						{:else}
-							<ChevronsUpDown size={16} />
-							<span class="hidden sm:inline">Expand All</span>
-						{/if}
+			<!-- Sort footer -->
+			<div class="flex-shrink-0 border-t flex items-center justify-between" style="padding: 10px 16px; border-color: var(--border-subtle);">
+				<span style="font-size: 10px; color: var(--text-faint);">Sorted by utilization</span>
+				{#if selectedPlugin !== null}
+					<button onclick={() => selectedPlugin = null} style="font-size: 10px; color: var(--accent); font-weight: 600;">
+						Clear ×
 					</button>
 				{/if}
 			</div>
-		{/if}
-	</div>
+			{/if}
+		</div>
 
-	<!-- Content Area -->
-	{#if activeView === 'analytics'}
-		<!-- Usage Analytics View -->
-		<UsageAnalytics
-			endpoint="/skills/usage/trend"
-			itemLabel="Skills"
-			colorFn={getSkillChartHex}
-			excludeItemFn={excludeFn}
-			itemLinkPrefix="/skills/"
-			itemDisplayFn={(name) => cleanSkillName(name, name.includes(':'))}
-		/>
-	{:else if !hasSkills}
-		<!-- Empty State: No skills at all -->
-		<div
-			class="text-center py-20 bg-[var(--bg-subtle)] rounded-2xl border border-dashed border-[var(--border)]"
-		>
-			<Zap class="mx-auto text-[var(--text-muted)] mb-3" size={48} />
-			<p class="text-[var(--text-secondary)] font-medium">No skills found</p>
-			<p class="text-sm text-[var(--text-muted)] mt-1">
-				Skill usage data will appear here once you start using skills in Claude Code
-			</p>
-		</div>
-	{:else if !hasFilteredSkills}
-		<!-- Empty State: No matching results -->
-		<div
-			class="text-center py-20 bg-[var(--bg-subtle)] rounded-2xl border border-dashed border-[var(--border)]"
-		>
-			<Search class="mx-auto text-[var(--text-muted)] mb-3" size={48} />
-			<p class="text-[var(--text-secondary)] font-medium">No matching skills</p>
-			<p class="text-sm text-[var(--text-muted)] mt-1">
-				Try adjusting your search or filter
-			</p>
-		</div>
-	{:else if activeView === 'table'}
-		<!-- Flat Table View -->
-		<SkillUsageTable skills={filteredSkills} />
-	{:else}
-		<!-- Grouped Skill Display (By Category) -->
-		<div class="space-y-4">
-			{#each groupedSkills as group (group.key)}
-				{@const groupColors = group.key.startsWith('plugin:') ? getSkillGroupColorVars(group.key) : getSkillCategoryColorVars(group.key)}
-				<CollapsibleGroup
-					title={group.label}
-					open={expandedGroups.has(group.key)}
-					onOpenChange={() => toggleGroup(group.key)}
-				>
-					{#snippet icon()}
+		<!-- ── Right Panel: Top Skills Leaderboard ──────────────────────────── -->
+		<div class="flex-1 flex flex-col overflow-hidden min-w-0" style="background: var(--bg-base); border: 1px solid var(--border); border-radius: 12px;">
+
+			<!-- Panel header -->
+			<div
+				class="flex-shrink-0 flex items-center justify-between border-b"
+				style="padding: 14px 16px 12px; background: var(--bg-base); border-color: var(--border);"
+			>
+				<div>
+					<div style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace; margin-bottom: 3px;">Top Skills</div>
+					<div style="font-size: 11px; color: var(--text-faint);">
+						{#if selectedPlugin !== null}
+							{@const pg = leftPanelGroups.find(g => (g.pluginName ?? g.key) === selectedPlugin)}
+							{rightPanelSkills.length} skills · {pg?.label ?? selectedPlugin}
+						{:else}
+							{rightPanelSkills.length} active skills ranked by usage
+						{/if}
+					</div>
+				</div>
+
+				<!-- View toggle + Sort dropdown -->
+				<div class="flex items-center gap-2">
+				<!-- List/Grid toggle -->
+				<div class="flex rounded-md overflow-hidden" style="border: 1px solid var(--border);">
+					<button
+						onclick={() => skillsView = 'list'}
+						style="padding: 5px 8px; background: {skillsView === 'list' ? 'var(--bg-muted)' : 'transparent'}; color: {skillsView === 'list' ? 'var(--text-primary)' : 'var(--text-faint)'}; display: flex; align-items: center;"
+						title="List view"
+					><LayoutList size={13} /></button>
+					<button
+						onclick={() => skillsView = 'grid'}
+						style="padding: 5px 8px; background: {skillsView === 'grid' ? 'var(--bg-muted)' : 'transparent'}; color: {skillsView === 'grid' ? 'var(--text-primary)' : 'var(--text-faint)'}; display: flex; align-items: center; border-left: 1px solid var(--border);"
+						title="Grid view"
+					><LayoutGrid size={13} /></button>
+				</div>
+
+				<!-- Sort dropdown -->
+				<div class="relative">
+					<button
+						onclick={() => showSortMenu = !showSortMenu}
+						class="flex items-center gap-1.5 rounded-lg transition-colors"
+						style="padding: 5px 10px; background: var(--bg-base); border: 1px solid var(--border); font-size: 11px; font-weight: 500; color: var(--text-secondary);"
+					>
+						<ArrowDownNarrowWide size={12} style="color: var(--text-faint);" />
+						{sortLabels[sortBy]}
+						<ChevronDown size={11} style="color: var(--text-faint);" />
+					</button>
+					{#if showSortMenu}
+						<!-- svelte-ignore a11y_no_static_element_interactions -->
 						<div
-							class="p-1.5 rounded-md"
-							style="background-color: {groupColors.subtle};"
+							class="absolute right-0 top-full mt-1 rounded-lg border shadow-lg z-10 overflow-hidden"
+							style="background: var(--bg-base); border-color: var(--border); min-width: 160px;"
+							onmouseleave={() => showSortMenu = false}
 						>
-							{#if group.icon === Puzzle}
-								<Puzzle size={14} style="color: {groupColors.color};" />
-							{:else if group.icon === Sparkles}
-								<Sparkles size={14} style="color: {groupColors.color};" />
-							{:else if group.icon === FolderOpen}
-								<FolderOpen size={14} style="color: {groupColors.color};" />
-							{:else}
-								<Zap size={14} style="color: {groupColors.color};" />
-							{/if}
-						</div>
-					{/snippet}
-					{#snippet metadata()}
-						{@const usedCount = group.skills.filter((s) => s.count > 0).length}
-						<div class="flex items-center gap-3">
-							<span class="text-xs text-[var(--text-muted)] tabular-nums">
-								{#if usedCount < group.skills.length}
-									{usedCount} used · {group.skills.length} total
-								{:else}
-									{group.skills.length} skill{group.skills.length !== 1 ? 's' : ''}
-								{/if}
-							</span>
-							{#if group.pluginName}
-								<a
-									href="/plugins/{encodeURIComponent(group.pluginName)}"
-									class="
-										inline-flex items-center gap-1 px-2 py-0.5
-										text-[10px] font-medium
-										text-[var(--accent)] hover:text-[var(--text-primary)]
-										bg-[var(--accent-subtle)] hover:bg-[var(--bg-muted)]
-										rounded-full
-										transition-colors
-									"
-									onclick={(e) => e.stopPropagation()}
-									title="View plugin"
+							{#each (['count', 'session_count', 'last_used'] as const) as key}
+								<button
+									class="w-full text-left px-3 py-2 transition-colors hover:bg-[var(--bg-subtle)]"
+									style="font-size: 12px; color: {sortBy === key ? 'var(--accent)' : 'var(--text-secondary)'}; font-weight: {sortBy === key ? '600' : '400'};"
+									onclick={() => { sortBy = key; showSortMenu = false; }}
 								>
-									<Puzzle size={10} />
-									View plugin
-									<ExternalLink size={9} />
-								</a>
-							{/if}
+									{sortLabels[key]}
+								</button>
+							{/each}
 						</div>
-					{/snippet}
+					{/if}
+				</div>
+				</div>
+			</div>
 
-					{@const sortedSkills = group.skills.slice().sort((a, b) => {
-						if (a.count > 0 && b.count === 0) return -1;
-						if (a.count === 0 && b.count > 0) return 1;
-						if (a.count > 0 && b.count > 0) return b.count - a.count;
-						return a.name.localeCompare(b.name);
-					})}
-					<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 stagger-children">
-						{#each sortedSkills as skill (skill.name)}
-							<SkillUsageCard {skill} {maxUsage} />
+			<!-- Table container -->
+			<div class="flex-1 overflow-y-auto">
+				{#if rightPanelSkills.length === 0}
+					<div class="flex flex-col items-center justify-center h-full gap-3">
+						<Search size={36} style="color: var(--text-faint);" />
+						<p style="font-size: 13px; color: var(--text-secondary); font-weight: 500;">No matching skills</p>
+						<p style="font-size: 11px; color: var(--text-faint);">Try adjusting filters or search</p>
+					</div>
+				{:else if skillsView === 'list'}
+					<!-- Column headers -->
+					<div
+						class="grid sticky top-0 border-b"
+						style="background: var(--bg-base); border-color: var(--border); grid-template-columns: 32px 1fr 160px 100px 56px 64px 72px; padding: 10px 12px 8px;"
+					>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; text-align: center;">#</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase;">Skill</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase;">Source</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; padding: 0 8px;">Invocations</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; text-align: right;">Uses</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; text-align: right;">Sessions</div>
+						<div style="font-size: 10px; color: var(--text-faint); letter-spacing: 0.06em; text-transform: uppercase; text-align: right;">Last used</div>
+					</div>
+
+					<!-- Skill rows -->
+					{#each rightPanelSkills as skill, i (skill.name)}
+						{@const displayName = cleanSkillName(skill.name, skill.is_plugin)}
+						{@const barWidth = Math.round((skill.count / globalMax) * 100)}
+						{@const sourceBadge = getSourceBadgeLabel(skill)}
+						{@const colors = getSkillColors(skill)}
+						{@const useColor = selectedFilter === 'plugin' && skill.is_plugin}
+						<a
+							href="/skills/{encodeURIComponent(skill.name)}"
+							class="grid border-b transition-colors hover:bg-[var(--bg-subtle)] no-underline"
+							style="grid-template-columns: 32px 1fr 160px 100px 56px 64px 72px; padding: 8px 12px; border-color: var(--border-subtle); align-items: center;"
+						>
+							<div style="font-size: 11px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace; text-align: center;">{i + 1}</div>
+							<div class="min-w-0 pr-3">
+								<span class="truncate block" style="font-size: 13px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;" title={displayName}>{displayName}</span>
+							</div>
+							<div class="min-w-0">
+								{#if useColor && skill.plugin}
+									<span class="truncate block rounded" style="font-size: 10px; font-weight: 700; font-family: 'JetBrains Mono', monospace; padding: 2px 7px; color: var(--bg-base); background: {colors.color}; display: inline-block; max-width: 100%;" title={skill.plugin}>{skill.plugin}</span>
+								{:else}
+									<span class="truncate block" style="font-size: 11px; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace;" title={sourceBadge}>{sourceBadge}</span>
+								{/if}
+							</div>
+							<div style="padding: 0 8px;">
+								<div style="background: var(--bg-muted); height: 4px; border-radius: 2px; overflow: hidden;">
+									<div style="height: 100%; border-radius: 2px; width: {barWidth}%; background: {useColor ? colors.color : 'var(--accent)'}; opacity: 0.7;"></div>
+								</div>
+							</div>
+							<div style="font-size: 13px; font-weight: 700; font-family: 'JetBrains Mono', monospace; text-align: right; color: {useColor ? colors.color : 'var(--text-primary)'};">{skill.count}</div>
+							<div style="font-size: 12px; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace; text-align: right;">{skill.session_count ?? 0}</div>
+							<div style="font-size: 11px; font-weight: 500; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace; text-align: right;">{shortDate(skill.last_used)}</div>
+						</a>
+					{/each}
+				{:else}
+					<!-- Grid view -->
+					<div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 8px; padding: 12px;">
+						{#each rightPanelSkills as skill, i (skill.name)}
+							{@const displayName = cleanSkillName(skill.name, skill.is_plugin)}
+							{@const barWidth = Math.round((skill.count / globalMax) * 100)}
+							{@const sourceBadge = getSourceBadgeLabel(skill)}
+							{@const colors = getSkillColors(skill)}
+							{@const useColor = selectedFilter === 'plugin' && skill.is_plugin}
+							<a
+								href="/skills/{encodeURIComponent(skill.name)}"
+								class="flex flex-col no-underline rounded-lg transition-all"
+								style="padding: 14px 14px 12px; gap: 6px;
+									border: 1px solid {useColor ? colors.subtle : 'var(--border-subtle)'};
+									background: {useColor ? colors.subtle : 'var(--bg-subtle)'};"
+								onmouseenter={(e) => { (e.currentTarget as HTMLElement).style.borderColor = useColor ? colors.color : 'var(--border)'; (e.currentTarget as HTMLElement).style.background = useColor ? colors.subtle : 'var(--bg-base)'; }}
+								onmouseleave={(e) => { (e.currentTarget as HTMLElement).style.borderColor = useColor ? colors.subtle : 'var(--border-subtle)'; (e.currentTarget as HTMLElement).style.background = useColor ? colors.subtle : 'var(--bg-subtle)'; }}
+							>
+								<!-- Count — hero -->
+								<div style="font-size: 28px; font-weight: 800; font-family: 'JetBrains Mono', monospace; letter-spacing: -1px; line-height: 1;
+									color: {useColor ? colors.color : 'var(--accent)'};">
+									{skill.count}
+								</div>
+
+								<!-- Skill name -->
+								<div class="min-w-0" style="margin-top: 2px;">
+									<span class="block truncate" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;" title={displayName}>{displayName}</span>
+								</div>
+
+								<!-- Bar -->
+								<div style="background: var(--bg-muted); height: 3px; border-radius: 2px; overflow: hidden; margin-top: 4px;">
+									<div style="height: 100%; border-radius: 2px; width: {barWidth}%; background: {useColor ? colors.color : 'var(--accent)'}; opacity: 0.7;"></div>
+								</div>
+
+								<!-- Footer: source · last used -->
+								<div class="flex items-center justify-between" style="margin-top: 2px; gap: 4px;">
+									{#if useColor && skill.plugin}
+										<span
+											class="truncate rounded"
+											style="font-size: 10px; font-weight: 700; font-family: 'JetBrains Mono', monospace; padding: 2px 7px; color: var(--bg-base); background: {colors.color}; flex-shrink: 1; min-width: 0;"
+											title={skill.plugin}
+										>{skill.plugin}</span>
+									{:else}
+										<span style="font-size: 10px; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace;" class="truncate">{sourceBadge}</span>
+									{/if}
+									<span class="flex items-center gap-1 flex-shrink-0" style="color: var(--text-faint);">
+									<svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+									<span style="font-size: 10px; font-weight: 500; font-family: 'JetBrains Mono', monospace;">{shortDate(skill.last_used)}</span>
+								</span>
+								</div>
+							</a>
 						{/each}
 					</div>
-				</CollapsibleGroup>
-			{/each}
+				{/if}
+			</div>
 		</div>
+
+	</div>
+
+	{:else}
+
+	<!-- Analytics view -->
+	<div style="padding: 18px 24px 64px; display: flex; flex-direction: column; gap: 14px;">
+
+		<!-- Insight banner -->
+		{#if insightText}
+			<div class="flex items-center gap-3 rounded-lg" style="padding: 10px 16px; background: linear-gradient(135deg, var(--accent-muted), color-mix(in oklch, var(--accent-muted), var(--bg-subtle) 50%)); border: 1px solid var(--accent-subtle);">
+				<Sparkles size={14} style="color: var(--accent); flex-shrink: 0;" />
+				<span style="font-size: 12px; color: var(--text-primary); line-height: 1.5;">
+					<strong>{insightText.bold}</strong>{insightText.rest}
+				</span>
+			</div>
+		{/if}
+
+		<!-- Stacked area chart -->
+		<div class="rounded-lg" style="padding: 16px 18px; background: var(--bg-base); border: 1px solid var(--border);">
+			<!-- Header -->
+			<div class="flex items-start justify-between" style="margin-bottom: 12px;">
+				<div>
+					<div style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace; margin-bottom: 5px;">Skill Invocations Over Time</div>
+					{#if stackedChartData}
+						<div class="flex items-center gap-4">
+							<span style="font-size: 11px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace;"><span style="font-weight: 700; color: var(--text-primary);">{stackedChartData.totalInv}</span> total</span>
+							<span style="font-size: 11px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace;"><span style="font-weight: 700; color: var(--text-primary);">{stackedChartData.avgPerDay}</span>/day avg</span>
+							<span style="font-size: 11px; color: var(--text-faint); font-family: 'JetBrains Mono', monospace;">peak <span style="font-weight: 700; color: var(--text-primary);">{stackedChartData.peakVal}</span> on {stackedChartData.peakDate}</span>
+						</div>
+					{/if}
+				</div>
+				<div class="flex items-center gap-3">
+					<!-- Legend -->
+					{#if stackedChartData}
+						<div class="flex items-center gap-2">
+							{#each stackedChartData.groups.slice(0, 4) as g}
+								<div class="flex items-center gap-1.5">
+									<div style="width: 8px; height: 8px; border-radius: 2px; background: {g.color}; flex-shrink: 0;"></div>
+									<span style="font-size: 10px; color: var(--text-faint);" class="truncate" title={g.label}>{g.label.length > 12 ? g.label.slice(0, 11) + '…' : g.label}</span>
+								</div>
+							{/each}
+							{#if stackedChartData.groups.length > 4}
+								<span style="font-size: 10px; color: var(--text-faint);">+{stackedChartData.groups.length - 4} more</span>
+							{/if}
+						</div>
+					{/if}
+					<!-- Range tabs -->
+					<div class="flex overflow-hidden rounded" style="border: 1px solid var(--border);">
+						{#each (['7d', '30d', '90d'] as const) as r}
+							<button
+								onclick={() => { trendRangeUserOverride = true; trendRange = r; }}
+								style="padding: 4px 10px; font-size: 11px; font-weight: {trendRange === r ? '700' : '500'}; font-family: 'JetBrains Mono', monospace; background: {trendRange === r ? 'var(--accent-muted)' : 'var(--bg-subtle)'}; color: {trendRange === r ? 'var(--accent)' : 'var(--text-faint)'}; {r !== '90d' ? 'border-right: 1px solid var(--border);' : ''}"
+							>{r}</button>
+						{/each}
+					</div>
+				</div>
+			</div>
+
+			<!-- SVG stacked area chart -->
+			{#if trendLoading && !trendData}
+				<div style="height: 188px; display: flex; align-items: center; justify-content: center;">
+					<div style="width: 18px; height: 18px; border: 2px solid var(--accent); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
+				</div>
+			{:else if !stackedChartData}
+				<div style="height: 188px; display: flex; align-items: center; justify-content: center; color: var(--text-faint); font-size: 13px;">No data for this period</div>
+			{:else}
+				<!-- Chart container: relative for tooltip positioning -->
+				<div style="position: relative;">
+					<svg
+						bind:this={chartSvgEl}
+						viewBox="0 0 900 188"
+						style="width: 100%; height: 188px; display: block; overflow: visible; cursor: crosshair;"
+						onmousemove={handleChartMouseMove}
+						onmouseleave={() => chartHoverIdx = null}
+					>
+						<defs>
+							{#each stackedChartData.layers as layer}
+								<linearGradient id={layer.gradId} x1="0" y1="0" x2="0" y2="1">
+									<stop offset="0%" stop-color={layer.color} stop-opacity="0.22" />
+									<stop offset="100%" stop-color={layer.color} stop-opacity="0.03" />
+								</linearGradient>
+							{/each}
+						</defs>
+
+						<!-- Gridlines -->
+						{#each stackedChartData.yTicks as tick}
+							<line x1={stackedChartData.cX1} y1={tick.y} x2={stackedChartData.cX2} y2={tick.y} stroke="var(--border)" stroke-width="0.5" />
+							<text x={stackedChartData.cX1 - 5} y={tick.y + 3} text-anchor="end" font-size="9" fill="var(--text-faint)" font-family="JetBrains Mono, monospace">{tick.val}</text>
+						{/each}
+						<line x1={stackedChartData.cX1} y1={stackedChartData.cY2} x2={stackedChartData.cX2} y2={stackedChartData.cY2} stroke="var(--border)" stroke-width="1" />
+
+						<!-- Area fills (bottom layer first) -->
+						{#each stackedChartData.layers as layer}
+							<path d={layer.area} fill="url(#{layer.gradId})" />
+						{/each}
+
+						<!-- Top lines per layer -->
+						{#each stackedChartData.layers as layer, i}
+							<path d={layer.line} fill="none" stroke={layer.color}
+								stroke-width={i === stackedChartData.layers.length - 1 ? 2 : 1.5}
+								stroke-opacity={i === 0 ? 0.5 : 0.8}
+								stroke-dasharray={i === 0 ? '3 3' : 'none'}
+							/>
+						{/each}
+
+						<!-- Hover crosshair -->
+						{#if chartHoverIdx !== null}
+							{@const hx = stackedChartData.xi(chartHoverIdx)}
+							<line x1={hx} y1={stackedChartData.cY1} x2={hx} y2={stackedChartData.cY2} stroke="var(--text-faint)" stroke-width="1" stroke-dasharray="3 2" opacity="0.6" />
+							<!-- Dots at each layer's top for hover index -->
+							{#each stackedChartData.layers as layer}
+								{@const cumY = layer.topPts?.[chartHoverIdx]?.y}
+								{#if cumY !== undefined && layer.counts[chartHoverIdx] > 0}
+									<circle cx={hx} cy={cumY} r="3.5" fill={layer.color} stroke="var(--bg-base)" stroke-width="1.5" />
+								{/if}
+							{/each}
+						{/if}
+
+						<!-- Peak annotation -->
+						{#if chartHoverIdx !== stackedChartData.peakX}
+							<circle cx={stackedChartData.peakX} cy={stackedChartData.peakY} r="4" fill="var(--accent)" stroke="var(--bg-base)" stroke-width="2" />
+							<text x={stackedChartData.peakX} y={stackedChartData.peakY - 10} text-anchor="middle" font-size="10" fill="var(--accent)" font-family="JetBrains Mono, monospace" font-weight="bold">peak · {stackedChartData.peakVal}</text>
+						{/if}
+
+						<!-- X-axis labels -->
+						{#each stackedChartData.xLabels as xl}
+							<text x={xl.x} y="184" text-anchor={xl.anchor} font-size="9" fill="var(--text-faint)" font-family="JetBrains Mono, monospace">{xl.label}</text>
+						{/each}
+					</svg>
+
+					<!-- Tooltip -->
+					{#if tooltipData && chartHoverIdx !== null}
+						{@const svgWidth = chartSvgEl?.getBoundingClientRect().width ?? 900}
+						{@const tipX = (tooltipData.x / 900) * svgWidth}
+						{@const flipLeft = tipX > svgWidth * 0.65}
+						<div
+							style="
+								position: absolute;
+								top: 0;
+								left: {tipX}px;
+								transform: translate({flipLeft ? 'calc(-100% - 10px)' : '10px'}, 4px);
+								pointer-events: none;
+								z-index: 20;
+								background: var(--bg-base);
+								border: 1px solid var(--border);
+								border-radius: 8px;
+								padding: 9px 12px;
+								min-width: 150px;
+								box-shadow: 0 4px 16px rgba(0,0,0,0.18);
+							"
+						>
+							<!-- Date + total -->
+							<div class="flex items-baseline justify-between gap-4" style="margin-bottom: 7px;">
+								<span style="font-size: 11px; font-weight: 700; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;">{tooltipData.date}</span>
+								<span style="font-size: 11px; font-weight: 700; color: var(--accent); font-family: 'JetBrains Mono', monospace;">{tooltipData.total}</span>
+							</div>
+							{#if tooltipData.rows.length > 0}
+								<div style="border-top: 1px solid var(--border-subtle); padding-top: 6px; display: flex; flex-direction: column; gap: 4px;">
+									{#each tooltipData.rows as row}
+										<div class="flex items-center justify-between gap-3">
+											<div class="flex items-center gap-1.5 min-w-0">
+												<div style="width: 7px; height: 7px; border-radius: 2px; background: {row.color}; flex-shrink: 0;"></div>
+												<span class="truncate" style="font-size: 10px; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace;" title={row.label}>{row.label.length > 16 ? row.label.slice(0, 15) + '…' : row.label}</span>
+											</div>
+											<span style="font-size: 10px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace; flex-shrink: 0;">{row.count}</span>
+										</div>
+									{/each}
+								</div>
+							{:else}
+								<div style="font-size: 10px; color: var(--text-faint); padding-top: 4px;">No activity</div>
+							{/if}
+						</div>
+					{/if}
+				</div>
+			{/if}
+		</div>
+
+		<!-- Bottom row: Session Reach + Cost -->
+		<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 14px; align-items: start;">
+
+			<!-- Session Reach panel -->
+			<div class="rounded-lg" style="padding: 16px 18px; background: var(--bg-base); border: 1px solid var(--border);">
+				<div style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace; margin-bottom: 2px;">Session Reach</div>
+				<div style="font-size: 11px; color: var(--text-faint); margin-bottom: 14px;">which skills are embedded in your workflow</div>
+
+				{#if sessionReachSkills.length === 0}
+					<div style="color: var(--text-faint); font-size: 12px; padding: 12px 0;">No data</div>
+				{:else}
+					<!-- Column headers -->
+					<div style="display: grid; grid-template-columns: 1fr 80px 44px; gap: 8px; padding: 0 4px; margin-bottom: 6px;">
+						<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase;">Skill</div>
+						<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase; text-align: center;">sessions</div>
+						<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase; text-align: right;">reach</div>
+					</div>
+					<div style="border-top: 1px solid var(--border-subtle); padding-top: 4px;">
+						{#each sessionReachSkills as skill}
+							{@const colors = getSkillColors(skill)}
+							{@const sessions = skill.session_count ?? 0}
+							{@const barPct = Math.round((sessions / sessionReachMax) * 100)}
+							{@const reachPct = analyticsTotalInvocations > 0 ? Math.round((sessions / analyticsTotalInvocations) * 100) : 0}
+							{@const displayName = cleanSkillName(skill.name, skill.is_plugin)}
+							<a
+								href="/skills/{encodeURIComponent(skill.name)}"
+								class="no-underline"
+								style="display: grid; grid-template-columns: 1fr 80px 44px; gap: 8px; align-items: center; padding: 5px 4px; border-radius: 4px; cursor: pointer;"
+								onmouseenter={(e) => (e.currentTarget as HTMLElement).style.background = 'var(--bg-subtle)'}
+								onmouseleave={(e) => (e.currentTarget as HTMLElement).style.background = 'transparent'}
+							>
+								<div class="flex items-center gap-1.5 min-w-0">
+									<div style="width: 5px; height: 5px; border-radius: 50%; background: {colors.color}; flex-shrink: 0;"></div>
+									<span class="truncate" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;" title={displayName}>{displayName}</span>
+								</div>
+								<div style="background: var(--bg-muted); height: 5px; border-radius: 3px; overflow: hidden;">
+									<div style="height: 100%; border-radius: 3px; width: {barPct}%; background: var(--accent);"></div>
+								</div>
+								<div style="font-size: 10px; font-weight: 700; color: {reachPct >= 30 ? 'var(--accent)' : 'var(--text-faint)'}; text-align: right; font-family: 'JetBrains Mono', monospace;">{sessions}</div>
+							</a>
+						{/each}
+					</div>
+					<div style="margin-top: 10px; border-top: 1px solid var(--border-subtle); padding-top: 8px; font-size: 10px; color: var(--text-faint); line-height: 1.5;">
+						Sessions count how many unique conversations triggered each skill — a high count means it's woven into your day-to-day
+					</div>
+				{/if}
+			</div>
+
+			<!-- Cost panel -->
+			{#if true}
+				{@const avgTokens = 500}
+				{@const pricePerMTok = 3.00}
+				{@const top5 = rightPanelSkills.slice(0, 5)}
+				{@const top5Total = top5.reduce((s, sk) => s + sk.count, 0)}
+				{@const allTotal = analyticsTotalInvocations}
+				{@const costMax = top5.length > 0 ? top5[0].count : 1}
+				{@const otherCount = allTotal - top5Total}
+				{@const estTotalCost = (allTotal * avgTokens * pricePerMTok) / 1_000_000}
+				{@const perInv = allTotal > 0 ? (estTotalCost / allTotal) : 0}
+			<div class="rounded-lg" style="padding: 16px 18px; background: var(--bg-base); border: 1px solid var(--border);">
+				<div style="font-size: 10px; font-weight: 700; color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-family: 'JetBrains Mono', monospace; margin-bottom: 2px;">Estimated Cost</div>
+				<div style="font-size: 11px; color: var(--text-faint); margin-bottom: 12px;">across {allTotal} invocations this period</div>
+
+				<!-- Hero total -->
+				<div class="flex items-baseline gap-2" style="margin-bottom: 4px;">
+					<span style="font-size: 32px; font-weight: 700; color: var(--text-primary); font-family: 'JetBrains Mono', monospace; letter-spacing: -1.5px;">~${estTotalCost < 0.01 ? estTotalCost.toFixed(4) : estTotalCost.toFixed(2)}</span>
+					<span style="font-size: 12px; color: var(--text-faint);">total</span>
+				</div>
+				<div style="font-size: 11px; color: var(--text-secondary); margin-bottom: 14px; font-family: 'JetBrains Mono', monospace;">~${perInv.toFixed(4)} per invocation avg</div>
+
+				<!-- Callout -->
+				<div class="flex gap-2 rounded" style="padding: 7px 10px; margin-bottom: 14px; background: var(--nav-orange-subtle); border: 1px solid color-mix(in oklch, var(--nav-orange) 30%, transparent);">
+					<Info size={12} style="color: var(--nav-orange); flex-shrink: 0; margin-top: 1px;" />
+					<span style="font-size: 10px; color: var(--nav-orange); line-height: 1.5;">Using ~500 tokens/invocation avg · actual cost varies by model and skill file size</span>
+				</div>
+
+				<!-- Column headers -->
+				<div style="display: grid; grid-template-columns: 1fr 1fr 40px 68px; gap: 10px; padding: 0 4px; margin-bottom: 6px;">
+					<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase;">Skill</div>
+					<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase;">Cost share</div>
+					<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase; text-align: right;">%</div>
+					<div style="font-size: 9px; color: var(--text-faint); letter-spacing: 0.1em; text-transform: uppercase; text-align: right;">Est. cost</div>
+				</div>
+
+				{#each top5 as skill}
+					{@const skillCost = (skill.count * avgTokens * pricePerMTok) / 1_000_000}
+					{@const pct = allTotal > 0 ? Math.round((skill.count / allTotal) * 100) : 0}
+					{@const barPct = Math.round((skill.count / costMax) * 100)}
+					{@const displayName = cleanSkillName(skill.name, skill.is_plugin)}
+					<a
+						href="/skills/{encodeURIComponent(skill.name)}"
+						class="no-underline cost-row"
+						style="display: grid; grid-template-columns: 1fr 1fr 40px 68px; gap: 10px; align-items: center; padding: 7px 4px; border-radius: 5px; cursor: pointer;"
+						onmouseenter={(e) => (e.currentTarget as HTMLElement).style.background = 'color-mix(in oklch, var(--nav-orange) 6%, transparent)'}
+						onmouseleave={(e) => (e.currentTarget as HTMLElement).style.background = 'transparent'}
+					>
+						<div class="truncate" style="font-size: 12px; font-weight: 600; color: var(--text-primary); font-family: 'JetBrains Mono', monospace;" title={displayName}>{displayName}</div>
+						<div style="background: color-mix(in oklch, var(--nav-orange) 15%, transparent); height: 7px; border-radius: 4px; overflow: hidden;">
+							<div style="background: var(--nav-orange); width: {barPct}%; height: 7px;"></div>
+						</div>
+						<div style="font-size: 11px; color: var(--text-faint); text-align: right; font-family: 'JetBrains Mono', monospace;">{pct}%</div>
+						<div style="font-size: 12px; font-weight: 700; color: var(--text-primary); text-align: right; font-family: 'JetBrains Mono', monospace;">~${skillCost.toFixed(3)}</div>
+					</a>
+				{/each}
+
+				{#if otherCount > 0}
+					{@const otherCost = (otherCount * avgTokens * pricePerMTok) / 1_000_000}
+					{@const otherPct = Math.round((otherCount / allTotal) * 100)}
+					{@const otherBarPct = Math.round((otherCount / costMax) * 100)}
+					<div style="display: grid; grid-template-columns: 1fr 1fr 40px 68px; gap: 10px; align-items: center; padding: 7px 4px; border-top: 1px dashed var(--border-subtle); margin-top: 2px;">
+						<div style="font-size: 11px; color: var(--text-faint); font-style: italic;">{rightPanelSkills.length - 5} other skills</div>
+						<div style="background: var(--bg-muted); height: 7px; border-radius: 4px; overflow: hidden;">
+							<div style="background: var(--text-faint); width: {Math.min(otherBarPct, 100)}%; height: 7px; opacity: 0.5;"></div>
+						</div>
+						<div style="font-size: 11px; color: var(--text-faint); text-align: right; font-family: 'JetBrains Mono', monospace;">{otherPct}%</div>
+						<div style="font-size: 12px; font-weight: 600; color: var(--text-faint); text-align: right; font-family: 'JetBrains Mono', monospace;">~${otherCost.toFixed(3)}</div>
+					</div>
+				{/if}
+
+				<div style="margin-top: 12px; border-top: 1px solid var(--border-subtle); padding-top: 8px; font-size: 10px; color: var(--text-faint); line-height: 1.6;">
+					~{avgTokens} tokens/invocation · Sonnet ${pricePerMTok}/MTok · actual cost varies by model &amp; skill file size
+				</div>
+			</div>
+			{/if}
+
+		</div>
+
+	</div>
+
 	{/if}
-	{/if}
+
 </div>
+
+{/if}


### PR DESCRIPTION
## Summary

Rebuilds the session detail page's secondary navigation from a tab-based layout into a persistent **68 px icon rail + 350 px contextual drawers** pattern. Every drawer panel was redesigned from scratch to fit the 350 px constraint without horizontal scroll, and visual consistency with the homepage and the /cron / /shells routes was established.

---

## Rail

- **Always-visible icons** for every available drawer. Unavailable items are shown at 0.7 opacity with a tooltip ("No agents in this session", "No cron jobs in this session", etc.) instead of being hidden or dotted inconsistently.
- **Tooltip fix for disabled buttons**: browsers suppress `title` on `pointer-events: none` elements. Solved by wrapping each rail button in a `<span>` with real dimensions that carries the `title` attribute.
- **Homepage custom icons** (Icon.svelte) used for Agents, Plan, Shells, Cron, Tickets — so users recognise them from the nav.
- `Icon.svelte` gains a `color` prop via a `display:contents` wrapper so the rail can tint icons active/inactive.
- `DrawerKey` union extended with `'cron'`.

## Shell drawer (`SessionShellsSection`)

- Rebuilt as **individual `rounded-lg` cards** with `gap-2` between them (was a flat bordered list).
- Status dot only — no text label in each row. Dot animates with `animate-pulse` when running.
- Status colours match the `/shells` route: `running → --success`, `kill → --error`, `natural → --info`, `timeout → --warning`, `session_end → --text-faint`.
- **Shell count pre-fetched** so the rail icon is hidden only on confirmed-empty responses, not on 404/errors (live sessions that haven't been written to DB yet still show the icon).
- **Legend** (all 5 states) pinned to the drawer footer via a `flex-shrink-0` strip — not inside the component.

## Cron drawer (`SessionCronSection`)

- **Full rewrite** to match the `/cron` route card design exactly:
  - `grid-template-columns: 10px 1fr 16px` row (dot · content · caret)
  - `Repeat`/`Zap` type icon in an 18 px square (blue for recurring, grey for one-shot)
  - Status tag with active/likely/deleted/expired colouring
  - Prompt truncates collapsed, expands in place
  - Meta line: `schedule · N fires · TTL remaining`
- **Expanded panel** is single-column (removed the `220px 1fr` two-column grid that blew out 350 px).
- **Fire history** uses the same dot+vertical-line timeline as `/cron`: `grid-template-columns: 18px 1fr`, connected dots, "confirmed" badge for hook-sourced fires.
- Cron icon added to rail; count pre-fetched from `GET /sessions/{uuid}/cron`.

## Agents drawer

- **Individual `rounded-lg border` cards** with `gap-2` (was a flat `SubagentGroup` component).
- Per-agent **expand/collapse** of the full prompt via `expandedAgentIds = $state<Set<string>>()`.
- Agent colour vars and ID formatting from shared utils.

## Plan drawer

- `app.css` gains `.markdown-preview--compact` modifier class: smaller `h1`/`h2`/`h3`/`p`/`ul`/`code`/`pre` sizing for the 350 px panel.
- `PlanViewer` uses `markdown-preview markdown-preview--compact` in embedded mode.

## Skills drawer (`SkillsPanel`)

- **Individual `rounded-lg` cards** with `gap-1.5` (was one flat bordered list with `border-t` dividers).
- Each card has hover border-color transition.

## Commands drawer (`CommandsPanel`)

- Flat bordered list (unchanged structure, already fits 350 px).
- Header compacted to `text-[10px] uppercase` count label.

## Tasks drawer (`TasksTab`)

- Removed large `h2` heading and description paragraph.
- Compact count label + `text-[11px]` view-mode toggle with `size={12}` icons.

## Tickets drawer (`SessionTicketsSection` + `TicketLinkInput`)

- Cards rebuilt with a **3-section layout**: header (provider badge + truncated key link + unlink button) · body (title, line-clamp-2) · footer (status dot + label, separated by a border).
- Provider badge uses `colorVar`/`subtleVar` from `PROVIDER_META` for branded colours (GH purple, LIN violet, JIR blue).
- `TicketLinkInput` placeholder shortened; hint text simplified and `break-all` on code blocks — eliminates horizontal overflow.

---

## Test plan

- [ ] Open a session with agents, plan, shells, cron, tickets, skills, commands, tasks — verify all rail icons appear and open the correct drawer
- [ ] Open a session with none of the above — verify icons are shown at 0.7 opacity and tooltip reads "No X in this session"
- [ ] Shell drawer: running shells show animated green dot; killed/timed-out shells show correct colour; legend footer shows all 5 states
- [ ] Cron drawer: collapsed row shows correct status tag and fires count; expand shows fire timeline with dot+line; fires with `inference_source === 'hook'` show "confirmed" badge
- [ ] Tickets drawer: long keys like `owner/VeryLongRepoName#123` truncate without horizontal scroll; unlink + undo flow works
- [ ] No horizontal scroll in any drawer at 350 px width

🤖 Generated with [Claude Code](https://claude.com/claude-code)