### PR TITLE
docs(setup): make Tier 2 the default install path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ Project (entry point)
 
 ## Captain Hook
 
-Type-safe Pydantic models for Claude Code's 10 hook types:
+Type-safe Pydantic models for Claude Code's 24 hook types (see `captain-hook/CLAUDE.md` for the full list). Karma's own hooks only use 8 of them:
 
 | Hook | Fires | Can Block? |
 |------|-------|------------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,8 @@ npm install && npm run dev
 
 Open http://localhost:5173 to view the dashboard.
 
+**This is Tier 1 only — a read-only historical viewer.** Karma's core feature is live session tracking (Tier 2 in [SETUP.md](./SETUP.md#tier-2-live-monitoring-core-feature)); install through Tier 2 by default unless the user explicitly wants only historical browsing.
+
 ## Repository Structure
 
 This is a monorepo with all components in a single repository:

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ npm install && npm run dev
 
 Open **http://localhost:5173** to view the dashboard.
 
-For detailed setup including live session tracking, see [SETUP.md](./SETUP.md).
+**This only gets you the historical dashboard.** Karma's core feature — live session tracking as sessions actually run — needs one more step, [Tier 2 in SETUP.md](./SETUP.md#tier-2-live-monitoring-core-feature). Install through Tier 2 by default; the rest of SETUP.md's tiers are optional polish on top.
 
 ## How It Works
 
@@ -291,7 +291,7 @@ claude-code-karma/
 
 ## Live Session Tracking
 
-Enable real-time session monitoring by installing Claude Code hooks. See [SETUP.md](./SETUP.md#live-sessions-tracking-optional) for setup instructions.
+This is Karma's core feature — without it, Karma is just a historical viewer. Enable real-time session monitoring by installing Claude Code hooks. See [Tier 2 in SETUP.md](./SETUP.md#tier-2-live-monitoring-core-feature) for setup instructions.
 
 Live sessions also get an **"open terminal"** button (on the session page, the home strip, and `/sessions`) that raises the terminal window the session is running in — Karma runs locally, so the API can ask the OS window manager directly. macOS Terminal.app and iTerm2 get the exact window/tab, tmux gets the exact pane, other macOS terminals are raised app-level, and Linux needs X11 with `xdotool` or `wmctrl`. Design details in [docs/feature/open-terminal/spec.md](./docs/feature/open-terminal/spec.md).
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -6,16 +6,18 @@
 
 ## What You'll Get
 
-Claude Code Karma installs in **4 progressive tiers**. Start with the core dashboard, then add live monitoring, smart titles, and ticket-linking workflows as needed.
+Claude Code Karma installs in **4 progressive tiers**. Tier 1 alone is a read-only history viewer — it shows you what's already sitting in `~/.claude/projects/*.jsonl`. **Tier 2 is what makes it Karma:** live, real-time visibility into every session as it happens. That's the core feature and the reason this dashboard is worth having open instead of just reading JSONL files by hand. Tiers 3–4 are polish on top of that.
 
 | Tier | Components | Dashboard Features | Installation Time |
 |------|-----------|-------------------|-------------------|
 | **1: Core Dashboard** | API + Frontend | Browse projects, view sessions, analytics, **`/tickets` page** (works empty) | ~5 min |
-| **2: Live Monitoring** | + Live Tracker Hook | Real-time session indicators, recently ended | +2 min |
+| **2: Live Monitoring** ⭐ | + Live Tracker Hook | Real-time session indicators, recently ended, Open Terminal button | +2 min |
 | **3: Smart Titles** | + Title Generator Hook | Human-readable session names | +2 min |
 | **4: Auto-Link Tickets** | + `link-ticket-to-session` skill, optional branch hook | Slash command + natural-language linking, optional auto-link from git branch name | +2 min |
 
-**You can stop after Tier 1.** Tiers 2–4 are optional enhancements installed independently. Tier 4 only adds *workflows* for creating links; the ticket pages themselves (`/tickets`, project Tickets tab, session Tickets section) all work in Tier 1 — you can paste a URL on any session page without any hooks or skills installed.
+⭐ = Karma's core feature — install through Tier 2 by default.
+
+**Install through Tier 2 unless the user specifically asked only for historical browsing.** Tier 1 by itself doesn't do anything Tier 2 doesn't also do; Tier 2 just adds the live tracking on top. Tiers 3 and 4 are genuinely optional: Tier 3 auto-titles sessions, and Tier 4 only adds *workflows* for creating ticket links — the ticket pages themselves (`/tickets`, project Tickets tab, session Tickets section) all work in Tier 1, you can paste a URL on any session page without any hooks or skills installed.
 
 ---
 
@@ -217,11 +219,11 @@ Open http://localhost:5173 in your browser. You should see the Claude Code Karma
 
 > **Agent notes:** If any core feature fails, check API health (`curl http://localhost:8000/health`) and browser console for errors. Do NOT proceed to Tier 2 until core works.
 
-**You can stop here.** The full historical dashboard works. Proceed to Tier 2 only if you want real-time monitoring.
+**This is the read-only historical view.** It works, but it's not what Karma is for. Continue to Tier 2 below — it's the core feature: live session tracking as sessions actually run, not just a record of what already happened.
 
 ---
 
-## Tier 2: Live Monitoring (Recommended)
+## Tier 2: Live Monitoring (Core Feature)
 
 Adds real-time session tracking — see which Claude Code sessions are active, waiting, idle, or recently ended.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -41,7 +41,8 @@ claude --version     # Claude CLI (any version)
 
 | Tool | Minimum | Required? | Why |
 |------|---------|-----------|-----|
-| Python | 3.9+ | Yes | API backend runs on Python |
+| Python (hooks) | 3.9+ | Yes | Hook scripts (Tiers 2-4) run fine on 3.9+ |
+| Python (API) | 3.10+ | Yes | API backend uses newer type-hint syntax; crashes on import under 3.9 |
 | Node.js | 18+ | Yes | Frontend build system |
 | npm | 7+ | Yes | Frontend package manager |
 | Git | Any | Yes | Clone repository |
@@ -256,7 +257,7 @@ chmod +x ~/.claude/hooks/live_session_tracker.py
 ls -la ~/.claude/hooks/live_session_tracker.py
 ```
 
-> **Agent notes:** Confirm symlink or copy succeeded. Script must be executable. Test with: `python3 ~/.claude/hooks/live_session_tracker.py < /dev/null` (should exit cleanly, may print help).
+> **Agent notes:** Confirm symlink or copy succeeded. Script must be executable. Test with: `python3 ~/.claude/hooks/live_session_tracker.py < /dev/null` — a silent exit 0 is success, not a failure; the script prints nothing on a clean run.
 
 ---
 
@@ -265,7 +266,7 @@ ls -la ~/.claude/hooks/live_session_tracker.py
 **What:** Register the tracker to listen for Claude Code events.
 **Why:** Tells Claude Code to call the tracker when sessions start, change state, or end.
 
-The tracker needs **8 of Claude Code's 13 hook events** registered in `~/.claude/settings.json`:
+The tracker needs **8 of Claude Code's 24 hook events** registered in `~/.claude/settings.json`:
 
 | Hook Event | Tracks |
 |-----------|--------|
@@ -399,7 +400,17 @@ ls ~/.claude_karma/live-sessions/
 **What:** Confirm the tracker is working in real-time.
 **Why:** Live indicators won't show up unless the tracker is being called by Claude Code.
 
-**Test:**
+**Headless/agent verification (no live Claude Code session required) — do this first:** this is the only method that works in a sandbox, CI, or any environment without an interactive Claude Code session.
+```bash
+# Fire a synthetic SessionStart event and confirm it flows through the whole pipeline
+echo '{"hook_event_name":"SessionStart","session_id":"verify-1","cwd":"'"$PWD"'","transcript_path":"/tmp/verify.jsonl"}' \
+  | python3 ~/.claude/hooks/live_session_tracker.py
+ls ~/.claude_karma/live-sessions/
+curl -s http://localhost:8000/live-sessions | python3 -m json.tool
+```
+A working pipeline shows the state file created and the session appearing in the API response.
+
+**Interactive verification (real usage on your actual machine):**
 1. Start a new Claude Code session (or resume an existing one)
 2. Check for state file: `ls ~/.claude_karma/live-sessions/`
 3. Refresh the dashboard at http://localhost:5173
@@ -418,7 +429,7 @@ watch -n1 'ls -la ~/.claude_karma/live-sessions/'
 curl http://localhost:8000/live-sessions 2>/dev/null | python3 -m json.tool
 ```
 
-> **Agent notes:** If no live sessions appear, check: 1) hook is in settings.json, 2) Claude Code is actually running, 3) state files in ~/.claude_karma/live-sessions/ are being created/updated.
+> **Agent notes:** In a headless/sandboxed/CI environment, use the synthetic-event test above — there's no live Claude Code session to wait for. On a real machine with no live sessions appearing, check: 1) hook is in settings.json, 2) Claude Code is actually running, 3) state files in ~/.claude_karma/live-sessions/ are being created/updated.
 
 **Note:** SubagentStart and SubagentStop events require Claude Code 2.1.19+. On older versions, subagent tracking won't work, but everything else will.
 
@@ -657,7 +668,6 @@ chmod +x hooks/ticket_branch_detector.py
   "hooks": {
     "SessionStart": [
       {
-        "matcher": ".*",
         "hooks": [
           { "type": "command", "command": "python3 ~/.claude/hooks/ticket_branch_detector.py" }
         ]

--- a/api/command_helpers/cli_js.py
+++ b/api/command_helpers/cli_js.py
@@ -5,6 +5,8 @@ Locates Claude Code's cli.js binary, extracts command names/descriptions,
 and resolves full prompt templates for bundled skills.
 """
 
+from __future__ import annotations
+
 import logging
 import re
 import shutil

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.0"
 description = "Pydantic models for parsing Claude Code local storage"
 readme = "README.md"
 license = {text = "Apache-2.0"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.0",
     "pydantic-settings>=2.0.0",


### PR DESCRIPTION
## Why this branch

Users handing SETUP.md to an agent were getting the Tier 1 dashboard and stopping there — never installing Tier 2 (live session tracking), which is Karma's actual differentiator. SETUP.md itself told agents to stop: "You can stop after Tier 1" / "You can stop here," right at the point Tier 2 begins. README and root CLAUDE.md's Quick Starts also only ever showed the Tier-1-only flow.

## What changed

- Tier 2 is now framed as the core feature, not an optional add-on alongside Tiers 3/4. Removed both "you can stop" callouts; reworded the tier table and intro so Tier 2 is the default install target unless a user explicitly wants only historical browsing.
- Fixed a dead anchor link and added consistent "Tier 2" pointers in README and CLAUDE.md's Quick Starts.
- `api/pyproject.toml` `requires-python` bumped to `>=3.10` — the API crashes on import under 3.9 (PEP 604 `Path | None` in `cli_js.py`, no `from __future__ import annotations`); hooks are fine on 3.9. Added the future-annotations import as a same-branch fix, and split SETUP.md's Prerequisites row accordingly.
- Fixed a stale hook-count claim (SETUP.md said 13, `captain-hook` actually models 24; root CLAUDE.md said 10 for the same reason), a misleading "may print help" note on a script that prints nothing, an inconsistent `matcher` field between two hook examples, and promoted the headless verification method in Step 7 above the interactive one.

## Testing

Verified with a blind test: a fresh subagent, with no knowledge of this diagnosis, was handed only this branch's URL and told to set up the project via its SETUP.md — nothing else. It ran inside an isolated Vercel Sandbox microVM (via a small reusable `@vercel/sandbox`-backed CLI bridge), so nothing touched any real machine's `~/.claude` config.

Result: the agent completed Tier 1, explicitly cited the new "Tier 2 is the core feature" wording as why it should continue, then paused specifically at the point of editing global `~/.claude/settings.json` to ask for confirmation before making a persistent, cross-session config change — which is correct, cautious behavior, not a doc failure. On go-ahead, it installed and verified Tier 2 end-to-end inside the sandbox: hook → settings.json → synthetic event → state file → `/live-sessions` API response, all confirmed. Tier 4's branch-detect was also verified end-to-end. I independently re-checked the live-sessions output and settings.json myself rather than trusting the report alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)