### PR TITLE
fix(terminal-tracking): durable identity, honest focus results, tmux GUI raise, dead-session reaper

### DIFF
--- a/api/models/live_session.py
+++ b/api/models/live_session.py
@@ -131,6 +131,16 @@ class TerminalInfo(BaseModel):
     pid: Optional[int] = Field(
         None, description="PID of the claude process (used to resolve its tty for exact-tab focus)"
     )
+    tty: Optional[str] = Field(
+        None,
+        description="Controlling tty captured while the process was alive, e.g. '/dev/ttys006'",
+    )
+    iterm_session_id: Optional[str] = Field(
+        None, description="iTerm2 session id (ITERM_SESSION_ID), e.g. 'w0t2p0:UUID'"
+    )
+    bundle_id: Optional[str] = Field(
+        None, description="macOS bundle id of the spawning app (__CFBundleIdentifier)"
+    )
 
 
 class LiveSessionState(BaseModel):

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -975,6 +975,9 @@ class TerminalInfo(BaseModel):
     term_session_id: Optional[str] = Field(None, description="Terminal session id (TERM_SESSION_ID)")
     window_id: Optional[str] = Field(None, description="X11 window id (WINDOWID)")
     pid: Optional[int] = Field(None, description="claude PID (tty lookup for exact-tab focus)")
+    tty: Optional[str] = Field(None, description="Controlling tty captured while alive")
+    iterm_session_id: Optional[str] = Field(None, description="iTerm2 session id (ITERM_SESSION_ID)")
+    bundle_id: Optional[str] = Field(None, description="macOS app bundle id (__CFBundleIdentifier)")
 
 
 class TerminalFocusResult(BaseModel):

--- a/api/services/live_session_store.py
+++ b/api/services/live_session_store.py
@@ -160,6 +160,30 @@ def delete_state(session_id: str) -> bool:
     return False
 
 
+def _iter_state_files():
+    """Yield ``(path, data)`` for every readable state file; skips malformed ones."""
+    live_dir = get_live_sessions_dir()
+    if not live_dir.exists():
+        return
+    for path in live_dir.glob("*.json"):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                yield path, json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+
+
+def _parse_timestamp(value: Any) -> Optional[datetime]:
+    """Parse an ISO timestamp from state JSON; None when missing/invalid."""
+    if not value:
+        return None
+    try:
+        ts = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    return ts.replace(tzinfo=timezone.utc) if ts.tzinfo is None else ts
+
+
 def purge_old_files(
     *,
     ended_max_age_sec: int = 600,
@@ -173,32 +197,15 @@ def purge_old_files(
 
     Returns the number of files deleted.
     """
-    live_dir = get_live_sessions_dir()
-    if not live_dir.exists():
-        return 0
-
     now = datetime.now(timezone.utc)
     deleted = 0
 
-    for path in live_dir.glob("*.json"):
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                data = json.load(f)
-        except (OSError, json.JSONDecodeError):
-            continue
-
+    for path, data in _iter_state_files():
         state = data.get("state")
-        updated_at = data.get("updated_at")
-        if not state or not updated_at:
-            continue
         if state not in ("ENDED", "STARTING"):
             continue
-
-        try:
-            ts = datetime.fromisoformat(str(updated_at).replace("Z", "+00:00"))
-            if ts.tzinfo is None:
-                ts = ts.replace(tzinfo=timezone.utc)
-        except ValueError:
+        ts = _parse_timestamp(data.get("updated_at"))
+        if ts is None:
             continue
 
         max_age = ended_max_age_sec if state == "ENDED" else starting_max_age_sec
@@ -223,6 +230,85 @@ def purge_old_files(
     return deleted
 
 
+# States that mean "the session is (supposedly) still going".
+_NON_TERMINAL_STATES = ("LIVE", "WAITING", "STOPPED", "STALE", "STARTING")
+
+# Files younger than this are never reaped — protects freshly-written state
+# from racing its own hook events (and pathological clock skew).
+_REAP_MIN_AGE_SEC = 30
+
+# Non-terminal files with no captured pid can't be probed; end them once
+# they've been silent this long (dead sessions used to linger forever).
+_PIDLESS_MAX_AGE_SEC = 24 * 3600
+
+
+def reap_dead_sessions() -> int:
+    """Mark non-terminal sessions whose claude process is gone as ENDED.
+
+    Sessions killed without a SessionEnd hook (SIGKILL, crash, closed
+    terminal window) previously lingered in STOPPED/STALE/WAITING forever —
+    no cleanup path covered those states. The captured pid gives direct
+    evidence: dead, or recycled onto a non-claude process, means the session
+    is over. Pid-less legacy files fall back to a 24h silence threshold.
+
+    Marks ENDED (end_reason="process_died") rather than deleting, so the
+    normal ENDED display window and ``purge_old_files`` lifecycle apply.
+    Runs from the reconciler background timer. Returns sessions reaped.
+    """
+    # Deferred import: services.terminal_focus owns the pid probing logic.
+    from services.terminal_focus import pid_is_live_claude
+
+    now = datetime.now(timezone.utc)
+    reaped = 0
+
+    for path, data in _iter_state_files():
+        if data.get("state") not in _NON_TERMINAL_STATES:
+            continue
+
+        ts = _parse_timestamp(data.get("updated_at"))
+        if ts is None:
+            continue
+        age_sec = (now - ts).total_seconds()
+        if age_sec < _REAP_MIN_AGE_SEC:
+            continue
+
+        pid = (data.get("terminal") or {}).get("pid")
+        if pid:
+            # Probing only works on the machine the session ran on; both the
+            # API and the hooks run locally, so that's always this host.
+            if pid_is_live_claude(pid):
+                continue
+            reason = "process_died"
+        elif age_sec > _PIDLESS_MAX_AGE_SEC:
+            reason = "reaped_stale"
+        else:
+            continue
+
+        session_id = data.get("session_id") or path.stem
+        # Write to the exact file we probed (legacy slug-named files would
+        # otherwise get a fresh session_id-named file and linger unreaped).
+        _write_under_lock(
+            path,
+            {
+                "session_id": session_id,
+                "state": "ENDED",
+                "end_reason": reason,
+                "last_hook": "Reaper",
+                "updated_at": _now_iso(),
+            },
+        )
+        reaped += 1
+        logger.info(
+            "reap_dead_sessions: ended %s (state=%s reason=%s pid=%s)",
+            session_id,
+            data.get("state"),
+            reason,
+            pid,
+        )
+
+    return reaped
+
+
 def find_state_file_for(identifier: str) -> Optional[Path]:
     """Locate the state file for a slug, session_id, or filename stem.
 
@@ -233,16 +319,7 @@ def find_state_file_for(identifier: str) -> Optional[Path]:
     if direct.exists():
         return direct
 
-    live_dir = get_live_sessions_dir()
-    if not live_dir.exists():
-        return None
-
-    for path in live_dir.glob("*.json"):
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                data = json.load(f)
-        except (OSError, json.JSONDecodeError):
-            continue
+    for path, data in _iter_state_files():
         if (
             data.get("session_id") == identifier
             or data.get("slug") == identifier
@@ -272,5 +349,6 @@ __all__ = [
     "delete_state",
     "delete_by_identifier",
     "purge_old_files",
+    "reap_dead_sessions",
     "find_state_file_for",
 ]

--- a/api/services/session_reconciler.py
+++ b/api/services/session_reconciler.py
@@ -168,6 +168,13 @@ async def run_session_reconciler(check_interval: int = 60, idle_threshold: int =
             if count > 0:
                 logger.info("Reconciler: ended %d stuck session(s)", count)
 
+            try:
+                reaped = await asyncio.to_thread(live_session_store.reap_dead_sessions)
+                if reaped:
+                    logger.info("Reconciler: reaped %d dead session(s)", reaped)
+            except Exception as e:  # noqa: BLE001 - best-effort reap
+                logger.warning("Reconciler: reap_dead_sessions error: %s", e)
+
             tick += 1
             if tick % purge_every_n == 0:
                 try:

--- a/api/services/terminal_focus.py
+++ b/api/services/terminal_focus.py
@@ -4,17 +4,21 @@ Claude Code Karma runs locally on the same machine as the terminals it
 tracks, so the API can shell out to OS-level window managers to bring the
 right terminal to the foreground. Supported focus methods:
 
-- **tmux**  : select the window/pane the session lives in (any host OS, when
-  the session was started inside tmux).
-- **macOS** : activate the terminal application via AppleScript (``osascript``),
-  mapped from ``TERM_PROGRAM``.
+- **tmux**  : select the window/pane, put it on an attached client, and (on
+  macOS) raise the GUI terminal window hosting that client.
+- **macOS** : exact tab via stored identifiers — iTerm2 session UUID or the
+  captured tty — with a guarded app activation fallback (``osascript``).
 - **Linux** : activate the X11 window via ``xdotool`` / ``wmctrl`` using
   ``WINDOWID``.
 
-Everything is best-effort: if the required tool isn't installed or the
-identifier wasn't captured, we report what was attempted instead of raising.
-The terminal identifiers come from
-:func:`hooks.live_session_tracker.resolve_terminal`.
+Identity comes from :func:`hooks.live_session_tracker.resolve_terminal`,
+which stores the claude process's tty (and iTerm session id / app bundle id)
+*while the process is alive*. Focus prefers those stored identifiers over a
+click-time pid lookup, so tab matching survives pid death and recycling.
+
+Everything is best-effort and honest: if a window genuinely could not be
+raised, the result says ``focused=False`` with a human-readable reason
+instead of raising — or worse, raising the wrong window.
 """
 
 from __future__ import annotations
@@ -23,10 +27,11 @@ import os
 import shutil
 import subprocess
 import sys
-from typing import Any, Dict, Optional
+import time
+from typing import Any, Dict, List, Optional, Tuple
 
-# TERM_PROGRAM -> macOS application name for `tell application "<name>" to activate`.
-# Falls back to the raw TERM_PROGRAM value when unmapped.
+# TERM_PROGRAM -> macOS application name for `tell application "<name>"`.
+# Only used when no bundle id was captured; falls back to the raw value.
 _MAC_APP_NAMES: Dict[str, str] = {
     "iTerm.app": "iTerm",
     "Apple_Terminal": "Terminal",
@@ -43,11 +48,17 @@ _MAC_APP_NAMES: Dict[str, str] = {
 _TIMEOUT_SECONDS = 5
 
 # Process names the captured pid may legitimately resolve to (the claude CLI,
-# or node/bun when the CLI runs under a JS runtime). Anything else means the
-# pid was recycled by the OS after the session died — its tty must not be
-# trusted. A recycled pid landing on another claude/node/bun process can still
-# slip through; a name check can't tell "our claude" from "a claude".
-_CLAUDE_PROCESS_NAMES = ("claude", "node", "bun")
+# or a JS runtime when the CLI runs under one). Anything else means the pid
+# was recycled by the OS after the session died. A recycled pid landing on
+# another claude/node/bun process can still slip through the name check, but
+# tab matching no longer trusts the pid's tty — the tty stored at capture
+# time wins — so a recycled pid can't redirect focus to the wrong tab.
+_CLAUDE_PROCESS_NAMES = ("claude", "node", "bun", "deno")
+
+# Cache pid liveness probes (they shell out to ps) — can_focus runs per
+# session on a 1s polling endpoint.
+_PROBE_TTL_SECONDS = 5.0
+_probe_cache: Dict[int, Tuple[float, bool]] = {}
 
 
 def _run(cmd: list[str]) -> subprocess.CompletedProcess:
@@ -59,67 +70,205 @@ def _applescript_str(value: str) -> str:
     return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r")
 
 
+# ---------------------------------------------------------------------------
+# Process liveness
+# ---------------------------------------------------------------------------
+
+
 def _pid_alive(pid: int) -> bool:
-    """Whether a process with this pid still exists (POSIX signal-0 probe)."""
-    if os.name != "posix":
-        return True  # os.kill(pid, 0) TERMINATES processes on Windows — never probe there
+    """Whether a process with this pid still exists."""
+    if os.name == "posix":
+        try:
+            os.kill(pid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except OSError:
+            return True  # exists but owned by someone else
+    if os.name == "nt":
+        # os.kill(pid, 0) TERMINATES processes on Windows — probe via ctypes.
+        return _pid_alive_windows(pid)
+    return True
+
+
+def _pid_alive_windows(pid: int) -> bool:  # pragma: no cover - Windows only
     try:
-        os.kill(pid, 0)
+        import ctypes
+
+        kernel32 = ctypes.windll.kernel32
+    except (ImportError, AttributeError):
+        return True  # no probe available; behave like the pre-probe era
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    ERROR_ACCESS_DENIED = 5
+    STILL_ACTIVE = 259
+    handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, int(pid))
+    if not handle:
+        return kernel32.GetLastError() == ERROR_ACCESS_DENIED
+    try:
+        code = ctypes.c_ulong()
+        if kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+            return code.value == STILL_ACTIVE
         return True
-    except ProcessLookupError:
-        return False
-    except OSError:
-        return True  # exists but owned by someone else
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def _comm_is_claude(pid: int) -> bool:
+    """Whether the pid's process name still looks like the claude CLI."""
+    try:
+        res = _run(["ps", "-o", "comm=", "-p", str(pid)])
+        comm = res.stdout.strip()
+        if res.returncode != 0 or not comm:
+            return False
+        return comm.rsplit("/", 1)[-1] in _CLAUDE_PROCESS_NAMES
+    except (subprocess.SubprocessError, OSError):
+        return True  # flaky ps must not hide a live session's button
+
+
+def pid_is_live_claude(pid: int) -> bool:
+    """Cached check: the pid is alive AND still the claude-ish process captured.
+
+    Detects both plain death and pid recycling onto an unrelated process.
+    Shared by ``can_focus`` (button visibility) and the dead-session reaper.
+    """
+    now = time.monotonic()
+    hit = _probe_cache.get(pid)
+    if hit is not None and now - hit[0] < _PROBE_TTL_SECONDS:
+        return hit[1]
+    ok = _pid_alive(pid)
+    if ok and os.name == "posix":
+        ok = _comm_is_claude(pid)
+    if len(_probe_cache) > 512:
+        _probe_cache.clear()
+    _probe_cache[pid] = (now, ok)
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# Button visibility
+# ---------------------------------------------------------------------------
 
 
 def can_focus(terminal: Optional[Dict[str, Any]]) -> bool:
     """Whether we have an identifier we could plausibly focus on this host.
 
     tmux panes are focusable on any OS; GUI-window focus depends on the host
-    the API is running on (which is the same machine as the terminal). A dead
-    captured pid means the session's window can no longer be located, so the
-    button is withheld (killed/crashed sessions linger as STALE state files).
+    the API is running on (which is the same machine as the terminal). When a
+    pid was captured, the button is withheld once that process is dead or
+    recycled — on every platform: a dead claude means the session is over,
+    and on Linux the X11 window id may itself have been recycled.
     """
     if not terminal:
         return False
-    if terminal.get("tmux_pane"):
-        return True
-    if sys.platform == "darwin" and terminal.get("term_program"):
-        pid = terminal.get("pid")
-        return _pid_alive(pid) if pid else True
-    if sys.platform.startswith("linux") and terminal.get("window_id"):
-        return True
-    return False
+    has_identifier = (
+        bool(terminal.get("tmux_pane"))
+        or (sys.platform == "darwin" and bool(terminal.get("term_program")))
+        or (sys.platform.startswith("linux") and bool(terminal.get("window_id")))
+    )
+    if not has_identifier:
+        return False
+    pid = terminal.get("pid")
+    if not pid:
+        return True  # legacy capture without pid — keep the button, fail honestly on click
+    return pid_is_live_claude(pid)
+
+
+# ---------------------------------------------------------------------------
+# tmux
+# ---------------------------------------------------------------------------
+
+
+def _tmux_clients(target_args: List[str]) -> List[Tuple[str, int]]:
+    """List tmux clients as (client_tty, last_activity), most recent first."""
+    res = _run(["tmux", "list-clients", *target_args, "-F", "#{client_tty}\t#{client_activity}"])
+    clients: List[Tuple[str, int]] = []
+    if res.returncode != 0:
+        return clients
+    for line in res.stdout.splitlines():
+        parts = line.split("\t")
+        if not parts or not parts[0]:
+            continue
+        try:
+            activity = int(parts[1]) if len(parts) > 1 and parts[1] else 0
+        except ValueError:
+            activity = 0
+        clients.append((parts[0], activity))
+    clients.sort(key=lambda c: c[1], reverse=True)
+    return clients
 
 
 def _focus_tmux(pane: str) -> Dict[str, Any]:
-    """Make ``pane`` the active pane in its tmux window/session."""
+    """Select ``pane`` and make sure some attached client is showing it.
+
+    Honest by construction: ``focused=True`` only when a client actually
+    displays the pane's session (already attached, or switched via
+    ``switch-client -c``). A detached server reports False with the attach
+    command. On success the result carries ``client_tty`` (internal key,
+    popped by the caller) so the GUI window hosting that client can be raised.
+    """
     if not shutil.which("tmux"):
         return {"focused": False, "method": "tmux", "detail": "tmux not found on PATH"}
     try:
-        _run(["tmux", "select-window", "-t", pane])
+        win = _run(["tmux", "select-window", "-t", pane])
         res = _run(["tmux", "select-pane", "-t", pane])
-        # If a client is attached to the pane's session, switch it to that window.
+        if win.returncode != 0 or res.returncode != 0:
+            detail = (
+                res.stderr.strip() or win.stderr.strip() or f"tmux pane {pane} no longer exists"
+            )
+            return {"focused": False, "method": "tmux", "detail": detail}
+
         sess = _run(["tmux", "display-message", "-p", "-t", pane, "#{session_name}"])
         session_name = sess.stdout.strip()
-        if session_name:
-            _run(["tmux", "switch-client", "-t", session_name])
-        ok = res.returncode == 0
+
+        client_tty: Optional[str] = None
+        attached = _tmux_clients(["-t", session_name]) if session_name else []
+        if attached:
+            client_tty = attached[0][0]
+        else:
+            other = _tmux_clients([])
+            if other and session_name:
+                candidate = other[0][0]
+                sw = _run(["tmux", "switch-client", "-c", candidate, "-t", session_name])
+                if sw.returncode == 0:
+                    client_tty = candidate
+
+        if client_tty:
+            return {
+                "focused": True,
+                "method": "tmux",
+                "detail": f"selected tmux pane {pane} in session '{session_name}'",
+                "client_tty": client_tty,
+            }
         return {
-            "focused": ok,
+            "focused": False,
             "method": "tmux",
-            "detail": (res.stderr.strip() or f"selected tmux pane {pane}"),
+            "detail": (
+                f"selected tmux pane {pane}, but no tmux client is attached — "
+                f"run: tmux attach -t {session_name or '<session>'}"
+            ),
         }
     except (subprocess.SubprocessError, OSError) as exc:
         return {"focused": False, "method": "tmux", "detail": str(exc)}
 
 
-# Per-app AppleScript to select the exact tab owning a tty. Keyed by
-# TERM_PROGRAM so we never `tell` (and thereby launch) an app the session
-# isn't actually running in. `{tty}` is substituted with e.g. /dev/ttys006.
-# Terminal.app silently ignores `set index`/`set frontmost`, so a non-front
-# window is raised via a miniaturize cycle (the only permission-free raise;
-# AXRaise would require an Accessibility grant).
+# ---------------------------------------------------------------------------
+# macOS
+# ---------------------------------------------------------------------------
+
+# App owning each supported tab script — probed with `is running` before any
+# `tell`, because telling a non-running app launches it.
+_TAB_SCRIPT_APPS: Dict[str, str] = {
+    "Apple_Terminal": "Terminal",
+    "iTerm.app": "iTerm2",
+}
+
+# Per-app AppleScript to select the exact tab owning a tty. `{tty}` is
+# substituted with e.g. /dev/ttys006. Terminal.app ignores `set frontmost`,
+# but `set index to 1` reorders reliably (windows parked on other Spaces
+# silently ignore `set miniaturized`, which is why index comes first and the
+# miniaturize cycle is only a fallback). The outcome is VERIFIED: the script
+# reports "raised" only when the matched window really is frontmost after
+# the attempts; anything else reports "selected" so the API stays honest.
 _MAC_TAB_SCRIPTS: Dict[str, str] = {
     "Apple_Terminal": (
         'tell application "Terminal"\n'
@@ -135,13 +284,23 @@ _MAC_TAB_SCRIPTS: Dict[str, str] = {
         "        if matchedId is not 0 then exit repeat\n"
         "    end repeat\n"
         '    if matchedId is 0 then return ""\n'
+        "    try\n"
+        "        set index of window id matchedId to 1\n"
+        "    end try\n"
         "    activate\n"
         "    if id of front window is not matchedId then\n"
-        "        set miniaturized of window id matchedId to true\n"
-        "        delay 0.4\n"
-        "        set miniaturized of window id matchedId to false\n"
+        "        try\n"
+        "            set miniaturized of window id matchedId to true\n"
+        "            delay 0.4\n"
+        "            set miniaturized of window id matchedId to false\n"
+        "            delay 0.2\n"
+        "        end try\n"
         "    end if\n"
-        "    return matchedId\n"
+        "    if id of front window is matchedId then\n"
+        '        return (matchedId as text) & " raised"\n'
+        "    else\n"
+        '        return (matchedId as text) & " selected"\n'
+        "    end if\n"
         "end tell"
     ),
     "iTerm.app": (
@@ -154,7 +313,7 @@ _MAC_TAB_SCRIPTS: Dict[str, str] = {
         "                    select t\n"
         "                    select w\n"
         "                    activate\n"
-        "                    return id of w\n"
+        '                    return (id of w as text) & " raised"\n'
         "                end if\n"
         "            end repeat\n"
         "        end repeat\n"
@@ -164,13 +323,54 @@ _MAC_TAB_SCRIPTS: Dict[str, str] = {
     ),
 }
 
+# Same shape, but matches an iTerm2 session by its unique id (the UUID from
+# ITERM_SESSION_ID). Survives pid death and recycling entirely.
+_ITERM_ID_SCRIPT = (
+    'tell application "iTerm2"\n'
+    "    repeat with w in windows\n"
+    "        repeat with t in tabs of w\n"
+    "            repeat with s in sessions of t\n"
+    '                if id of s is "{value}" then\n'
+    "                    select s\n"
+    "                    select t\n"
+    "                    select w\n"
+    "                    activate\n"
+    '                    return (id of w as text) & " raised"\n'
+    "                end if\n"
+    "            end repeat\n"
+    "        end repeat\n"
+    "    end repeat\n"
+    '    return ""\n'
+    "end tell"
+)
+
+
+def _app_is_running(target: str) -> bool:
+    """Whether ``target`` (an AppleScript app specifier) is running.
+
+    The standalone ``application X is running`` form never launches the app;
+    an unknown bundle id errors out, which also reads as not running.
+    """
+    try:
+        res = _run(["osascript", "-e", f"{target} is running"])
+        return res.returncode == 0 and res.stdout.strip() == "true"
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
+def _macos_app_target(term_program: str, bundle_id: Optional[str]) -> str:
+    """AppleScript specifier for the session's terminal app, exact when possible."""
+    if bundle_id:
+        return f'application id "{_applescript_str(bundle_id)}"'
+    app = _MAC_APP_NAMES.get(term_program, term_program)
+    return f'application "{_applescript_str(app)}"'
+
 
 def _tty_for_pid(pid: int) -> Optional[str]:
-    """Resolve the tty the live claude process is attached to, e.g. '/dev/ttys006'.
+    """Resolve the tty the claude process is attached to, e.g. '/dev/ttys006'.
 
-    The pid was captured at SessionStart; if the OS has since recycled it for
-    an unrelated process, its tty would point at the wrong tab, so the process
-    name is verified before the tty is trusted.
+    Click-time fallback for state files that predate stored-tty capture. The
+    process name is verified so a recycled pid's tty is never trusted.
     """
     try:
         res = _run(["ps", "-o", "tty=,comm=", "-p", str(pid)])
@@ -188,58 +388,142 @@ def _tty_for_pid(pid: int) -> Optional[str]:
     return None
 
 
+def _parse_tab_result(
+    res: subprocess.CompletedProcess, term_program: str, matched: str
+) -> Optional[Dict[str, Any]]:
+    """Interpret a tab script's "<window-id> raised|selected" output."""
+    out = res.stdout.strip()
+    if res.returncode != 0 or not out:
+        return None
+    parts = out.split()
+    window_id = parts[0]
+    if len(parts) > 1 and parts[1] == "selected":
+        return {
+            "focused": False,
+            "method": "osascript-tab",
+            "detail": (
+                f"selected the {term_program} tab on {matched} (window id {window_id}), "
+                "but its window could not be raised — it may be full screen; "
+                "click it in the Dock or Mission Control"
+            ),
+        }
+    return {
+        "focused": True,
+        "method": "osascript-tab",
+        "detail": f"selected {term_program} tab on {matched} (window id {window_id})",
+    }
+
+
 def _focus_macos_tab(term_program: str, tty: str) -> Optional[Dict[str, Any]]:
     """Select the exact window/tab owning ``tty``; None means fall back."""
     script = _MAC_TAB_SCRIPTS.get(term_program)
     if not script:
         return None
+    app = _TAB_SCRIPT_APPS[term_program]
+    if not _app_is_running(f'application "{_applescript_str(app)}"'):
+        return None
     try:
         res = _run(["osascript", "-e", script.format(tty=_applescript_str(tty))])
-        window_id = res.stdout.strip()
-        if res.returncode == 0 and window_id:
-            return {
-                "focused": True,
-                "method": "osascript-tab",
-                "detail": f"selected {term_program} tab on {tty} (window id {window_id})",
-            }
+        return _parse_tab_result(res, term_program, tty)
     except (subprocess.SubprocessError, OSError):
         pass
     return None
 
 
-def _focus_macos(term_program: str, pid: Optional[int] = None) -> Dict[str, Any]:
-    """Bring the macOS terminal to the foreground, exact tab when possible.
+def _focus_iterm_by_session_id(iterm_session_id: str) -> Optional[Dict[str, Any]]:
+    """Select the iTerm2 session whose unique id matches ITERM_SESSION_ID."""
+    uuid = iterm_session_id.rsplit(":", 1)[-1].strip()
+    if not uuid:
+        return None
+    if not _app_is_running('application "iTerm2"'):
+        return None
+    try:
+        res = _run(["osascript", "-e", _ITERM_ID_SCRIPT.format(value=_applescript_str(uuid))])
+        return _parse_tab_result(res, "iTerm.app", f"session {uuid}")
+    except (subprocess.SubprocessError, OSError):
+        pass
+    return None
 
-    The session's captured pid is the live ``claude`` process; while the
-    session is running its tty identifies the exact tab, which the supported
-    apps can select via AppleScript. Anything else falls back to activating
-    the application.
+
+def _raise_gui_for_tty(tty: str) -> Optional[Dict[str, Any]]:
+    """Raise the GUI window of whichever *running* terminal app owns ``tty``.
+
+    Used for tmux: the pane's client tty belongs to some GUI terminal tab,
+    but nothing recorded which app — so every supported app is tried, gated
+    on being running (never launches anything).
     """
     if not shutil.which("osascript"):
-        return {"focused": False, "method": "osascript", "detail": "osascript not found"}
-    if pid:
-        tty = _tty_for_pid(pid)
-        if tty is None:
-            # Dead/recycled pid: the window can't be located, and blindly
-            # activating the app would raise an arbitrary window.
-            return {
-                "focused": False,
-                "method": "osascript-tab",
-                "detail": "Could not locate the session's terminal window (its process is gone or has no tty).",
-            }
-        exact = _focus_macos_tab(term_program, tty)
-        if exact:
-            return exact
-    app = _MAC_APP_NAMES.get(term_program, term_program)
+        return None
+    for term_program in _MAC_TAB_SCRIPTS:
+        result = _focus_macos_tab(term_program, tty)
+        if result is not None:
+            return result
+    return None
+
+
+def _activate_app(term_program: str, bundle_id: Optional[str]) -> Dict[str, Any]:
+    """App-level activation, guarded so a non-running app is never launched."""
+    target = _macos_app_target(term_program, bundle_id)
+    label = bundle_id or _MAC_APP_NAMES.get(term_program, term_program)
+    if not _app_is_running(target):
+        return {
+            "focused": False,
+            "method": "osascript",
+            "detail": f"{label} is not running — the session's terminal app appears to have quit.",
+        }
     try:
-        res = _run(["osascript", "-e", f'tell application "{_applescript_str(app)}" to activate'])
+        res = _run(["osascript", "-e", f"tell {target} to activate"])
         return {
             "focused": res.returncode == 0,
             "method": "osascript",
-            "detail": (res.stderr.strip() or f"activated {app}"),
+            "detail": (res.stderr.strip() or f"activated {label}"),
         }
     except (subprocess.SubprocessError, OSError) as exc:
         return {"focused": False, "method": "osascript", "detail": str(exc)}
+
+
+def _focus_macos(term_program: str, terminal: Dict[str, Any]) -> Dict[str, Any]:
+    """Bring the macOS terminal to the foreground, exact tab when possible.
+
+    Identifier preference: iTerm2 session UUID (fully durable, never
+    recycled — usable even after the process dies) → tty stored at capture
+    time (immune to pid recycling) → live pid→tty lookup (legacy state
+    files). tty devices ARE recycled once their tab closes, so tty matching
+    and app activation require the session's process to still be alive; a
+    dead session fails honestly rather than risk raising a stranger's tab.
+    """
+    if not shutil.which("osascript"):
+        return {"focused": False, "method": "osascript", "detail": "osascript not found"}
+
+    pid = terminal.get("pid")
+
+    if term_program == "iTerm.app" and terminal.get("iterm_session_id"):
+        exact = _focus_iterm_by_session_id(terminal["iterm_session_id"])
+        if exact:
+            return exact
+
+    if pid and not pid_is_live_claude(pid):
+        return {
+            "focused": False,
+            "method": "osascript-tab",
+            "detail": (
+                "Could not locate the session's terminal window (its process is "
+                "gone, and its tty may have been reassigned to an unrelated tab)."
+            ),
+        }
+
+    tty = terminal.get("tty") or (_tty_for_pid(pid) if pid else None)
+    if tty:
+        exact = _focus_macos_tab(term_program, tty)
+        if exact:
+            return exact  # includes the honest "selected but not raised" case
+
+    return _activate_app(term_program, terminal.get("bundle_id"))
+
+
+# ---------------------------------------------------------------------------
+# Linux
+# ---------------------------------------------------------------------------
 
 
 def _focus_linux(window_id: str) -> Dict[str, Any]:
@@ -281,15 +565,21 @@ def _focus_linux(window_id: str) -> Dict[str, Any]:
     }
 
 
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
 def focus_terminal(terminal: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """Attempt to raise the terminal for a session.
 
     Returns a dict ``{focused: bool, method: str, detail: str}``. Never
     raises — a missing tool or identifier is reported via ``focused=False``.
 
-    Strategy: bring the GUI terminal window forward for the host OS *and*,
-    when the session runs in tmux, select the correct pane inside it. The
-    most informative successful result is returned (GUI focus preferred).
+    tmux sessions route entirely through the tmux path (their captured
+    tty/TERM_PROGRAM describe the tmux server, not a GUI tab): select the
+    pane, ensure a client displays it, then raise that client's GUI window.
+    Everything else goes through the host OS window manager directly.
     """
     if not terminal:
         return {
@@ -299,27 +589,36 @@ def focus_terminal(terminal: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         }
 
     tmux_pane = terminal.get("tmux_pane")
-    tmux_result = _focus_tmux(tmux_pane) if tmux_pane else None
+    if tmux_pane:
+        result = _focus_tmux(tmux_pane)
+        client_tty = result.pop("client_tty", None)
+        if client_tty and sys.platform == "darwin":
+            gui = _raise_gui_for_tty(client_tty)
+            if gui and gui.get("focused"):
+                result["method"] = "tmux+gui"
+                result["detail"] += f"; {gui['detail']}"
+            elif result.get("focused"):
+                result["detail"] += (
+                    "; the hosting terminal window could not be raised automatically"
+                )
+        return result
 
     if sys.platform == "darwin" and terminal.get("term_program"):
-        gui_result: Optional[Dict[str, Any]] = _focus_macos(
-            terminal["term_program"], pid=terminal.get("pid")
-        )
-    elif sys.platform.startswith("linux") and terminal.get("window_id"):
-        gui_result = _focus_linux(str(terminal["window_id"]))
-    else:
-        gui_result = None
+        return _focus_macos(terminal["term_program"], terminal)
 
-    # Prefer a successful GUI focus, then a successful tmux focus, then any
-    # attempted result so the caller sees a useful detail message.
-    if gui_result and gui_result.get("focused"):
-        return gui_result
-    if tmux_result and tmux_result.get("focused"):
-        return tmux_result
-    if gui_result:
-        return gui_result
-    if tmux_result:
-        return tmux_result
+    if sys.platform.startswith("linux") and terminal.get("window_id"):
+        pid = terminal.get("pid")
+        if pid and not pid_is_live_claude(pid):
+            return {
+                "focused": False,
+                "method": "linux",
+                "detail": (
+                    "The session's process is gone; refusing to raise a window id "
+                    "that may have been recycled."
+                ),
+            }
+        return _focus_linux(str(terminal["window_id"]))
+
     return {
         "focused": False,
         "method": "none",

--- a/api/tests/test_live_session_store.py
+++ b/api/tests/test_live_session_store.py
@@ -138,3 +138,133 @@ def test_reconciler_mark_uses_store(tmp_live_dir: Path):
     with patch("services.session_reconciler.live_session_store.mark_ended") as mock_ended:
         _mark_session_ended(state_file, {"session_id": "sess-r"}, end_reason="x")
         mock_ended.assert_called_once_with("sess-r", end_reason="x", last_hook="Reconciler")
+
+
+# ---------------------------------------------------------------------------
+# reap_dead_sessions
+# ---------------------------------------------------------------------------
+
+
+def _iso_ago(seconds: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds)).isoformat()
+
+
+def _write_raw(live_dir: Path, name: str, **fields) -> Path:
+    path = live_dir / f"{name}.json"
+    path.write_text(json.dumps(fields))
+    return path
+
+
+def _mock_liveness(monkeypatch, alive: bool):
+    """The reaper defers its import, so patch the source module attribute."""
+    from services import terminal_focus
+
+    monkeypatch.setattr(terminal_focus, "pid_is_live_claude", lambda pid: alive)
+
+
+def test_reap_ends_nonterminal_sessions_with_dead_pid(tmp_live_dir: Path, monkeypatch):
+    _mock_liveness(monkeypatch, alive=False)
+    for state in ("LIVE", "WAITING", "STOPPED", "STALE", "STARTING"):
+        _write_raw(
+            tmp_live_dir,
+            f"dead-{state.lower()}",
+            session_id=f"dead-{state.lower()}",
+            state=state,
+            updated_at=_iso_ago(300),
+            terminal={"pid": 4242},
+        )
+
+    assert live_session_store.reap_dead_sessions() == 5
+    for state in ("LIVE", "WAITING", "STOPPED", "STALE", "STARTING"):
+        data = json.loads((tmp_live_dir / f"dead-{state.lower()}.json").read_text())
+        assert data["state"] == "ENDED"
+        assert data["end_reason"] == "process_died"
+        assert data["last_hook"] == "Reaper"
+
+
+def test_reap_spares_live_pid_and_ended_files(tmp_live_dir: Path, monkeypatch):
+    _mock_liveness(monkeypatch, alive=True)
+    _write_raw(
+        tmp_live_dir,
+        "alive",
+        session_id="alive",
+        state="LIVE",
+        updated_at=_iso_ago(300),
+        terminal={"pid": 4242},
+    )
+    _write_raw(
+        tmp_live_dir,
+        "done",
+        session_id="done",
+        state="ENDED",
+        updated_at=_iso_ago(9999),
+        terminal={"pid": 4242},
+    )
+    assert live_session_store.reap_dead_sessions() == 0
+    assert json.loads((tmp_live_dir / "alive.json").read_text())["state"] == "LIVE"
+    assert json.loads((tmp_live_dir / "done.json").read_text())["state"] == "ENDED"
+
+
+def test_reap_spares_freshly_written_files(tmp_live_dir: Path, monkeypatch):
+    # A file younger than the min age is never reaped, even with a dead pid —
+    # protects a just-started session from racing its own hook events.
+    _mock_liveness(monkeypatch, alive=False)
+    _write_raw(
+        tmp_live_dir,
+        "fresh",
+        session_id="fresh",
+        state="LIVE",
+        updated_at=_iso_ago(5),
+        terminal={"pid": 4242},
+    )
+    assert live_session_store.reap_dead_sessions() == 0
+
+
+def test_reap_pidless_files_use_age_fallback(tmp_live_dir: Path, monkeypatch):
+    def boom(pid):
+        raise AssertionError("no pid probe for pid-less files")
+
+    from services import terminal_focus
+
+    monkeypatch.setattr(terminal_focus, "pid_is_live_claude", boom)
+    _write_raw(
+        tmp_live_dir,
+        "ancient",
+        session_id="ancient",
+        state="STOPPED",
+        updated_at=_iso_ago(25 * 3600),
+    )
+    _write_raw(
+        tmp_live_dir,
+        "recent",
+        session_id="recent",
+        state="STOPPED",
+        updated_at=_iso_ago(3600),
+    )
+    assert live_session_store.reap_dead_sessions() == 1
+    assert json.loads((tmp_live_dir / "ancient.json").read_text())["end_reason"] == "reaped_stale"
+    assert json.loads((tmp_live_dir / "recent.json").read_text())["state"] == "STOPPED"
+
+
+def test_reap_updates_legacy_slug_named_file_in_place(tmp_live_dir: Path, monkeypatch):
+    # Legacy files are named by slug, not session_id; the reaper must update
+    # that exact file rather than minting a session_id-named sibling.
+    _mock_liveness(monkeypatch, alive=False)
+    _write_raw(
+        tmp_live_dir,
+        "my-slug",
+        session_id="uuid-123",
+        state="STALE",
+        updated_at=_iso_ago(300),
+        terminal={"pid": 4242},
+    )
+    assert live_session_store.reap_dead_sessions() == 1
+    assert json.loads((tmp_live_dir / "my-slug.json").read_text())["state"] == "ENDED"
+    assert not (tmp_live_dir / "uuid-123.json").exists()
+
+
+def test_reap_skips_malformed_files(tmp_live_dir: Path, monkeypatch):
+    _mock_liveness(monkeypatch, alive=False)
+    (tmp_live_dir / "garbage.json").write_text("{not json")
+    _write_raw(tmp_live_dir, "no-ts", session_id="no-ts", state="LIVE")
+    assert live_session_store.reap_dead_sessions() == 0

--- a/api/tests/test_terminal_focus.py
+++ b/api/tests/test_terminal_focus.py
@@ -2,8 +2,8 @@
 
 The service shells out to OS window managers, so every test mocks
 ``shutil.which`` / ``subprocess.run`` / ``sys.platform`` — nothing real is
-executed. Covers method selection, best-effort fallbacks, and the never-raise
-contract.
+executed. Covers method selection, durable-identifier preference, honest
+success reporting, best-effort fallbacks, and the never-raise contract.
 """
 
 from __future__ import annotations
@@ -11,6 +11,8 @@ from __future__ import annotations
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 _api_dir = Path(__file__).resolve().parent.parent
 if str(_api_dir) not in sys.path:
@@ -24,6 +26,40 @@ class _FakeCompleted:
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
+
+
+@pytest.fixture(autouse=True)
+def _clear_probe_cache():
+    terminal_focus._probe_cache.clear()
+    yield
+    terminal_focus._probe_cache.clear()
+
+
+def _fake_run_factory(
+    tty="ttys006",
+    comm="claude",
+    tab_stdout="13387 raised",
+    record=None,
+    app_running=True,
+):
+    """_run stub routing ps / is-running probes / tab scripts / activation."""
+
+    def fake_run(cmd):
+        if record is not None:
+            record.append(cmd)
+        if cmd[0] == "ps":
+            if "tty=,comm=" in cmd:
+                return _FakeCompleted(stdout=f"{tty} {comm}\n")
+            return _FakeCompleted(stdout=f"{comm}\n")
+        if cmd[0] == "osascript":
+            script = cmd[-1]
+            if script.endswith("is running"):
+                return _FakeCompleted(stdout="true\n" if app_running else "false\n")
+            if "tty of" in script or "id of s is" in script:
+                return _FakeCompleted(stdout=f"{tab_stdout}\n")
+        return _FakeCompleted(returncode=0)
+
+    return fake_run
 
 
 # ---------------------------------------------------------------------------
@@ -53,6 +89,74 @@ def test_can_focus_linux_needs_window_id(monkeypatch):
     assert terminal_focus.can_focus({"term_program": "iTerm.app"}) is False
 
 
+def test_can_focus_dead_pid_hides_button_everywhere(monkeypatch):
+    # A dead (or recycled) pid means the session is over — the button is
+    # withheld on every platform, tmux panes included.
+    monkeypatch.setattr(terminal_focus, "pid_is_live_claude", lambda pid: False)
+    monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
+    assert terminal_focus.can_focus({"term_program": "Apple_Terminal", "pid": 1234}) is False
+    assert terminal_focus.can_focus({"tmux_pane": "%1", "pid": 1234}) is False
+    monkeypatch.setattr(terminal_focus.sys, "platform", "linux")
+    assert terminal_focus.can_focus({"window_id": "123", "pid": 1234}) is False
+
+
+def test_can_focus_alive_pid(monkeypatch):
+    monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
+    monkeypatch.setattr(terminal_focus, "pid_is_live_claude", lambda pid: True)
+    assert terminal_focus.can_focus({"term_program": "Apple_Terminal", "pid": 1234}) is True
+
+
+def test_can_focus_legacy_no_pid_keeps_button(monkeypatch):
+    def boom(pid):
+        raise AssertionError("pid probe must not run without a pid")
+
+    monkeypatch.setattr(terminal_focus, "pid_is_live_claude", boom)
+    monkeypatch.setattr(terminal_focus.sys, "platform", "linux")
+    assert terminal_focus.can_focus({"window_id": "123"}) is True
+
+
+# ---------------------------------------------------------------------------
+# pid liveness probes
+# ---------------------------------------------------------------------------
+
+
+def test_pid_alive_windows_fallback_without_ctypes_windll(monkeypatch):
+    # On non-Windows hosts the ctypes probe is unavailable; never os.kill.
+    def boom(pid, sig):
+        raise AssertionError("os.kill must not run off POSIX")
+
+    monkeypatch.setattr(terminal_focus.os, "kill", boom)
+    monkeypatch.setattr(terminal_focus.os, "name", "nt")
+    assert terminal_focus._pid_alive(1234) is True
+
+
+def test_pid_is_live_claude_rejects_recycled_comm(monkeypatch):
+    monkeypatch.setattr(terminal_focus, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(comm="vim"))
+    monkeypatch.setattr(terminal_focus.os, "name", "posix")
+    assert terminal_focus.pid_is_live_claude(4242) is False
+
+
+def test_pid_is_live_claude_accepts_claude_comm(monkeypatch):
+    monkeypatch.setattr(terminal_focus, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(comm="/usr/local/bin/claude"))
+    monkeypatch.setattr(terminal_focus.os, "name", "posix")
+    assert terminal_focus.pid_is_live_claude(4242) is True
+
+
+def test_pid_is_live_claude_caches_probe(monkeypatch):
+    calls = []
+
+    def fake_alive(pid):
+        calls.append(pid)
+        return False
+
+    monkeypatch.setattr(terminal_focus, "_pid_alive", fake_alive)
+    assert terminal_focus.pid_is_live_claude(7) is False
+    assert terminal_focus.pid_is_live_claude(7) is False
+    assert calls == [7]  # second call served from the TTL cache
+
+
 # ---------------------------------------------------------------------------
 # focus_terminal — no info / never raises
 # ---------------------------------------------------------------------------
@@ -77,26 +181,114 @@ def test_focus_terminal_no_method_available(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_focus_tmux_success(monkeypatch):
+def _tmux_run_factory(
+    record,
+    session_name="main",
+    attached=None,
+    all_clients=None,
+    pane_ok=True,
+    switch_ok=True,
+    gui_tab_stdout="42 raised",
+):
+    def fake_run(cmd):
+        record.append(cmd)
+        if cmd[0] == "osascript":
+            script = cmd[-1]
+            if script.endswith("is running"):
+                return _FakeCompleted(stdout="true\n")
+            if "tty of" in script:
+                return _FakeCompleted(stdout=f"{gui_tab_stdout}\n")
+            return _FakeCompleted()
+        if cmd[0] != "tmux":
+            return _FakeCompleted()
+        sub = cmd[1]
+        if sub in ("select-window", "select-pane"):
+            return _FakeCompleted(
+                returncode=0 if pane_ok else 1,
+                stderr="" if pane_ok else "can't find pane",
+            )
+        if sub == "display-message":
+            return _FakeCompleted(stdout=f"{session_name}\n")
+        if sub == "list-clients":
+            rows = (attached or []) if "-t" in cmd else (all_clients or [])
+            return _FakeCompleted(stdout="".join(f"{t}\t{a}\n" for t, a in rows))
+        if sub == "switch-client":
+            return _FakeCompleted(returncode=0 if switch_ok else 1)
+        return _FakeCompleted()
+
+    return fake_run
+
+
+def test_focus_tmux_attached_client_success(monkeypatch):
     monkeypatch.setattr(terminal_focus.sys, "platform", "win32")
     monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/tmux")
-
     calls = []
-
-    def fake_run(cmd):
-        calls.append(cmd)
-        if "display-message" in cmd:
-            return _FakeCompleted(stdout="main\n")
-        return _FakeCompleted(returncode=0)
-
-    monkeypatch.setattr(terminal_focus, "_run", fake_run)
+    monkeypatch.setattr(
+        terminal_focus, "_run", _tmux_run_factory(calls, attached=[("/dev/ttys009", 100)])
+    )
 
     result = terminal_focus.focus_terminal({"tmux_pane": "%3"})
     assert result["focused"] is True
     assert result["method"] == "tmux"
-    # select-window, select-pane, display-message, switch-client
-    assert any("select-pane" in c for c in calls)
-    assert any("switch-client" in c for c in calls)
+    assert "client_tty" not in result  # internal key must not leak to the API
+    # A client already shows the session — no client stealing.
+    assert not any(c[0] == "tmux" and c[1] == "switch-client" for c in calls)
+
+
+def test_focus_tmux_switches_client_from_other_session(monkeypatch):
+    monkeypatch.setattr(terminal_focus.sys, "platform", "win32")
+    monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/tmux")
+    calls = []
+    monkeypatch.setattr(
+        terminal_focus,
+        "_run",
+        _tmux_run_factory(calls, attached=[], all_clients=[("/dev/ttys009", 100)]),
+    )
+
+    result = terminal_focus.focus_terminal({"tmux_pane": "%3"})
+    assert result["focused"] is True
+    switch = next(c for c in calls if c[0] == "tmux" and c[1] == "switch-client")
+    # The target client is named explicitly — from the API process there is
+    # no "current client" for tmux to infer.
+    assert "-c" in switch and "/dev/ttys009" in switch
+
+
+def test_focus_tmux_detached_is_honest(monkeypatch):
+    monkeypatch.setattr(terminal_focus.sys, "platform", "win32")
+    monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/tmux")
+    calls = []
+    monkeypatch.setattr(terminal_focus, "_run", _tmux_run_factory(calls))
+
+    result = terminal_focus.focus_terminal({"tmux_pane": "%3"})
+    assert result["focused"] is False
+    assert "tmux attach -t main" in result["detail"]
+
+
+def test_focus_tmux_dead_pane_is_honest(monkeypatch):
+    monkeypatch.setattr(terminal_focus.sys, "platform", "win32")
+    monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/tmux")
+    calls = []
+    monkeypatch.setattr(terminal_focus, "_run", _tmux_run_factory(calls, pane_ok=False))
+
+    result = terminal_focus.focus_terminal({"tmux_pane": "%3"})
+    assert result["focused"] is False
+    assert "can't find pane" in result["detail"]
+
+
+def test_focus_tmux_raises_hosting_gui_window_on_macos(monkeypatch):
+    monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
+    monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: f"/usr/bin/{name}")
+    calls = []
+    monkeypatch.setattr(
+        terminal_focus, "_run", _tmux_run_factory(calls, attached=[("/dev/ttys009", 100)])
+    )
+
+    result = terminal_focus.focus_terminal({"tmux_pane": "%3"})
+    assert result["focused"] is True
+    assert result["method"] == "tmux+gui"
+    # The GUI raise matches the CLIENT's tty, not the pane's pty.
+    gui_scripts = [c[-1] for c in calls if c[0] == "osascript" and "tty of" in c[-1]]
+    assert any("/dev/ttys009" in s for s in gui_scripts)
 
 
 def test_focus_tmux_missing_binary(monkeypatch):
@@ -120,58 +312,76 @@ def test_focus_tmux_subprocess_error_is_caught(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# macOS
+# macOS — app activation fallback (guarded)
 # ---------------------------------------------------------------------------
 
 
 def test_focus_macos_maps_app_name(monkeypatch):
     monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
     monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
+    calls = []
+    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(record=calls))
 
-    captured = {}
-
-    def fake_run(cmd):
-        captured["cmd"] = cmd
-        return _FakeCompleted(returncode=0)
-
-    monkeypatch.setattr(terminal_focus, "_run", fake_run)
     result = terminal_focus.focus_terminal({"term_program": "iTerm.app"})
     assert result["focused"] is True
     assert result["method"] == "osascript"
     # iTerm.app maps to "iTerm"
-    assert 'tell application "iTerm" to activate' in captured["cmd"][-1]
+    assert any('tell application "iTerm" to activate' in c[-1] for c in calls)
 
 
 def test_focus_macos_unknown_program_uses_raw_name(monkeypatch):
     monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
     monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
+    calls = []
+    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(record=calls))
 
-    captured = {}
-
-    def fake_run(cmd):
-        captured["cmd"] = cmd
-        return _FakeCompleted(returncode=0)
-
-    monkeypatch.setattr(terminal_focus, "_run", fake_run)
     terminal_focus.focus_terminal({"term_program": "SomeNewTerm"})
-    assert 'tell application "SomeNewTerm" to activate' in captured["cmd"][-1]
+    assert any('tell application "SomeNewTerm" to activate' in c[-1] for c in calls)
+
+
+def test_focus_macos_prefers_bundle_id(monkeypatch):
+    monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
+    monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
+    calls = []
+    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(record=calls))
+
+    # Cursor sets TERM_PROGRAM=vscode; the bundle id must win so real VS Code
+    # is never targeted.
+    result = terminal_focus.focus_terminal(
+        {"term_program": "vscode", "bundle_id": "com.todesktop.cursor"}
+    )
+    assert result["focused"] is True
+    assert any('tell application id "com.todesktop.cursor" to activate' in c[-1] for c in calls)
+    assert not any('application "Code"' in c[-1] for c in calls)
+
+
+def test_focus_macos_never_launches_a_quit_app(monkeypatch):
+    monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
+    monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
+    calls = []
+    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(record=calls, app_running=False))
+
+    result = terminal_focus.focus_terminal({"term_program": "WezTerm"})
+    assert result["focused"] is False
+    assert "not running" in result["detail"]
+    # `tell ... to activate` launches non-running apps; it must never be sent.
+    assert not any("to activate" in c[-1] for c in calls if c[0] == "osascript")
 
 
 def test_focus_macos_escapes_applescript_injection(monkeypatch):
     # A quote in TERM_PROGRAM must not break out of the AppleScript string.
     monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
     monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
+    calls = []
+    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(record=calls))
 
-    captured = {}
-
-    def fake_run(cmd):
-        captured["cmd"] = cmd
-        return _FakeCompleted(returncode=0)
-
-    monkeypatch.setattr(terminal_focus, "_run", fake_run)
     terminal_focus.focus_terminal({"term_program": 'Evil" \n do shell script "id'})
-    script = captured["cmd"][-1]
-    assert script == 'tell application "Evil\\" \\n do shell script \\"id" to activate'
+    activate = [c[-1] for c in calls if c[0] == "osascript" and "to activate" in c[-1]]
+    assert activate == ['tell application "Evil\\" \\n do shell script \\"id" to activate']
+
+
+def test_applescript_str_escapes_control_characters():
+    assert terminal_focus._applescript_str('a"b\\c\nd\re') == 'a\\"b\\\\c\\nd\\re'
 
 
 # ---------------------------------------------------------------------------
@@ -227,24 +437,22 @@ def test_focus_linux_no_tools(monkeypatch):
     assert result["focused"] is False
 
 
+def test_focus_linux_dead_pid_refuses_recycled_window_id(monkeypatch):
+    monkeypatch.setattr(terminal_focus.sys, "platform", "linux")
+    monkeypatch.setattr(terminal_focus, "pid_is_live_claude", lambda pid: False)
+
+    def boom(cmd):
+        raise AssertionError("no window manager tool may run for a dead session")
+
+    monkeypatch.setattr(terminal_focus, "_run", boom)
+    result = terminal_focus.focus_terminal({"window_id": "123", "pid": 4242})
+    assert result["focused"] is False
+    assert "recycled" in result["detail"]
+
+
 # ---------------------------------------------------------------------------
-# macOS exact-tab focus (pid → tty → AppleScript tab match)
+# macOS exact-tab focus (stored identifiers > pid → tty)
 # ---------------------------------------------------------------------------
-
-
-def _fake_run_factory(tty="ttys006", comm="claude", tab_stdout="13387", record=None):
-    """_run stub routing ps / tab-script / activate calls."""
-
-    def fake_run(cmd):
-        if record is not None:
-            record.append(cmd)
-        if cmd[0] == "ps":
-            return _FakeCompleted(stdout=f"{tty} {comm}\n")
-        if cmd[0] == "osascript" and "tty of" in cmd[-1]:
-            return _FakeCompleted(stdout=f"{tab_stdout}\n")
-        return _FakeCompleted(returncode=0)
-
-    return fake_run
 
 
 def test_tty_for_pid_parses_ps(monkeypatch):
@@ -271,58 +479,140 @@ def test_tty_for_pid_recycled_pid_rejected(monkeypatch):
     assert terminal_focus._tty_for_pid(91314) is None
 
 
-def test_tty_for_pid_accepts_full_claude_path(monkeypatch):
-    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(comm="/usr/local/bin/claude"))
-    assert terminal_focus._tty_for_pid(91314) == "/dev/ttys006"
-
-
-def test_focus_macos_exact_tab(monkeypatch):
+def test_focus_macos_exact_tab_via_stored_tty(monkeypatch):
     monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
     monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
+    monkeypatch.setattr(terminal_focus, "pid_is_live_claude", lambda pid: True)
+    calls = []
+    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(record=calls))
+
+    result = terminal_focus.focus_terminal(
+        {"term_program": "Apple_Terminal", "pid": 91314, "tty": "/dev/ttys006"}
+    )
+    assert result["focused"] is True
+    assert result["method"] == "osascript-tab"
+    assert "/dev/ttys006" in result["detail"]
+    assert "13387" in result["detail"]
+    tab_script = next(c[-1] for c in calls if c[0] == "osascript" and "tty of" in c[-1])
+    assert '"Terminal"' in tab_script
+    assert '"/dev/ttys006"' in tab_script
+    # Stored tty wins — no click-time pid → tty lookup at all.
+    assert not any(c[0] == "ps" for c in calls)
+
+
+def test_focus_macos_stored_tty_beats_recycled_pids_tty(monkeypatch):
+    # Pid recycled onto another claude on ttys999: the stored tty from
+    # capture time must be matched, not the impostor's.
+    monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
+    monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
+    monkeypatch.setattr(terminal_focus, "pid_is_live_claude", lambda pid: True)
+    calls = []
+    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(tty="ttys999", record=calls))
+
+    terminal_focus.focus_terminal(
+        {"term_program": "Apple_Terminal", "pid": 91314, "tty": "/dev/ttys006"}
+    )
+    tab_script = next(c[-1] for c in calls if c[0] == "osascript" and "tty of" in c[-1])
+    assert '"/dev/ttys006"' in tab_script
+    assert "ttys999" not in tab_script
+
+
+def test_focus_macos_legacy_state_falls_back_to_pid_tty(monkeypatch):
+    monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
+    monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
+    monkeypatch.setattr(terminal_focus, "pid_is_live_claude", lambda pid: True)
     calls = []
     monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(record=calls))
 
     result = terminal_focus.focus_terminal({"term_program": "Apple_Terminal", "pid": 91314})
     assert result["focused"] is True
     assert result["method"] == "osascript-tab"
-    assert "/dev/ttys006" in result["detail"]
-    assert "13387" in result["detail"]
-    tab_script = next(c[-1] for c in calls if c[0] == "osascript")
-    assert '"Terminal"' in tab_script
-    assert '"/dev/ttys006"' in tab_script
+    assert any(c[0] == "ps" for c in calls)
 
 
-def test_focus_macos_iterm_targets_iterm2(monkeypatch):
+def test_focus_macos_iterm_by_session_id_first(monkeypatch):
     monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
     monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
     calls = []
     monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(record=calls))
 
+    result = terminal_focus.focus_terminal(
+        {
+            "term_program": "iTerm.app",
+            "pid": 91314,
+            "tty": "/dev/ttys006",
+            "iterm_session_id": "w0t2p0:44BF03B0-AAAA-BBBB-CCCC-DDDDEEEEFFFF",
+        }
+    )
+    assert result["focused"] is True
+    assert result["method"] == "osascript-tab"
+    id_script = next(c[-1] for c in calls if c[0] == "osascript" and "id of s is" in c[-1])
+    # The UUID part after the colon is matched against the session's id.
+    assert '"44BF03B0-AAAA-BBBB-CCCC-DDDDEEEEFFFF"' in id_script
+    # The durable id matched — the tty script never runs.
+    assert not any("tty of" in c[-1] for c in calls if c[0] == "osascript")
+
+
+def test_focus_macos_iterm_id_miss_falls_back_to_tty(monkeypatch):
+    monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
+    monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
+    calls = []
+
+    def fake_run(cmd):
+        calls.append(cmd)
+        script = cmd[-1]
+        if cmd[0] == "osascript":
+            if script.endswith("is running"):
+                return _FakeCompleted(stdout="true\n")
+            if "id of s is" in script:
+                return _FakeCompleted(stdout="\n")  # tab was closed / id unknown
+            if "tty of" in script:
+                return _FakeCompleted(stdout="7 raised\n")
+        return _FakeCompleted()
+
+    monkeypatch.setattr(terminal_focus, "_run", fake_run)
+    result = terminal_focus.focus_terminal(
+        {
+            "term_program": "iTerm.app",
+            "tty": "/dev/ttys006",
+            "iterm_session_id": "w0t2p0:DEAD",
+        }
+    )
+    assert result["focused"] is True
+    assert any("tty of" in c[-1] for c in calls if c[0] == "osascript")
+
+
+def test_focus_macos_iterm_tty_script_targets_iterm2(monkeypatch):
+    monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
+    monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
+    monkeypatch.setattr(terminal_focus, "pid_is_live_claude", lambda pid: True)
+    calls = []
+    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(record=calls))
+
     result = terminal_focus.focus_terminal({"term_program": "iTerm.app", "pid": 91314})
     assert result["method"] == "osascript-tab"
-    tab_script = next(c[-1] for c in calls if c[0] == "osascript")
+    tab_script = next(c[-1] for c in calls if c[0] == "osascript" and "tty of" in c[-1])
     assert '"iTerm2"' in tab_script
     assert "sessions of t" in tab_script
 
 
-def test_focus_macos_tab_not_found_falls_back_to_activate(monkeypatch):
+def test_focus_macos_tab_not_found_alive_pid_falls_back_to_activate(monkeypatch):
     monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
     monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
+    monkeypatch.setattr(terminal_focus, "pid_is_live_claude", lambda pid: True)
     calls = []
     monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(tab_stdout="", record=calls))
 
     result = terminal_focus.focus_terminal({"term_program": "Apple_Terminal", "pid": 91314})
     assert result["focused"] is True
     assert result["method"] == "osascript"
-    activate = [
-        c for c in calls if c[0] == "osascript" and "activate" in c[-1] and "tty" not in c[-1]
-    ]
-    assert activate, "expected fallback to plain app activation"
+    assert any("to activate" in c[-1] for c in calls if c[0] == "osascript")
 
 
 def test_focus_macos_unsupported_app_skips_tab_script(monkeypatch):
     monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
     monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
+    monkeypatch.setattr(terminal_focus, "pid_is_live_claude", lambda pid: True)
     calls = []
     monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(record=calls))
 
@@ -342,75 +632,93 @@ def test_focus_macos_no_pid_keeps_activate_behavior(monkeypatch):
     assert not any(c[0] == "ps" for c in calls)
 
 
-def test_applescript_str_escapes_control_characters():
-    assert terminal_focus._applescript_str('a"b\\c\nd\re') == 'a\\"b\\\\c\\nd\\re'
-
-
 # ---------------------------------------------------------------------------
-# Window raise + dead-session lifecycle
+# Window raise truthfulness + dead-session lifecycle
 # ---------------------------------------------------------------------------
 
 
-def test_terminal_app_script_raises_via_miniaturize_cycle():
-    # Terminal.app ignores `set index`/`set frontmost`; the script must use
-    # the miniaturize cycle and only when the window isn't already front.
+def test_terminal_app_script_raises_index_first_with_verified_fallback():
+    # `set index to 1` is the raise that works (windows on other Spaces
+    # ignore `set miniaturized`); the cycle stays as fallback, and the
+    # script must VERIFY the outcome instead of assuming it.
     script = terminal_focus._MAC_TAB_SCRIPTS["Apple_Terminal"]
+    assert "set index of window id matchedId to 1" in script
+    assert script.index("set index") < script.index("activate")
     assert "set miniaturized" in script
     assert "if id of front window is not matchedId" in script
-    assert "set index" not in script
+    assert '" raised"' in script
+    assert '" selected"' in script
+
+
+def test_focus_macos_fullscreen_selected_not_raised_is_honest(monkeypatch):
+    # Fullscreen windows can't be miniaturized: the tab gets selected but the
+    # window stays buried. The result must say focused=false, and must NOT
+    # fall through to app activation (which would raise a different window).
+    monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
+    monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
+    monkeypatch.setattr(terminal_focus, "pid_is_live_claude", lambda pid: True)
+    calls = []
+    monkeypatch.setattr(
+        terminal_focus, "_run", _fake_run_factory(tab_stdout="13387 selected", record=calls)
+    )
+
+    result = terminal_focus.focus_terminal(
+        {"term_program": "Apple_Terminal", "tty": "/dev/ttys006", "pid": 91314}
+    )
+    assert result["focused"] is False
+    assert result["method"] == "osascript-tab"
+    assert "full screen" in result["detail"]
+    assert not any("to activate" in c[-1] for c in calls if c[0] == "osascript")
 
 
 def test_focus_macos_dead_pid_fails_instead_of_wrong_window(monkeypatch):
     monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
     monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
-
+    monkeypatch.setattr(terminal_focus, "pid_is_live_claude", lambda pid: False)
     calls = []
+    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(record=calls))
 
-    def fake_run(cmd):
-        calls.append(cmd)
-        if cmd[0] == "ps":
-            return _FakeCompleted(returncode=1)  # process gone
-        return _FakeCompleted(returncode=0)
-
-    monkeypatch.setattr(terminal_focus, "_run", fake_run)
     result = terminal_focus.focus_terminal({"term_program": "Apple_Terminal", "pid": 424242})
     assert result["focused"] is False
     assert "Could not locate" in result["detail"]
     # No blind app activation of an arbitrary window.
-    assert not any(c[0] == "osascript" for c in calls)
+    assert not any("to activate" in c[-1] for c in calls if c[0] == "osascript")
 
 
-def test_can_focus_dead_pid_hides_button(monkeypatch):
+def test_focus_macos_dead_pid_refuses_stored_tty_match(monkeypatch):
+    # tty devices are recycled once their tab closes — after the process
+    # dies, a stored tty may already belong to a stranger's tab, so it must
+    # not be matched (honest failure beats raising the wrong window).
     monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
-    monkeypatch.setattr(terminal_focus, "_pid_alive", lambda pid: False)
-    assert terminal_focus.can_focus({"term_program": "Apple_Terminal", "pid": 1234}) is False
-    # tmux panes can outlive the process; stay focusable.
-    assert terminal_focus.can_focus({"tmux_pane": "%1", "pid": 1234}) is True
+    monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
+    monkeypatch.setattr(terminal_focus, "pid_is_live_claude", lambda pid: False)
+    calls = []
+    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(record=calls))
+
+    result = terminal_focus.focus_terminal(
+        {"term_program": "Apple_Terminal", "pid": 424242, "tty": "/dev/ttys006"}
+    )
+    assert result["focused"] is False
+    assert not any("tty of" in c[-1] for c in calls if c[0] == "osascript")
 
 
-def test_can_focus_alive_pid(monkeypatch):
+def test_focus_macos_dead_pid_still_matches_iterm_session_id(monkeypatch):
+    # iTerm session UUIDs are never recycled — unlike a tty, the id match
+    # stays safe after the process dies (click racing the session's death).
     monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
-    monkeypatch.setattr(terminal_focus, "_pid_alive", lambda pid: True)
-    assert terminal_focus.can_focus({"term_program": "Apple_Terminal", "pid": 1234}) is True
+    monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
+    monkeypatch.setattr(terminal_focus, "pid_is_live_claude", lambda pid: False)
+    calls = []
+    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(record=calls))
 
-
-def test_can_focus_never_probes_pid_on_non_macos(monkeypatch):
-    # os.kill(pid, 0) terminates processes on Windows; the probe must be
-    # unreachable on platforms whose branches can't return True anyway.
-    def boom(pid):
-        raise AssertionError("pid probe must not run here")
-
-    monkeypatch.setattr(terminal_focus, "_pid_alive", boom)
-    monkeypatch.setattr(terminal_focus.sys, "platform", "win32")
-    assert terminal_focus.can_focus({"term_program": "Apple_Terminal", "pid": 1234}) is False
-    monkeypatch.setattr(terminal_focus.sys, "platform", "linux")
-    assert terminal_focus.can_focus({"window_id": "123", "pid": 1234}) is True
-
-
-def test_pid_alive_short_circuits_off_posix(monkeypatch):
-    def boom(pid, sig):
-        raise AssertionError("os.kill must not run off POSIX")
-
-    monkeypatch.setattr(terminal_focus.os, "kill", boom)
-    monkeypatch.setattr(terminal_focus.os, "name", "nt")
-    assert terminal_focus._pid_alive(1234) is True
+    result = terminal_focus.focus_terminal(
+        {
+            "term_program": "iTerm.app",
+            "pid": 424242,
+            "tty": "/dev/ttys006",
+            "iterm_session_id": "w0t2p0:44BF03B0-AAAA-BBBB-CCCC-DDDDEEEEFFFF",
+        }
+    )
+    assert result["focused"] is True
+    assert result["method"] == "osascript-tab"
+    assert any("id of s is" in c[-1] for c in calls if c[0] == "osascript")

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -659,6 +659,12 @@ export interface TerminalInfo {
 	term_session_id: string | null;
 	window_id: string | null;
 	pid: number | null;
+	/** Controlling tty captured while the process was alive, e.g. '/dev/ttys006'. */
+	tty: string | null;
+	/** iTerm2 session id (ITERM_SESSION_ID), e.g. 'w0t2p0:UUID'. */
+	iterm_session_id: string | null;
+	/** macOS bundle id of the spawning app (__CFBundleIdentifier). */
+	bundle_id: string | null;
 }
 
 /** Result of attempting to focus a session's terminal window/pane. */

--- a/hooks/_captain_hook_lite.py
+++ b/hooks/_captain_hook_lite.py
@@ -79,8 +79,9 @@ if HAS_PYDANTIC:
 
     class StopHook(_BaseHook):
         hook_event_name: str = Field("Stop")
+        # A missing field means no stop hook is running — a natural stop.
         stop_hook_active: bool = Field(
-            True,
+            False,
             description="True if already continuing from a previous Stop hook",
         )
 

--- a/hooks/live_session_tracker.py
+++ b/hooks/live_session_tracker.py
@@ -114,6 +114,25 @@ def resolve_git_root(cwd: str) -> Optional[str]:
     return None
 
 
+def _tty_of_pid(pid: Optional[int]) -> Optional[str]:
+    """Resolve a process's controlling tty via ``ps``, e.g. '/dev/ttys006'."""
+    if not pid:
+        return None
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "tty=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        tty = result.stdout.strip()
+        if result.returncode == 0 and tty and tty not in ("??", "-"):
+            return tty if tty.startswith("/dev/") else f"/dev/{tty}"
+    except (subprocess.SubprocessError, OSError):
+        pass
+    return None
+
+
 def resolve_terminal() -> Dict[str, Any]:
     """Capture the terminal/pane a session is running in from the environment.
 
@@ -123,11 +142,15 @@ def resolve_terminal() -> Dict[str, Any]:
 
     - ``TMUX`` / ``TMUX_PANE``   → running inside tmux (works on any OS)
     - ``TERM_PROGRAM`` / ``TERM_SESSION_ID`` → macOS terminal apps (osascript)
+    - ``ITERM_SESSION_ID``       → iTerm2 tab/session UUID (survives pid death)
+    - ``__CFBundleIdentifier``   → exact macOS app that spawned the shell
     - ``WINDOWID``               → Linux X11 window (xdotool/wmctrl)
 
-    ``pid`` is the hook's parent — the live ``claude`` process. It is not the
-    terminal, but while the session runs its tty identifies the exact tab,
-    which the API uses for per-window focus on macOS.
+    ``pid`` is the hook's parent — the live ``claude`` process. ``tty`` is
+    that process's controlling terminal, resolved NOW while the process is
+    alive; the API prefers it over a click-time pid→tty lookup so tab
+    matching survives pid death and recycling. Inside tmux the tty is the
+    tmux server's pty (not a GUI tab) — the API detects that via ``tmux``.
     All fields are best-effort; missing ones stay ``None``.
     """
     env = os.environ
@@ -141,9 +164,19 @@ def resolve_terminal() -> Dict[str, Any]:
         "tmux_pane": tmux_pane,
         "term_program": env.get("TERM_PROGRAM") or None,
         "term_session_id": env.get("TERM_SESSION_ID") or None,
+        "iterm_session_id": env.get("ITERM_SESSION_ID") or None,
+        "bundle_id": env.get("__CFBundleIdentifier") or None,
         "window_id": env.get("WINDOWID") or None,
         "pid": pid,
+        "tty": _tty_of_pid(pid),
     }
+
+
+def _terminal_for(existing_terminal: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Keep a current-format terminal dict; (re-)resolve legacy or missing ones."""
+    if existing_terminal and "tty" in existing_terminal:
+        return existing_terminal
+    return resolve_terminal()
 
 
 def write_state_atomic(path: Path, update_fn: Callable[[dict], dict]) -> None:
@@ -341,16 +374,22 @@ def write_state(
     last_notification_message: Optional[str] = None,
     pending_permission_message: Optional[str] = None,
     terminal: Optional[Dict[str, Any]] = None,
+    skip_if_current_state: Optional[str] = None,
 ) -> None:
     """Write session state to disk under an exclusive lock.
 
     Files are always keyed by ``session_id``. Preserves ``started_at``,
     ``subagents``, and previously-resolved fields across updates.
+    ``skip_if_current_state`` makes the write a no-op when the on-disk state
+    matches — checked inside the lock, so racing hooks can't interleave
+    between a read and this write.
     """
     now = datetime.now(timezone.utc).isoformat()
     target_path = get_state_path(session_id)
 
     def update_fn(existing: dict) -> dict:
+        if skip_if_current_state and existing.get("state") == skip_if_current_state:
+            return existing
         # NB: keep `slug` writable so legacy callers don't lose it, but we
         # never SET it here — the field stays whatever it was (usually None).
         new_data = {
@@ -372,10 +411,8 @@ def write_state(
             "source": source or existing.get("source"),
             "claude_model": claude_model or existing.get("claude_model"),
             "agent_type": agent_type or existing.get("agent_type"),
-            # SessionStart resolves terminal identity fresh; any other event
-            # backfills it for sessions that predate terminal tracking (env
-            # and parent pid are identical on every hook invocation).
-            "terminal": terminal or existing.get("terminal") or resolve_terminal(),
+            # Non-SessionStart events backfill legacy/missing captures via _terminal_for.
+            "terminal": terminal or _terminal_for(existing.get("terminal")),
         }
 
         # Pending permission text is sticky until cleared by a non-WAITING transition.
@@ -475,14 +512,14 @@ def _handle_event(data: Dict[str, Any]) -> None:
                 last_notification_message=message,
             )
         elif notification_type == "idle_prompt":
-            _, existing = read_existing_state(session_id)
-            if existing.get("state") != "WAITING":
-                write_state(
-                    session_id,
-                    "STALE",
-                    data,
-                    last_notification_message=message,
-                )
+            # WAITING outranks STALE; the check runs inside the write lock.
+            write_state(
+                session_id,
+                "STALE",
+                data,
+                last_notification_message=message,
+                skip_if_current_state="WAITING",
+            )
 
     elif hook_name == "PermissionRequest":
         # Permission requests are essentially a richer WAITING signal.
@@ -497,7 +534,9 @@ def _handle_event(data: Dict[str, Any]) -> None:
 
     elif hook_name == "Stop":
         # Only mark STOPPED if agent finished naturally (not forced continue).
-        if not _get(hook, "stop_hook_active", True):
+        # A missing stop_hook_active field means no stop hook is running —
+        # that's a natural stop, so the default must be False.
+        if not _get(hook, "stop_hook_active", False):
             write_state(session_id, "STOPPED", data)
 
     elif hook_name == "SubagentStart":

--- a/hooks/tests/test_live_session_tracker.py
+++ b/hooks/tests/test_live_session_tracker.py
@@ -1,0 +1,176 @@
+"""Tests for hooks/live_session_tracker.py terminal capture and state logic.
+
+Direct-import unit tests (unlike the subprocess-driven ticket detector
+tests): the interesting logic here is pure functions plus locked file
+writes, and LIVE_SESSIONS_DIR is a module global we can point at tmp.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_hooks_dir = Path(__file__).resolve().parent.parent
+if str(_hooks_dir) not in sys.path:
+    sys.path.insert(0, str(_hooks_dir))
+
+import live_session_tracker as tracker
+
+
+class _FakeCompleted:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+@pytest.fixture
+def live_dir(tmp_path, monkeypatch) -> Path:
+    """Redirect state files (and the error log) to a tmp dir."""
+    d = tmp_path / "live-sessions"
+    monkeypatch.setattr(tracker, "LIVE_SESSIONS_DIR", d)
+    monkeypatch.setattr(tracker, "ERROR_LOG", d / ".errors.log")
+    return d
+
+
+def _read_state(live_dir: Path, session_id: str) -> dict:
+    return json.loads((live_dir / f"{session_id}.json").read_text())
+
+
+# ---------------------------------------------------------------------------
+# resolve_terminal
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_terminal_captures_identity(monkeypatch):
+    env = {
+        "TERM_PROGRAM": "Apple_Terminal",
+        "TERM_SESSION_ID": "UUID-1",
+        "ITERM_SESSION_ID": "w0t2p0:UUID-2",
+        "__CFBundleIdentifier": "com.apple.Terminal",
+    }
+    monkeypatch.setattr(tracker.os, "environ", env)
+    monkeypatch.setattr(tracker.os, "getppid", lambda: 4242)
+    monkeypatch.setattr(
+        tracker.subprocess, "run", lambda *a, **k: _FakeCompleted(stdout="ttys004\n")
+    )
+
+    t = tracker.resolve_terminal()
+    assert t["term_program"] == "Apple_Terminal"
+    assert t["term_session_id"] == "UUID-1"
+    assert t["iterm_session_id"] == "w0t2p0:UUID-2"
+    assert t["bundle_id"] == "com.apple.Terminal"
+    assert t["pid"] == 4242
+    assert t["tty"] == "/dev/ttys004"
+    assert t["tmux"] is False
+
+
+def test_resolve_terminal_headless_stores_nones(monkeypatch):
+    monkeypatch.setattr(tracker.os, "environ", {})
+    monkeypatch.setattr(tracker.os, "getppid", lambda: 4242)
+    monkeypatch.setattr(
+        tracker.subprocess, "run", lambda *a, **k: _FakeCompleted(stdout="??\n")
+    )
+
+    t = tracker.resolve_terminal()
+    assert t["term_program"] is None
+    assert t["bundle_id"] is None
+    assert t["tty"] is None  # "??" means no controlling tty
+    assert "tty" in t  # key presence marks current-format capture
+
+
+def test_tty_of_pid_survives_ps_failure(monkeypatch):
+    def boom(*a, **k):
+        raise OSError("ps unavailable")
+
+    monkeypatch.setattr(tracker.subprocess, "run", boom)
+    assert tracker._tty_of_pid(4242) is None
+    assert tracker._tty_of_pid(None) is None
+
+
+# ---------------------------------------------------------------------------
+# terminal backfill / upgrade
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_for_keeps_current_format(monkeypatch):
+    def boom():
+        raise AssertionError("must not re-resolve a current-format capture")
+
+    monkeypatch.setattr(tracker, "resolve_terminal", boom)
+    current = {"term_program": "Apple_Terminal", "pid": 1, "tty": None}
+    assert tracker._terminal_for(current) is current
+
+
+def test_terminal_for_upgrades_legacy_and_missing(monkeypatch):
+    fresh = {"term_program": "X", "pid": 2, "tty": "/dev/ttys009"}
+    monkeypatch.setattr(tracker, "resolve_terminal", lambda: fresh)
+    legacy = {"term_program": "Apple_Terminal", "pid": 1}  # predates tty capture
+    assert tracker._terminal_for(legacy) is fresh
+    assert tracker._terminal_for(None) is fresh
+
+
+def test_write_state_upgrades_legacy_terminal_once(live_dir, monkeypatch):
+    fresh = {"term_program": "Apple_Terminal", "pid": 7, "tty": "/dev/ttys001"}
+    monkeypatch.setattr(tracker, "resolve_terminal", lambda: fresh)
+
+    tracker.write_state("s1", "LIVE", {}, terminal={"term_program": "Apple_Terminal", "pid": 7})
+    tracker.write_state("s1", "LIVE", {})  # legacy dict on disk → upgraded
+    assert _read_state(live_dir, "s1")["terminal"] == fresh
+
+
+# ---------------------------------------------------------------------------
+# Stop semantics
+# ---------------------------------------------------------------------------
+
+
+def test_stop_without_flag_marks_stopped(live_dir, monkeypatch):
+    monkeypatch.setattr(tracker, "resolve_terminal", lambda: {"tty": None})
+    tracker._handle_event({"hook_event_name": "Stop", "session_id": "s2"})
+    assert _read_state(live_dir, "s2")["state"] == "STOPPED"
+
+
+def test_stop_with_active_stop_hook_is_ignored(live_dir, monkeypatch):
+    monkeypatch.setattr(tracker, "resolve_terminal", lambda: {"tty": None})
+    tracker._handle_event(
+        {"hook_event_name": "Stop", "session_id": "s3", "stop_hook_active": True}
+    )
+    assert not (live_dir / "s3.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# idle_prompt vs WAITING (locked, no TOCTOU)
+# ---------------------------------------------------------------------------
+
+
+def _notification(session_id: str, notification_type: str) -> dict:
+    return {
+        "hook_event_name": "Notification",
+        "session_id": session_id,
+        "notification_type": notification_type,
+        "message": "msg",
+    }
+
+
+def test_idle_prompt_does_not_demote_waiting(live_dir, monkeypatch):
+    monkeypatch.setattr(tracker, "resolve_terminal", lambda: {"tty": None})
+    tracker._handle_event(_notification("s4", "permission_prompt"))
+    before = _read_state(live_dir, "s4")
+    assert before["state"] == "WAITING"
+
+    tracker._handle_event(_notification("s4", "idle_prompt"))
+    after = _read_state(live_dir, "s4")
+    assert after["state"] == "WAITING"
+    assert after["updated_at"] == before["updated_at"]  # true no-op skip
+
+
+def test_idle_prompt_marks_live_session_stale(live_dir, monkeypatch):
+    monkeypatch.setattr(tracker, "resolve_terminal", lambda: {"tty": None})
+    tracker._handle_event(
+        {"hook_event_name": "UserPromptSubmit", "session_id": "s5", "prompt": "hi"}
+    )
+    tracker._handle_event(_notification("s5", "idle_prompt"))
+    assert _read_state(live_dir, "s5")["state"] == "STALE"


### PR DESCRIPTION
## Summary

Fixes all seven flaws found in the terminal-focus/live-tracking analysis of #86/#87. Root fix: the ephemeral pid is no longer the identity key — hooks capture the claude process's **tty**, **ITERM_SESSION_ID**, and **__CFBundleIdentifier** while it's alive, and focus matches on those durable identifiers. Every result is now verified and honest: `focused=true` is only reported when the window genuinely came to front.

## Changes

- **Durable capture** (`hooks/live_session_tracker.py`): store tty/iTerm UUID/bundle id at hook time; legacy state files upgrade automatically on their next event
- **Focus rewrite** (`api/services/terminal_focus.py`): iTerm session-UUID match first (never recycled), stored tty second; tty matching refuses once the pid is dead so a recycled tty can't raise a stranger's tab (adversarial-review finding)
- **Terminal.app raise that works**: `set index to 1` + activate — the #87 miniaturize cycle silently no-ops for windows on other Spaces *while reporting success*; the script now verifies front-window and returns `raised` vs `selected`
- **tmux**: `switch-client -c <client>` (the old bare `switch-client` was a no-op from the API), `focused=true` only when a client actually displays the pane, GUI raise of the client's hosting window on macOS, exact `tmux attach -t …` hint when detached
- **Guarded activation**: bundle-id targeting behind AppleScript `is running` — clicking a Cursor session can no longer launch VS Code
- **can_focus parity**: cached pid-liveness + comm check on every platform (the #87 gate was macOS-only; Linux kept live buttons for dead sessions); real `OpenProcess` probe on Windows
- **Dead-session reaper** (`api/services/live_session_store.py` + reconciler): non-terminal state files with a dead/recycled pid → `ENDED/process_died`; pid-less files expire after 24h. Cleared 16 immortal stale entries on its first live run
- **Nits**: `stop_hook_active` default False in the vendored lite model (missing field = natural stop; the True default suppressed STOPPED), idle_prompt WAITING check moved inside the file lock (TOCTOU), response schema + frontend types extended

## Component

- [x] API (FastAPI backend)
- [x] Frontend (SvelteKit dashboard)
- [x] Hook Scripts

## Type

- [x] Bug fix

## Testing

- [x] API tests pass (`cd api && pytest`) — 73 in the touched suites; full-suite failures are 3 pre-existing `background_shells` tests that fail identically on clean `main`
- [x] Frontend type-checks (`cd frontend && npm run check`)
- [x] Captain Hook tests pass — plus a new `hooks/tests/test_live_session_tracker.py` suite (10 tests)
- [x] Manually tested in browser — Playwright end-to-end: capture backfill, honest-false on an unraisable window, verified-true raise (front window independently confirmed), reaper live run

Reviewed by two independent agents (bugs + quality); the one major finding (stale-tty match before liveness check) and all five minor findings are fixed in this diff.

## Related Issues

Relates to #86, #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P26rGnzmYY4A6Rq4y1JU27