### PR TITLE
fix(terminal-focus): actually raise Terminal.app windows + dead-session lifecycle

### DIFF
--- a/api/services/terminal_focus.py
+++ b/api/services/terminal_focus.py
@@ -19,6 +19,7 @@ The terminal identifiers come from
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -58,16 +59,32 @@ def _applescript_str(value: str) -> str:
     return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r")
 
 
+def _pid_alive(pid: int) -> bool:
+    """Whether a process with this pid still exists (signal 0 probe)."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except OSError:
+        return True  # exists but owned by someone else
+
+
 def can_focus(terminal: Optional[Dict[str, Any]]) -> bool:
     """Whether we have an identifier we could plausibly focus on this host.
 
     tmux panes are focusable on any OS; GUI-window focus depends on the host
-    the API is running on (which is the same machine as the terminal).
+    the API is running on (which is the same machine as the terminal). A dead
+    captured pid means the session's window can no longer be located, so the
+    button is withheld (killed/crashed sessions linger as STALE state files).
     """
     if not terminal:
         return False
     if terminal.get("tmux_pane"):
         return True
+    pid = terminal.get("pid")
+    if pid and not _pid_alive(pid):
+        return False
     if sys.platform == "darwin" and terminal.get("term_program"):
         return True
     if sys.platform.startswith("linux") and terminal.get("window_id"):
@@ -100,20 +117,31 @@ def _focus_tmux(pane: str) -> Dict[str, Any]:
 # Per-app AppleScript to select the exact tab owning a tty. Keyed by
 # TERM_PROGRAM so we never `tell` (and thereby launch) an app the session
 # isn't actually running in. `{tty}` is substituted with e.g. /dev/ttys006.
+# Terminal.app silently ignores `set index`/`set frontmost`, so a non-front
+# window is raised via a miniaturize cycle (the only permission-free raise;
+# AXRaise would require an Accessibility grant).
 _MAC_TAB_SCRIPTS: Dict[str, str] = {
     "Apple_Terminal": (
         'tell application "Terminal"\n'
+        "    set matchedId to 0\n"
         "    repeat with w in windows\n"
         "        repeat with t in tabs of w\n"
         '            if tty of t is "{tty}" then\n'
         "                set selected of t to true\n"
-        "                set index of w to 1\n"
-        "                activate\n"
-        "                return id of w\n"
+        "                set matchedId to id of w\n"
+        "                exit repeat\n"
         "            end if\n"
         "        end repeat\n"
+        "        if matchedId is not 0 then exit repeat\n"
         "    end repeat\n"
-        '    return ""\n'
+        '    if matchedId is 0 then return ""\n'
+        "    activate\n"
+        "    if id of front window is not matchedId then\n"
+        "        set miniaturized of window id matchedId to true\n"
+        "        delay 0.4\n"
+        "        set miniaturized of window id matchedId to false\n"
+        "    end if\n"
+        "    return matchedId\n"
         "end tell"
     ),
     "iTerm.app": (
@@ -189,8 +217,16 @@ def _focus_macos(term_program: str, pid: Optional[int] = None) -> Dict[str, Any]
     """
     if not shutil.which("osascript"):
         return {"focused": False, "method": "osascript", "detail": "osascript not found"}
-    tty = _tty_for_pid(pid) if pid else None
-    if tty:
+    if pid:
+        tty = _tty_for_pid(pid)
+        if tty is None:
+            # Dead/recycled pid: the window can't be located, and blindly
+            # activating the app would raise an arbitrary window.
+            return {
+                "focused": False,
+                "method": "osascript-tab",
+                "detail": "Could not locate the session's terminal window (its process is gone or has no tty).",
+            }
         exact = _focus_macos_tab(term_program, tty)
         if exact:
             return exact

--- a/api/services/terminal_focus.py
+++ b/api/services/terminal_focus.py
@@ -60,7 +60,9 @@ def _applescript_str(value: str) -> str:
 
 
 def _pid_alive(pid: int) -> bool:
-    """Whether a process with this pid still exists (signal 0 probe)."""
+    """Whether a process with this pid still exists (POSIX signal-0 probe)."""
+    if os.name != "posix":
+        return True  # os.kill(pid, 0) TERMINATES processes on Windows — never probe there
     try:
         os.kill(pid, 0)
         return True
@@ -82,11 +84,9 @@ def can_focus(terminal: Optional[Dict[str, Any]]) -> bool:
         return False
     if terminal.get("tmux_pane"):
         return True
-    pid = terminal.get("pid")
-    if pid and not _pid_alive(pid):
-        return False
     if sys.platform == "darwin" and terminal.get("term_program"):
-        return True
+        pid = terminal.get("pid")
+        return _pid_alive(pid) if pid else True
     if sys.platform.startswith("linux") and terminal.get("window_id"):
         return True
     return False

--- a/api/tests/test_terminal_focus.py
+++ b/api/tests/test_terminal_focus.py
@@ -344,3 +344,51 @@ def test_focus_macos_no_pid_keeps_activate_behavior(monkeypatch):
 
 def test_applescript_str_escapes_control_characters():
     assert terminal_focus._applescript_str('a"b\\c\nd\re') == 'a\\"b\\\\c\\nd\\re'
+
+
+# ---------------------------------------------------------------------------
+# Window raise + dead-session lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_app_script_raises_via_miniaturize_cycle():
+    # Terminal.app ignores `set index`/`set frontmost`; the script must use
+    # the miniaturize cycle and only when the window isn't already front.
+    script = terminal_focus._MAC_TAB_SCRIPTS["Apple_Terminal"]
+    assert "set miniaturized" in script
+    assert "if id of front window is not matchedId" in script
+    assert "set index" not in script
+
+
+def test_focus_macos_dead_pid_fails_instead_of_wrong_window(monkeypatch):
+    monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
+    monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
+
+    calls = []
+
+    def fake_run(cmd):
+        calls.append(cmd)
+        if cmd[0] == "ps":
+            return _FakeCompleted(returncode=1)  # process gone
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(terminal_focus, "_run", fake_run)
+    result = terminal_focus.focus_terminal({"term_program": "Apple_Terminal", "pid": 424242})
+    assert result["focused"] is False
+    assert "Could not locate" in result["detail"]
+    # No blind app activation of an arbitrary window.
+    assert not any(c[0] == "osascript" for c in calls)
+
+
+def test_can_focus_dead_pid_hides_button(monkeypatch):
+    monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
+    monkeypatch.setattr(terminal_focus, "_pid_alive", lambda pid: False)
+    assert terminal_focus.can_focus({"term_program": "Apple_Terminal", "pid": 1234}) is False
+    # tmux panes can outlive the process; stay focusable.
+    assert terminal_focus.can_focus({"tmux_pane": "%1", "pid": 1234}) is True
+
+
+def test_can_focus_alive_pid(monkeypatch):
+    monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
+    monkeypatch.setattr(terminal_focus, "_pid_alive", lambda pid: True)
+    assert terminal_focus.can_focus({"term_program": "Apple_Terminal", "pid": 1234}) is True

--- a/api/tests/test_terminal_focus.py
+++ b/api/tests/test_terminal_focus.py
@@ -392,3 +392,25 @@ def test_can_focus_alive_pid(monkeypatch):
     monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
     monkeypatch.setattr(terminal_focus, "_pid_alive", lambda pid: True)
     assert terminal_focus.can_focus({"term_program": "Apple_Terminal", "pid": 1234}) is True
+
+
+def test_can_focus_never_probes_pid_on_non_macos(monkeypatch):
+    # os.kill(pid, 0) terminates processes on Windows; the probe must be
+    # unreachable on platforms whose branches can't return True anyway.
+    def boom(pid):
+        raise AssertionError("pid probe must not run here")
+
+    monkeypatch.setattr(terminal_focus, "_pid_alive", boom)
+    monkeypatch.setattr(terminal_focus.sys, "platform", "win32")
+    assert terminal_focus.can_focus({"term_program": "Apple_Terminal", "pid": 1234}) is False
+    monkeypatch.setattr(terminal_focus.sys, "platform", "linux")
+    assert terminal_focus.can_focus({"window_id": "123", "pid": 1234}) is True
+
+
+def test_pid_alive_short_circuits_off_posix(monkeypatch):
+    def boom(pid, sig):
+        raise AssertionError("os.kill must not run off POSIX")
+
+    monkeypatch.setattr(terminal_focus.os, "kill", boom)
+    monkeypatch.setattr(terminal_focus.os, "name", "nt")
+    assert terminal_focus._pid_alive(1234) is True


### PR DESCRIPTION
## Summary

Follow-up to #86, fixing the "wrong window raised" report on native macOS Terminal.

Two real bugs:

1. **Terminal.app ignores `set index`/`set frontmost`** — verified empirically with instrumented AppleScript (index stays unchanged, no error). The exact-tab script selected the correct tab but the subsequent `activate` raised whichever Terminal window was already frontmost. It only *looked* correct when the target happened to be the front window (which is why #86's live tests passed). Fix: `activate` + a miniaturize cycle on the matched window — the only permission-free raise that works (AXRaise needs an Accessibility grant; `visible` cycling doesn't raise). Also capture the matched window id before any reordering so the response `detail` is truthful.
2. **Dead sessions kept a live button** — a claude killed/crashed without SessionEnd lingers as a STALE state file; its dead pid made the exact-tab path bail into blind app activation → arbitrary window + "opened!". Now `can_focus` probes pid liveness (signal-0), hiding the button for dead sessions, and a click that races the death returns `focused: false` with an explanatory detail.

## Testing

- [x] 38 terminal tests pass (4 new: miniaturize-cycle script contract, dead-pid focus failure, dead/alive pid gating)
- [x] Live-verified: occu-go-api window (id 14379) raised via the API with Terminal as the active app — the exact case that failed before
- [x] Live-verified: dead-pid session hides the button (`can_focus_terminal: false`) and fails honestly on POST
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017REfqdyZ2g8W9DRiNyJrU3