### PR TITLE
docs: make Tier 2 the default install path and fix Python/hook-count claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ Project (entry point)
 
 ## Captain Hook
 
-Type-safe Pydantic models for Claude Code's 10 hook types:
+Type-safe Pydantic models for Claude Code's 24 hook types (see `captain-hook/CLAUDE.md` for the full list). Karma's own hooks only use 8 of them:
 
 | Hook | Fires | Can Block? |
 |------|-------|------------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,7 +210,7 @@ hook = parse_hook_event(json_data)
 ## Tech Stack
 
 ### Backend
-- **Python 3.9+**
+- **Python 3.10+** (hook scripts alone run on 3.9+)
 - **FastAPI** - Web framework
 - **Pydantic 2.x** - Data validation
 - **aiofiles** - Async file I/O

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,8 @@ npm install && npm run dev
 
 Open http://localhost:5173 to view the dashboard.
 
+**This is Tier 1 only — a read-only historical viewer.** Karma's core feature is live session tracking (Tier 2 in [SETUP.md](./SETUP.md#tier-2-live-monitoring-core-feature)); install through Tier 2 by default unless the user explicitly wants only historical browsing.
+
 ## Repository Structure
 
 This is a monorepo with all components in a single repository:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://www.apache.org/licenses/LICENSE-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License: Apache-2.0" /></a>
-  <a href="https://www.python.org/"><img src="https://img.shields.io/badge/Python-3.9+-blue.svg" alt="Python 3.9+" /></a>
+  <a href="https://www.python.org/"><img src="https://img.shields.io/badge/Python-3.10+-blue.svg" alt="Python 3.10+" /></a>
   <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/Node-18+-green.svg" alt="Node 18+" /></a>
   <a href="https://kit.svelte.dev/"><img src="https://img.shields.io/badge/SvelteKit-2-FF3E00.svg" alt="SvelteKit 2" /></a>
 </p>
@@ -306,7 +306,7 @@ Live sessions also get an **"open terminal"** button (on the session page, the h
 ## Technology Stack
 
 ### Backend
-- **Python 3.9+** with **FastAPI** and **Pydantic 2.x**
+- **Python 3.10+** with **FastAPI** and **Pydantic 2.x**
 - **SQLite** for metadata indexing
 - **pytest** for testing, **ruff** for linting
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ npm install && npm run dev
 
 Open **http://localhost:5173** to view the dashboard.
 
-For detailed setup including live session tracking, see [SETUP.md](./SETUP.md).
+**This only gets you the historical dashboard.** Karma's core feature — live session tracking as sessions actually run — needs one more step, [Tier 2 in SETUP.md](./SETUP.md#tier-2-live-monitoring-core-feature). Install through Tier 2 by default; the rest of SETUP.md's tiers are optional polish on top.
 
 ## How It Works
 
@@ -291,7 +291,7 @@ claude-code-karma/
 
 ## Live Session Tracking
 
-Enable real-time session monitoring by installing Claude Code hooks. See [SETUP.md](./SETUP.md#live-sessions-tracking-optional) for setup instructions.
+This is Karma's core feature — without it, Karma is just a historical viewer. Enable real-time session monitoring by installing Claude Code hooks. See [Tier 2 in SETUP.md](./SETUP.md#tier-2-live-monitoring-core-feature) for setup instructions.
 
 Live sessions also get an **"open terminal"** button (on the session page, the home strip, and `/sessions`) that raises the terminal window the session is running in — Karma runs locally, so the API can ask the OS window manager directly. macOS Terminal.app and iTerm2 get the exact window/tab, tmux gets the exact pane, other macOS terminals are raised app-level, and Linux needs X11 with `xdotool` or `wmctrl`. Design details in [docs/feature/open-terminal/spec.md](./docs/feature/open-terminal/spec.md).
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -6,16 +6,18 @@
 
 ## What You'll Get
 
-Claude Code Karma installs in **4 progressive tiers**. Start with the core dashboard, then add live monitoring, smart titles, and ticket-linking workflows as needed.
+Claude Code Karma installs in **4 progressive tiers**. Tier 1 alone is a read-only history viewer — it shows you what's already sitting in `~/.claude/projects/*.jsonl`. **Tier 2 is what makes it Karma:** live, real-time visibility into every session as it happens. That's the core feature and the reason this dashboard is worth having open instead of just reading JSONL files by hand. Tiers 3–4 are polish on top of that.
 
 | Tier | Components | Dashboard Features | Installation Time |
 |------|-----------|-------------------|-------------------|
 | **1: Core Dashboard** | API + Frontend | Browse projects, view sessions, analytics, **`/tickets` page** (works empty) | ~5 min |
-| **2: Live Monitoring** | + Live Tracker Hook | Real-time session indicators, recently ended | +2 min |
+| **2: Live Monitoring** ⭐ | + Live Tracker Hook | Real-time session indicators, recently ended, Open Terminal button | +2 min |
 | **3: Smart Titles** | + Title Generator Hook | Human-readable session names | +2 min |
 | **4: Auto-Link Tickets** | + `link-ticket-to-session` skill, optional branch hook | Slash command + natural-language linking, optional auto-link from git branch name | +2 min |
 
-**You can stop after Tier 1.** Tiers 2–4 are optional enhancements installed independently. Tier 4 only adds *workflows* for creating links; the ticket pages themselves (`/tickets`, project Tickets tab, session Tickets section) all work in Tier 1 — you can paste a URL on any session page without any hooks or skills installed.
+⭐ = Karma's core feature — install through Tier 2 by default.
+
+**Install through Tier 2 unless the user specifically asked only for historical browsing.** Tier 1 by itself doesn't do anything Tier 2 doesn't also do; Tier 2 just adds the live tracking on top. Tiers 3 and 4 are genuinely optional: Tier 3 auto-titles sessions, and Tier 4 only adds *workflows* for creating ticket links — the ticket pages themselves (`/tickets`, project Tickets tab, session Tickets section) all work in Tier 1, you can paste a URL on any session page without any hooks or skills installed.
 
 ---
 
@@ -217,11 +219,11 @@ Open http://localhost:5173 in your browser. You should see the Claude Code Karma
 
 > **Agent notes:** If any core feature fails, check API health (`curl http://localhost:8000/health`) and browser console for errors. Do NOT proceed to Tier 2 until core works.
 
-**You can stop here.** The full historical dashboard works. Proceed to Tier 2 only if you want real-time monitoring.
+**This is the read-only historical view.** It works, but it's not what Karma is for. Continue to Tier 2 below — it's the core feature: live session tracking as sessions actually run, not just a record of what already happened.
 
 ---
 
-## Tier 2: Live Monitoring (Recommended)
+## Tier 2: Live Monitoring (Core Feature)
 
 Adds real-time session tracking — see which Claude Code sessions are active, waiting, idle, or recently ended.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -41,7 +41,8 @@ claude --version     # Claude CLI (any version)
 
 | Tool | Minimum | Required? | Why |
 |------|---------|-----------|-----|
-| Python | 3.9+ | Yes | API backend runs on Python |
+| Python (hooks) | 3.9+ | Yes | Hook scripts (Tiers 2-4) run fine on 3.9+ |
+| Python (API) | 3.10+ | Yes | API backend uses newer type-hint syntax; crashes on import under 3.9 |
 | Node.js | 18+ | Yes | Frontend build system |
 | npm | 7+ | Yes | Frontend package manager |
 | Git | Any | Yes | Clone repository |
@@ -256,7 +257,7 @@ chmod +x ~/.claude/hooks/live_session_tracker.py
 ls -la ~/.claude/hooks/live_session_tracker.py
 ```
 
-> **Agent notes:** Confirm symlink or copy succeeded. Script must be executable. Test with: `python3 ~/.claude/hooks/live_session_tracker.py < /dev/null` (should exit cleanly, may print help).
+> **Agent notes:** Confirm symlink or copy succeeded. Script must be executable. Test with: `python3 ~/.claude/hooks/live_session_tracker.py < /dev/null` — a silent exit 0 is success, not a failure; the script prints nothing on a clean run.
 
 ---
 
@@ -265,7 +266,7 @@ ls -la ~/.claude/hooks/live_session_tracker.py
 **What:** Register the tracker to listen for Claude Code events.
 **Why:** Tells Claude Code to call the tracker when sessions start, change state, or end.
 
-The tracker needs **8 of Claude Code's 13 hook events** registered in `~/.claude/settings.json`:
+The tracker needs **8 of Claude Code's 24 hook events** registered in `~/.claude/settings.json`:
 
 | Hook Event | Tracks |
 |-----------|--------|
@@ -399,7 +400,17 @@ ls ~/.claude_karma/live-sessions/
 **What:** Confirm the tracker is working in real-time.
 **Why:** Live indicators won't show up unless the tracker is being called by Claude Code.
 
-**Test:**
+**Headless/agent verification (no live Claude Code session required) — do this first:** this is the only method that works in a sandbox, CI, or any environment without an interactive Claude Code session.
+```bash
+# Fire a synthetic SessionStart event and confirm it flows through the whole pipeline
+echo '{"hook_event_name":"SessionStart","session_id":"verify-1","cwd":"'"$PWD"'","transcript_path":"/tmp/verify.jsonl"}' \
+  | python3 ~/.claude/hooks/live_session_tracker.py
+ls ~/.claude_karma/live-sessions/
+curl -s http://localhost:8000/live-sessions | python3 -m json.tool
+```
+A working pipeline shows the state file created and the session appearing in the API response.
+
+**Interactive verification (real usage on your actual machine):**
 1. Start a new Claude Code session (or resume an existing one)
 2. Check for state file: `ls ~/.claude_karma/live-sessions/`
 3. Refresh the dashboard at http://localhost:5173
@@ -418,7 +429,7 @@ watch -n1 'ls -la ~/.claude_karma/live-sessions/'
 curl http://localhost:8000/live-sessions 2>/dev/null | python3 -m json.tool
 ```
 
-> **Agent notes:** If no live sessions appear, check: 1) hook is in settings.json, 2) Claude Code is actually running, 3) state files in ~/.claude_karma/live-sessions/ are being created/updated.
+> **Agent notes:** In a headless/sandboxed/CI environment, use the synthetic-event test above — there's no live Claude Code session to wait for. On a real machine with no live sessions appearing, check: 1) hook is in settings.json, 2) Claude Code is actually running, 3) state files in ~/.claude_karma/live-sessions/ are being created/updated.
 
 **Note:** SubagentStart and SubagentStop events require Claude Code 2.1.19+. On older versions, subagent tracking won't work, but everything else will.
 
@@ -657,7 +668,6 @@ chmod +x hooks/ticket_branch_detector.py
   "hooks": {
     "SessionStart": [
       {
-        "matcher": ".*",
         "hooks": [
           { "type": "command", "command": "python3 ~/.claude/hooks/ticket_branch_detector.py" }
         ]

--- a/SETUP.md
+++ b/SETUP.md
@@ -27,7 +27,7 @@ Verify you have the required tools:
 
 ```bash
 # Required
-python3 --version    # 3.9+
+python3 --version    # 3.10+ (API requires 3.10; hook scripts alone run on 3.9+)
 node --version       # 18+
 npm --version        # 7+
 git --version        # any version
@@ -1035,7 +1035,7 @@ Run through this after setup to confirm everything works.
 **Symptom:** `uvicorn main:app` fails or hangs
 
 ```bash
-# Check Python version (must be 3.9+)
+# Check Python version (API requires 3.10+)
 python3 --version
 
 # Verify requirements installed

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -176,7 +176,7 @@ pytest -k "test_usage"             # Tests matching pattern
 
 ## Dependencies
 
-- **Python 3.9+**
+- **Python 3.10+**
 - **FastAPI** - Web framework
 - **Pydantic 2.x** - Data validation
 - **aiofiles** - Async file I/O

--- a/api/command_helpers/cli_js.py
+++ b/api/command_helpers/cli_js.py
@@ -5,6 +5,8 @@ Locates Claude Code's cli.js binary, extracts command names/descriptions,
 and resolves full prompt templates for bundled skills.
 """
 
+from __future__ import annotations
+
 import logging
 import re
 import shutil

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2.0"
 description = "Pydantic models for parsing Claude Code local storage"
 readme = "README.md"
 license = {text = "Apache-2.0"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.0",
     "pydantic-settings>=2.0.0",


### PR DESCRIPTION
## Summary

Repositions Tier 2 (live monitoring) as Karma's core feature and default install path across README, CLAUDE.md, and SETUP.md, and fixes several factual claims in the docs: the Python version requirement (the API needs 3.10+, only the hook scripts run on 3.9), the Claude Code hook-event count (24, not 10/13), and the headless verification path for the live tracker.

## Changes

- **README / CLAUDE.md / SETUP.md**: Tier 1 is now described as a read-only historical viewer; Tier 2 is labeled the core feature (⭐) with "install through Tier 2 by default" guidance. All links updated to the new `#tier-2-live-monitoring-core-feature` anchor.
- **Python version claims**: SETUP.md prerequisites now split Python requirements — hooks 3.9+, API 3.10+ (the API uses PEP 604 `X | None` syntax in Pydantic models and crashes on import under 3.9). `api/pyproject.toml` bumped to `requires-python = ">=3.10"`. Stale `3.9+` references swept from the README badge and tech stack, CLAUDE.md, api/CLAUDE.md, and SETUP.md's prereq check and troubleshooting section.
- **Hook counts**: Corrected to 24 hook types (matching `captain-hook/CLAUDE.md`), with Karma's own hooks using 8 of them.
- **SETUP.md Tier 2 verification**: Added a headless/synthetic-event verification path (pipe a fake `SessionStart` event into the tracker) for sandboxed/CI environments, and clarified that a silent exit 0 from the tracker is success.
- **SETUP.md Tier 4**: Dropped the unnecessary `"matcher": ".*"` from the SessionStart hook config example.
- **api/command_helpers/cli_js.py**: Added `from __future__ import annotations`.

## Component

- [x] API (FastAPI backend)
- [ ] Frontend (SvelteKit dashboard)
- [ ] Captain Hook (hook models)
- [ ] Hook Scripts
- [x] Documentation
- [ ] CI / Build

## Type

- [ ] Feature (new functionality)
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests

## Testing

- [ ] API tests pass (`cd api && pytest`)
- [ ] Frontend type-checks (`cd frontend && npm run check`)
- [ ] Frontend lints clean (`cd frontend && npm run lint`)
- [ ] Captain Hook tests pass (`cd captain-hook && pytest tests/test_models.py`)
- [ ] Manually tested in browser
- [x] N/A (docs only) — verified all `SETUP.md#` anchor links resolve to real headings and confirmed the API's 3.10-only syntax claims by grepping for PEP 604 unions in `api/models/` and `api/routers/`

## Screenshots

N/A — no frontend changes.

## Related Issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhR9YFBKh4ZTMrmSPeENFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhR9YFBKh4ZTMrmSPeENFs)_