### PR TITLE
fix(terminal-focus): reliable Terminal.app raise — retry + out-of-process verify, no miniaturize, honest cross-Space reporting

### DIFF
--- a/api/services/terminal_focus.py
+++ b/api/services/terminal_focus.py
@@ -16,6 +16,15 @@ which stores the claude process's tty (and iTerm session id / app bundle id)
 *while the process is alive*. Focus prefers those stored identifiers over a
 click-time pid lookup, so tab matching survives pid death and recycling.
 
+Terminal.app raising is racy: ``set index to 1`` genuinely fails ~40% of the
+time right after other window reordering (the window server needs ~0.3–0.5s
+to settle), and window-order reads *inside the mutating script* return stale
+values in both directions. The raise is therefore retried with settle
+delays and verified from a separate ``osascript`` process. ``activate`` also
+never switches macOS Spaces when the app already has a window on the current
+Space — a cross-Space window can top the z-order while staying invisible, so
+Space visibility is probed via System Events and reported honestly.
+
 Everything is best-effort and honest: if a window genuinely could not be
 raised, the result says ``focused=False`` with a human-readable reason
 instead of raising — or worse, raising the wrong window.
@@ -24,6 +33,7 @@ instead of raising — or worse, raising the wrong window.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -263,12 +273,12 @@ _TAB_SCRIPT_APPS: Dict[str, str] = {
 }
 
 # Per-app AppleScript to select the exact tab owning a tty. `{tty}` is
-# substituted with e.g. /dev/ttys006. Terminal.app ignores `set frontmost`,
-# but `set index to 1` reorders reliably (windows parked on other Spaces
-# silently ignore `set miniaturized`, which is why index comes first and the
-# miniaturize cycle is only a fallback). The outcome is VERIFIED: the script
-# reports "raised" only when the matched window really is frontmost after
-# the attempts; anything else reports "selected" so the API stays honest.
+# substituted with e.g. /dev/ttys006. Terminal.app's script only selects and
+# raises (`set index to 1` + activate) and returns the matched window id —
+# NO in-script verification (order reads are stale within the mutating
+# script) and NO miniaturize fallback (programmatic un-miniaturize restores
+# the window to the BACK of the z-order, burying what was just raised).
+# Verification happens in Python via a separate osascript process.
 _MAC_TAB_SCRIPTS: Dict[str, str] = {
     "Apple_Terminal": (
         'tell application "Terminal"\n'
@@ -288,19 +298,7 @@ _MAC_TAB_SCRIPTS: Dict[str, str] = {
         "        set index of window id matchedId to 1\n"
         "    end try\n"
         "    activate\n"
-        "    if id of front window is not matchedId then\n"
-        "        try\n"
-        "            set miniaturized of window id matchedId to true\n"
-        "            delay 0.4\n"
-        "            set miniaturized of window id matchedId to false\n"
-        "            delay 0.2\n"
-        "        end try\n"
-        "    end if\n"
-        "    if id of front window is matchedId then\n"
-        '        return (matchedId as text) & " raised"\n'
-        "    else\n"
-        '        return (matchedId as text) & " selected"\n'
-        "    end if\n"
+        "    return matchedId as text\n"
         "end tell"
     ),
     "iTerm.app": (
@@ -322,6 +320,34 @@ _MAC_TAB_SCRIPTS: Dict[str, str] = {
         "end tell"
     ),
 }
+
+# Raise verification, run as a SEPARATE osascript process — reads from the
+# script that mutated the order are stale (measured both false negatives and
+# false positives live). Returns "<front id>\n<target window name>".
+_TERMINAL_VERIFY_SCRIPT = (
+    'tell application "Terminal"\n'
+    "    return (id of front window as text) & linefeed & (name of window id {window_id})\n"
+    "end tell"
+)
+
+# System Events only enumerates windows on the CURRENT Space — exactly the
+# probe needed to tell "raised where the user can see it" from "topped the
+# z-order on another desktop". Requires Accessibility permission; failure is
+# treated as unknown and z-order is trusted.
+_SE_WINDOW_NAMES_SCRIPT = (
+    'tell application "System Events" to tell process "Terminal"\n'
+    "    set out to \"\"\n"
+    "    repeat with w in windows\n"
+    "        set out to out & (name of w) & linefeed\n"
+    "    end repeat\n"
+    "    return out\n"
+    "end tell"
+)
+
+# Post-churn, the first raise reliably fails; ~0.45s of settle almost always
+# lands it (measured 9/10, nearly all on the third attempt).
+_RAISE_ATTEMPTS = 3
+_RAISE_SETTLE_SECONDS = 0.15
 
 # Same shape, but matches an iTerm2 session by its unique id (the UUID from
 # ITERM_SESSION_ID). Survives pid death and recycling entirely.
@@ -414,6 +440,82 @@ def _parse_tab_result(
     }
 
 
+def _sanitize_title(title: str) -> str:
+    """Reduce a window title to stable ASCII (spinner glyphs animate between reads)."""
+    return re.sub(r"\s+", " ", re.sub(r"[^ -~]", "", title)).strip()
+
+
+def _window_on_current_space(target_name: str) -> Optional[bool]:
+    """Whether a window with this title is on the user's current Space; None = unknown."""
+    target = _sanitize_title(target_name)
+    if not target:
+        return None
+    try:
+        res = _run(["osascript", "-e", _SE_WINDOW_NAMES_SCRIPT])
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if res.returncode != 0:
+        return None  # likely no Accessibility permission
+    names = [_sanitize_title(line) for line in res.stdout.splitlines()]
+    return target in [n for n in names if n]
+
+
+def _terminal_front_and_name(window_id: str) -> Tuple[Optional[str], str]:
+    """Fresh-process read of Terminal's front window id and the target's title."""
+    try:
+        res = _run(["osascript", "-e", _TERMINAL_VERIFY_SCRIPT.format(window_id=window_id)])
+    except (subprocess.SubprocessError, OSError):
+        return None, ""
+    if res.returncode != 0:
+        return None, ""
+    lines = res.stdout.splitlines()
+    front = lines[0].strip() if lines else None
+    name = lines[1] if len(lines) > 1 else ""
+    return front, name
+
+
+def _focus_terminal_app_tab(tty: str) -> Optional[Dict[str, Any]]:
+    """Raise the Terminal.app window owning ``tty``: retry, verify, report honestly."""
+    script = _MAC_TAB_SCRIPTS["Apple_Terminal"]
+    window_id = ""
+    for _ in range(_RAISE_ATTEMPTS):
+        try:
+            res = _run(["osascript", "-e", script.format(tty=_applescript_str(tty))])
+        except (subprocess.SubprocessError, OSError):
+            return None
+        window_id = res.stdout.strip()
+        if res.returncode != 0 or not window_id:
+            return None  # no tab owns this tty — let the caller fall back
+        time.sleep(_RAISE_SETTLE_SECONDS)
+        front, name = _terminal_front_and_name(window_id)
+        if front != window_id:
+            continue  # settle race — reorder didn't take yet; try again
+        if _window_on_current_space(name) is False:
+            return {
+                "focused": False,
+                "method": "osascript-tab",
+                "detail": (
+                    f"selected the Apple_Terminal tab on {tty} (window id {window_id}), "
+                    "but the window is on another desktop or full screen — macOS won't "
+                    "switch Spaces automatically; find it via Mission Control"
+                ),
+            }
+        return {
+            "focused": True,
+            "method": "osascript-tab",
+            "detail": f"selected Apple_Terminal tab on {tty} (window id {window_id})",
+        }
+    return {
+        "focused": False,
+        "method": "osascript-tab",
+        "detail": (
+            f"selected the Apple_Terminal tab on {tty} (window id {window_id}), "
+            f"but its window could not be raised after {_RAISE_ATTEMPTS} attempts — "
+            "try clicking again"
+        ),
+    }
+
+
 def _focus_macos_tab(term_program: str, tty: str) -> Optional[Dict[str, Any]]:
     """Select the exact window/tab owning ``tty``; None means fall back."""
     script = _MAC_TAB_SCRIPTS.get(term_program)
@@ -422,6 +524,8 @@ def _focus_macos_tab(term_program: str, tty: str) -> Optional[Dict[str, Any]]:
     app = _TAB_SCRIPT_APPS[term_program]
     if not _app_is_running(f'application "{_applescript_str(app)}"'):
         return None
+    if term_program == "Apple_Terminal":
+        return _focus_terminal_app_tab(tty)
     try:
         res = _run(["osascript", "-e", script.format(tty=_applescript_str(tty))])
         return _parse_tab_result(res, term_program, tty)

--- a/api/services/terminal_focus.py
+++ b/api/services/terminal_focus.py
@@ -323,22 +323,33 @@ _MAC_TAB_SCRIPTS: Dict[str, str] = {
 
 # Raise verification, run as a SEPARATE osascript process — reads from the
 # script that mutated the order are stale (measured both false negatives and
-# false positives live). Returns "<front id>\n<target window name>".
+# false positives live). Returns "<front id>\n<x1,y1,x2,y2>\n<target name>";
+# the name goes last so a pathological linefeed in a title can't shift the
+# machine-parsed fields.
 _TERMINAL_VERIFY_SCRIPT = (
     'tell application "Terminal"\n'
-    "    return (id of front window as text) & linefeed & (name of window id {window_id})\n"
+    "    set b to bounds of window id {window_id}\n"
+    "    return (id of front window as text) & linefeed & "
+    '(item 1 of b as text) & "," & (item 2 of b as text) & "," & '
+    '(item 3 of b as text) & "," & (item 4 of b as text) & linefeed & '
+    "(name of window id {window_id})\n"
     "end tell"
 )
 
 # System Events only enumerates windows on the CURRENT Space — exactly the
 # probe needed to tell "raised where the user can see it" from "topped the
-# z-order on another desktop". Requires Accessibility permission; failure is
-# treated as unknown and z-order is trusted.
+# z-order on another desktop". Emits "<x>,<y>,<w>,<h>|<name>" per window:
+# titles are not unique (every idle tab is "-zsh — 80×24"), so visibility
+# requires the geometry to match too. Requires Accessibility permission;
+# failure is treated as unknown and z-order is trusted.
 _SE_WINDOW_NAMES_SCRIPT = (
     'tell application "System Events" to tell process "Terminal"\n'
     '    set out to ""\n'
     "    repeat with w in windows\n"
-    "        set out to out & (name of w) & linefeed\n"
+    "        set p to position of w\n"
+    "        set s to size of w\n"
+    '        set out to out & (item 1 of p as text) & "," & (item 2 of p as text) & "," & '
+    '(item 1 of s as text) & "," & (item 2 of s as text) & "|" & (name of w) & linefeed\n'
     "    end repeat\n"
     "    return out\n"
     "end tell"
@@ -445,33 +456,67 @@ def _sanitize_title(title: str) -> str:
     return re.sub(r"\s+", " ", re.sub(r"[^ -~]", "", title)).strip()
 
 
-def _window_on_current_space(target_name: str) -> Optional[bool]:
-    """Whether a window with this title is on the user's current Space; None = unknown."""
+def _window_on_current_space(
+    target_name: str, target_bounds: Optional[Tuple[int, int, int, int]]
+) -> Optional[bool]:
+    """Whether THIS window (title + exact geometry) is on the current Space; None = unknown.
+
+    Titles alone are ambiguous — two idle tabs share "-zsh — 80×24" — so a
+    match also requires the System Events position/size to equal the bounds
+    Terminal reported for the exact window id (coordinate systems agree:
+    verified live, SE position = x1,y1 and size = x2-x1,y2-y1).
+    """
     target = _sanitize_title(target_name)
-    if not target:
+    if not target or target_bounds is None:
         return None
+    x1, y1, x2, y2 = target_bounds
+    target_geo = (x1, y1, x2 - x1, y2 - y1)
     try:
         res = _run(["osascript", "-e", _SE_WINDOW_NAMES_SCRIPT])
     except (subprocess.SubprocessError, OSError):
         return None
     if res.returncode != 0:
         return None  # likely no Accessibility permission
-    names = [_sanitize_title(line) for line in res.stdout.splitlines()]
-    return target in [n for n in names if n]
+    for line in res.stdout.splitlines():
+        geo_part, sep, name_part = line.partition("|")
+        if not sep or _sanitize_title(name_part) != target:
+            continue
+        try:
+            geo = tuple(int(v) for v in geo_part.split(","))
+        except ValueError:
+            continue
+        if geo == target_geo:
+            return True
+    return False
 
 
-def _terminal_front_and_name(window_id: str) -> Tuple[Optional[str], str]:
-    """Fresh-process read of Terminal's front window id and the target's title."""
+def _parse_bounds(csv: str) -> Optional[Tuple[int, int, int, int]]:
+    """Parse the verify script's "x1,y1,x2,y2" line; None when malformed."""
+    parts = csv.split(",")
+    if len(parts) != 4:
+        return None
+    try:
+        x1, y1, x2, y2 = (int(v) for v in parts)
+    except ValueError:
+        return None
+    return x1, y1, x2, y2
+
+
+def _terminal_verify_state(
+    window_id: str,
+) -> Tuple[Optional[str], Optional[Tuple[int, int, int, int]], str]:
+    """Fresh-process read of Terminal's front id plus the target's bounds and title."""
     try:
         res = _run(["osascript", "-e", _TERMINAL_VERIFY_SCRIPT.format(window_id=window_id)])
     except (subprocess.SubprocessError, OSError):
-        return None, ""
+        return None, None, ""
     if res.returncode != 0:
-        return None, ""
+        return None, None, ""
     lines = res.stdout.splitlines()
     front = lines[0].strip() if lines else None
-    name = lines[1] if len(lines) > 1 else ""
-    return front, name
+    bounds = _parse_bounds(lines[1]) if len(lines) > 1 else None
+    name = "\n".join(lines[2:]) if len(lines) > 2 else ""
+    return front, bounds, name
 
 
 def _focus_terminal_app_tab(tty: str) -> Optional[Dict[str, Any]]:
@@ -487,10 +532,10 @@ def _focus_terminal_app_tab(tty: str) -> Optional[Dict[str, Any]]:
         if res.returncode != 0 or not window_id:
             return None  # no tab owns this tty — let the caller fall back
         time.sleep(_RAISE_SETTLE_SECONDS)
-        front, name = _terminal_front_and_name(window_id)
+        front, bounds, name = _terminal_verify_state(window_id)
         if front != window_id:
             continue  # settle race — reorder didn't take yet; try again
-        if _window_on_current_space(name) is False:
+        if _window_on_current_space(name, bounds) is False:
             return {
                 "focused": False,
                 "method": "osascript-tab",

--- a/api/services/terminal_focus.py
+++ b/api/services/terminal_focus.py
@@ -336,7 +336,7 @@ _TERMINAL_VERIFY_SCRIPT = (
 # treated as unknown and z-order is trusted.
 _SE_WINDOW_NAMES_SCRIPT = (
     'tell application "System Events" to tell process "Terminal"\n'
-    "    set out to \"\"\n"
+    '    set out to ""\n'
     "    repeat with w in windows\n"
     "        set out to out & (name of w) & linefeed\n"
     "    end repeat\n"

--- a/api/tests/test_terminal_focus.py
+++ b/api/tests/test_terminal_focus.py
@@ -720,9 +720,7 @@ def test_terminal_app_raise_retries_after_stale_front(monkeypatch):
 def test_terminal_app_raise_gives_up_honestly_after_retries(monkeypatch):
     _macos_tab_env(monkeypatch)
     calls = []
-    monkeypatch.setattr(
-        terminal_focus, "_run", _fake_run_factory(record=calls, front_ids=["999"])
-    )
+    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(record=calls, front_ids=["999"]))
 
     result = terminal_focus.focus_terminal(_APPLE_TERM)
     assert result["focused"] is False

--- a/api/tests/test_terminal_focus.py
+++ b/api/tests/test_terminal_focus.py
@@ -41,8 +41,16 @@ def _fake_run_factory(
     tab_stdout="13387 raised",
     record=None,
     app_running=True,
+    target_name="claude-karma — claude — 142×43",
+    se_names=None,
+    se_rc=0,
+    front_ids=None,
 ):
-    """_run stub routing ps / is-running probes / tab scripts / activation."""
+    """_run stub routing ps / is-running probes / raise / verify / SE scripts."""
+    window_id = tab_stdout.split()[0] if tab_stdout.split() else ""
+    names = se_names if se_names is not None else (target_name,)
+    fronts = list(front_ids) if front_ids is not None else [window_id]
+    state = {"verify": 0}
 
     def fake_run(cmd):
         if record is not None:
@@ -55,8 +63,16 @@ def _fake_run_factory(
             script = cmd[-1]
             if script.endswith("is running"):
                 return _FakeCompleted(stdout="true\n" if app_running else "false\n")
-            if "tty of" in script or "id of s is" in script:
+            if "System Events" in script:
+                return _FakeCompleted(returncode=se_rc, stdout="\n".join(names) + "\n")
+            if "sessions of t" in script:  # iTerm2 one-shot scripts
                 return _FakeCompleted(stdout=f"{tab_stdout}\n")
+            if "tty of t is" in script:  # Terminal.app raise script
+                return _FakeCompleted(stdout=f"{window_id}\n")
+            if "front window" in script:  # Terminal.app verify script
+                i = min(state["verify"], len(fronts) - 1)
+                state["verify"] += 1
+                return _FakeCompleted(stdout=f"{fronts[i]}\n{target_name}\n")
         return _FakeCompleted(returncode=0)
 
     return fake_run
@@ -190,14 +206,22 @@ def _tmux_run_factory(
     switch_ok=True,
     gui_tab_stdout="42 raised",
 ):
+    gui_window_id = gui_tab_stdout.split()[0] if gui_tab_stdout.split() else ""
+
     def fake_run(cmd):
         record.append(cmd)
         if cmd[0] == "osascript":
             script = cmd[-1]
             if script.endswith("is running"):
                 return _FakeCompleted(stdout="true\n")
-            if "tty of" in script:
+            if "System Events" in script:
+                return _FakeCompleted(stdout="tmux window\n")
+            if "sessions of t" in script:
                 return _FakeCompleted(stdout=f"{gui_tab_stdout}\n")
+            if "tty of t is" in script:
+                return _FakeCompleted(stdout=f"{gui_window_id}\n")
+            if "front window" in script:
+                return _FakeCompleted(stdout=f"{gui_window_id}\ntmux window\n")
             return _FakeCompleted()
         if cmd[0] != "tmux":
             return _FakeCompleted()
@@ -637,38 +661,123 @@ def test_focus_macos_no_pid_keeps_activate_behavior(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_terminal_app_script_raises_index_first_with_verified_fallback():
-    # `set index to 1` is the raise that works (windows on other Spaces
-    # ignore `set miniaturized`); the cycle stays as fallback, and the
-    # script must VERIFY the outcome instead of assuming it.
-    script = terminal_focus._MAC_TAB_SCRIPTS["Apple_Terminal"]
-    assert "set index of window id matchedId to 1" in script
-    assert script.index("set index") < script.index("activate")
-    assert "set miniaturized" in script
-    assert "if id of front window is not matchedId" in script
-    assert '" raised"' in script
-    assert '" selected"' in script
-
-
-def test_focus_macos_fullscreen_selected_not_raised_is_honest(monkeypatch):
-    # Fullscreen windows can't be miniaturized: the tab gets selected but the
-    # window stays buried. The result must say focused=false, and must NOT
-    # fall through to app activation (which would raise a different window).
+def _macos_tab_env(monkeypatch):
     monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
     monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")
     monkeypatch.setattr(terminal_focus, "pid_is_live_claude", lambda pid: True)
+    monkeypatch.setattr(terminal_focus.time, "sleep", lambda s: None)
+
+
+_APPLE_TERM = {"term_program": "Apple_Terminal", "pid": 91314, "tty": "/dev/ttys006"}
+
+
+def test_terminal_app_raise_script_has_no_miniaturize_or_inline_verify():
+    # Terminal.app's window-order reads are stale within the mutating script
+    # (both false negatives and false positives were measured live), and the
+    # miniaturize cycle restores windows to the BACK of the z-order — burying
+    # the window it just raised. The raise script must only select + raise.
+    script = terminal_focus._MAC_TAB_SCRIPTS["Apple_Terminal"]
+    assert "set index of window id matchedId to 1" in script
+    assert script.index("set index") < script.index("activate")
+    assert "miniaturized" not in script
+    assert "front window" not in script
+
+
+def test_terminal_app_verify_runs_in_separate_osascript(monkeypatch):
+    _macos_tab_env(monkeypatch)
+    calls = []
+    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(record=calls))
+
+    result = terminal_focus.focus_terminal(_APPLE_TERM)
+    assert result["focused"] is True
+    assert result["method"] == "osascript-tab"
+    assert "/dev/ttys006" in result["detail"]
+    assert "13387" in result["detail"]
+    scripts = [c[-1] for c in calls if c[0] == "osascript"]
+    raises = [s for s in scripts if "set index" in s]
+    verifies = [s for s in scripts if "front window" in s]
+    assert raises and verifies
+    # Fresh-process verification: no script both mutates order and reads it.
+    assert all("front window" not in s for s in raises)
+    assert all("set index" not in s for s in verifies)
+
+
+def test_terminal_app_raise_retries_after_stale_front(monkeypatch):
+    _macos_tab_env(monkeypatch)
     calls = []
     monkeypatch.setattr(
-        terminal_focus, "_run", _fake_run_factory(tab_stdout="13387 selected", record=calls)
+        terminal_focus,
+        "_run",
+        _fake_run_factory(record=calls, front_ids=["999", "999", "13387"]),
     )
 
-    result = terminal_focus.focus_terminal(
-        {"term_program": "Apple_Terminal", "tty": "/dev/ttys006", "pid": 91314}
+    result = terminal_focus.focus_terminal(_APPLE_TERM)
+    assert result["focused"] is True
+    raises = [c[-1] for c in calls if c[0] == "osascript" and "set index" in c[-1]]
+    assert len(raises) == 3
+
+
+def test_terminal_app_raise_gives_up_honestly_after_retries(monkeypatch):
+    _macos_tab_env(monkeypatch)
+    calls = []
+    monkeypatch.setattr(
+        terminal_focus, "_run", _fake_run_factory(record=calls, front_ids=["999"])
     )
+
+    result = terminal_focus.focus_terminal(_APPLE_TERM)
     assert result["focused"] is False
     assert result["method"] == "osascript-tab"
-    assert "full screen" in result["detail"]
+    assert "could not be raised" in result["detail"]
+    raises = [c[-1] for c in calls if c[0] == "osascript" and "set index" in c[-1]]
+    assert len(raises) == 3
+    # Honest failure — never a blind app activation of some other window.
     assert not any("to activate" in c[-1] for c in calls if c[0] == "osascript")
+
+
+def test_terminal_app_cross_space_window_reported_honestly(monkeypatch):
+    # z-order top but invisible: System Events (current Space only) can't see
+    # the window — activate won't switch Spaces, so the user sees nothing.
+    _macos_tab_env(monkeypatch)
+    calls = []
+    monkeypatch.setattr(
+        terminal_focus,
+        "_run",
+        _fake_run_factory(record=calls, se_names=("some other window — zsh — 80×24",)),
+    )
+
+    result = terminal_focus.focus_terminal(_APPLE_TERM)
+    assert result["focused"] is False
+    assert result["method"] == "osascript-tab"
+    assert "another desktop" in result["detail"]
+    # Retrying can't move a window across Spaces — one attempt only.
+    raises = [c[-1] for c in calls if c[0] == "osascript" and "set index" in c[-1]]
+    assert len(raises) == 1
+
+
+def test_terminal_app_se_unavailable_trusts_zorder(monkeypatch):
+    # No Accessibility permission → Space visibility unknown → trust z-order.
+    _macos_tab_env(monkeypatch)
+    monkeypatch.setattr(terminal_focus, "_run", _fake_run_factory(se_rc=1))
+
+    result = terminal_focus.focus_terminal(_APPLE_TERM)
+    assert result["focused"] is True
+
+
+def test_terminal_app_name_match_ignores_unstable_glyphs(monkeypatch):
+    # Titles embed an animated spinner + unicode dashes; the Space-visibility
+    # name match must survive the glyph ticking between the two reads.
+    _macos_tab_env(monkeypatch)
+    monkeypatch.setattr(
+        terminal_focus,
+        "_run",
+        _fake_run_factory(
+            target_name="claude-karma — ⠐ Debug session — 142×43",
+            se_names=("claude-karma — ⠋ Debug session — 142×43",),
+        ),
+    )
+
+    result = terminal_focus.focus_terminal(_APPLE_TERM)
+    assert result["focused"] is True
 
 
 def test_focus_macos_dead_pid_fails_instead_of_wrong_window(monkeypatch):

--- a/api/tests/test_terminal_focus.py
+++ b/api/tests/test_terminal_focus.py
@@ -825,6 +825,100 @@ def test_terminal_app_name_match_ignores_unstable_glyphs(monkeypatch):
     assert result["focused"] is True
 
 
+def test_terminal_app_sleeps_between_raise_and_verify(monkeypatch):
+    # The settle delay IS the churn fix — without it the first verify reads
+    # mid-reorder state (measured: raises land on attempt 3, ~0.45s in).
+    # Deleting the sleep must not pass silently.
+    _macos_tab_env(monkeypatch)
+    sleeps = []
+    monkeypatch.setattr(terminal_focus.time, "sleep", sleeps.append)
+    monkeypatch.setattr(
+        terminal_focus,
+        "_run",
+        _fake_run_factory(front_ids=["999", "999", "13387"]),
+    )
+
+    result = terminal_focus.focus_terminal(_APPLE_TERM)
+    assert result["focused"] is True
+    # One settle before each of the three verifies, wired to the constant.
+    assert sleeps == [terminal_focus._RAISE_SETTLE_SECONDS] * 3
+
+
+def test_terminal_app_truncated_verify_output_trusts_zorder(monkeypatch):
+    # Verify output missing the bounds/name lines → visibility unknown →
+    # trust the z-order match rather than inventing a cross-Space failure.
+    _macos_tab_env(monkeypatch)
+
+    def fake_run(cmd):
+        script = cmd[-1]
+        if script.endswith("is running"):
+            return _FakeCompleted(stdout="true\n")
+        if "tty of t is" in script:
+            return _FakeCompleted(stdout="13387\n")
+        if "front window" in script:
+            return _FakeCompleted(stdout="13387\n")  # front id only
+        return _FakeCompleted()
+
+    monkeypatch.setattr(terminal_focus, "_run", fake_run)
+    result = terminal_focus.focus_terminal(_APPLE_TERM)
+    assert result["focused"] is True
+    assert result["method"] == "osascript-tab"
+
+
+def test_terminal_app_verify_error_retries_then_fails_honestly(monkeypatch):
+    # The window closing between raise and verify makes the verify script
+    # error (returncode != 0); that must count as "not raised" and retry,
+    # ending in the honest failure — never a claimed success.
+    _macos_tab_env(monkeypatch)
+    calls = []
+
+    def fake_run(cmd):
+        calls.append(cmd)
+        script = cmd[-1]
+        if script.endswith("is running"):
+            return _FakeCompleted(stdout="true\n")
+        if "tty of t is" in script:
+            return _FakeCompleted(stdout="13387\n")
+        if "front window" in script:
+            return _FakeCompleted(returncode=1, stderr="Invalid index. (-1719)")
+        return _FakeCompleted()
+
+    monkeypatch.setattr(terminal_focus, "_run", fake_run)
+    result = terminal_focus.focus_terminal(_APPLE_TERM)
+    assert result["focused"] is False
+    assert "could not be raised" in result["detail"]
+    raises = [c[-1] for c in calls if c[0] == "osascript" and "set index" in c[-1]]
+    assert len(raises) == 3
+
+
+def test_terminal_app_midloop_raise_error_falls_back_to_activate(monkeypatch):
+    # A raise-script SubprocessError mid-retry (Terminal briefly wedged)
+    # abandons the exact-tab path for the guarded app-activation fallback —
+    # it must neither crash nor claim an osascript-tab success.
+    _macos_tab_env(monkeypatch)
+    calls = []
+    state = {"raises": 0}
+
+    def fake_run(cmd):
+        calls.append(cmd)
+        script = cmd[-1]
+        if script.endswith("is running"):
+            return _FakeCompleted(stdout="true\n")
+        if "tty of t is" in script:
+            state["raises"] += 1
+            if state["raises"] == 2:
+                raise subprocess.TimeoutExpired(cmd, 5)
+            return _FakeCompleted(stdout="13387\n")
+        if "front window" in script:
+            return _FakeCompleted(stdout="999\n0,69,1728,1117\nother\n")
+        return _FakeCompleted()
+
+    monkeypatch.setattr(terminal_focus, "_run", fake_run)
+    result = terminal_focus.focus_terminal(_APPLE_TERM)
+    assert result["method"] == "osascript"
+    assert any("to activate" in c[-1] for c in calls if c[0] == "osascript")
+
+
 def test_focus_macos_dead_pid_fails_instead_of_wrong_window(monkeypatch):
     monkeypatch.setattr(terminal_focus.sys, "platform", "darwin")
     monkeypatch.setattr(terminal_focus.shutil, "which", lambda name: "/usr/bin/osascript")

--- a/api/tests/test_terminal_focus.py
+++ b/api/tests/test_terminal_focus.py
@@ -42,13 +42,19 @@ def _fake_run_factory(
     record=None,
     app_running=True,
     target_name="claude-karma — claude — 142×43",
+    target_bounds="0,69,1728,1117",
     se_names=None,
+    se_geometries=None,
     se_rc=0,
     front_ids=None,
 ):
     """_run stub routing ps / is-running probes / raise / verify / SE scripts."""
     window_id = tab_stdout.split()[0] if tab_stdout.split() else ""
     names = se_names if se_names is not None else (target_name,)
+    # SE reports position+size; default to geometry matching target_bounds.
+    x1, y1, x2, y2 = (int(v) for v in target_bounds.split(","))
+    matching_geo = f"{x1},{y1},{x2 - x1},{y2 - y1}"
+    geos = se_geometries if se_geometries is not None else (matching_geo,) * len(names)
     fronts = list(front_ids) if front_ids is not None else [window_id]
     state = {"verify": 0}
 
@@ -64,7 +70,8 @@ def _fake_run_factory(
             if script.endswith("is running"):
                 return _FakeCompleted(stdout="true\n" if app_running else "false\n")
             if "System Events" in script:
-                return _FakeCompleted(returncode=se_rc, stdout="\n".join(names) + "\n")
+                lines = [f"{g}|{n}" for g, n in zip(geos, names)]
+                return _FakeCompleted(returncode=se_rc, stdout="\n".join(lines) + "\n")
             if "sessions of t" in script:  # iTerm2 one-shot scripts
                 return _FakeCompleted(stdout=f"{tab_stdout}\n")
             if "tty of t is" in script:  # Terminal.app raise script
@@ -72,7 +79,7 @@ def _fake_run_factory(
             if "front window" in script:  # Terminal.app verify script
                 i = min(state["verify"], len(fronts) - 1)
                 state["verify"] += 1
-                return _FakeCompleted(stdout=f"{fronts[i]}\n{target_name}\n")
+                return _FakeCompleted(stdout=f"{fronts[i]}\n{target_bounds}\n{target_name}\n")
         return _FakeCompleted(returncode=0)
 
     return fake_run
@@ -759,6 +766,46 @@ def test_terminal_app_se_unavailable_trusts_zorder(monkeypatch):
 
     result = terminal_focus.focus_terminal(_APPLE_TERM)
     assert result["focused"] is True
+
+
+def test_terminal_app_space_probe_requires_matching_geometry(monkeypatch):
+    # Titles are not unique — every uncustomized idle tab is "-zsh — 80×24".
+    # A same-titled window at a DIFFERENT position/size on the current Space
+    # must not fake visibility for a target sitting on another Space
+    # (review finding: title-only matching produced false focused=true).
+    _macos_tab_env(monkeypatch)
+    monkeypatch.setattr(
+        terminal_focus,
+        "_run",
+        _fake_run_factory(
+            target_name="-zsh — 80×24",
+            target_bounds="0,69,1728,1117",
+            se_names=("-zsh — 80×24",),
+            se_geometries=("100,200,800,600",),
+        ),
+    )
+
+    result = terminal_focus.focus_terminal(_APPLE_TERM)
+    assert result["focused"] is False
+    assert "another desktop" in result["detail"]
+
+
+def test_terminal_app_space_probe_ignores_phantom_windows(monkeypatch):
+    # System Events lists phantom AXUnknown windows (empty title, menu-bar
+    # sized) for Terminal; they must never satisfy the visibility probe.
+    _macos_tab_env(monkeypatch)
+    monkeypatch.setattr(
+        terminal_focus,
+        "_run",
+        _fake_run_factory(
+            se_names=("", "some other session — 80×24"),
+            se_geometries=("0,0,1728,33", "100,200,800,600"),
+        ),
+    )
+
+    result = terminal_focus.focus_terminal(_APPLE_TERM)
+    assert result["focused"] is False
+    assert "another desktop" in result["detail"]
 
 
 def test_terminal_app_name_match_ignores_unstable_glyphs(monkeypatch):


### PR DESCRIPTION
## What happened

The "open terminal" button (#86/#87/#89) degraded from working in the morning to intermittent by afternoon (2026-07-21). Live systematic debugging against the running dashboard reproduced the failure through a real browser click and isolated three measured defects in the Apple_Terminal path of `terminal_focus.py` — all in the AppleScript layer, none in the #89 identity/lifecycle logic:

1. **Reorder-churn race** — `set index of window id X to 1` + `activate` genuinely fails ~40% of the time (measured 2/5) when it closely follows other window reordering, e.g. the user clicking the browser right before the button. The window server needs ~0.3–0.5s to settle.
2. **Stale in-script verification** — reading `id of front window` inside the same AppleScript run that mutated the order returned pre-mutation state in both directions during trials: false "not raised" *and* one false "raised" (fresh-process ground truth disagreed).
3. **Harmful miniaturize fallback** — on a verification miss, the miniaturize/un-miniaturize cycle restored the window to the *back* of the z-order. Observed live: the target went from front to index 7 (bottom), so a transient miss both reported failure and buried the user's window, making the next click start from a worse state.

Plus a fourth mechanism explaining the time-of-day pattern: **`activate` never switches macOS Spaces while Terminal has a window on the current Space**, so a raise can top the z-order while staying invisible to the user. As windows spread across Spaces during the day, more sessions silently fell into this mode (5 of 7 Terminal windows were off-Space when debugged).

## What this PR changes

- The Apple_Terminal raise script now *only* selects the tab, sets `index to 1`, and activates, returning the matched window id — no in-script verification, no miniaturize cycle, so a transient miss can no longer bury the target window.
- New `_focus_terminal_app_tab()` drives the raise from Python: up to 3 attempts with 0.15s settle each, verifying via a **separate** `osascript` process (`_TERMINAL_VERIFY_SCRIPT`), so verification reads are never stale-in-transaction.
- New cross-Space probe `_window_on_current_space()`: System Events enumerates only current-Space windows; if the raised window's title isn't there, the API returns `focused=false` with "the window is on another desktop or full screen — find it via Mission Control" instead of a false success. Titles are sanitized to stable ASCII (`_sanitize_title`) so Terminal's animated spinner glyphs and unicode dashes don't break the match between two reads.
- Probe failure (no Accessibility permission for System Events) degrades to trusting z-order — machines without that permission keep exactly the old success behavior, never a new failure.
- Exhausted retries return an honest `focused=false` ("could not be raised after 3 attempts — try clicking again") and never fall through to blind app activation.
- iTerm2, tmux, and Linux paths are unchanged; the tmux GUI-raise path picks up the same hardened Terminal.app mechanics automatically.

## How it was verified

- **TDD**: 7 new behavioral tests (separate-process verify, retry-on-stale-front, honest give-up, cross-Space honesty, permission fallback, glyph-tolerant matching, structural guard that the raise script contains no `miniaturized`/`front window`). The 5 core ones were watched failing against the old code for the right reasons before implementation. Focus suite: **53/53 pass**; ruff clean.
- **Full API suite**: 1771 passed. 6 failures are pre-existing and unrelated — `tests/api/test_background_shells_router.py` leaks real machine state (the endpoint reads the live `~/.claude_karma/metadata.db` instead of the test fixture DB; verified by rerunning one test and seeing real shell rows in the "empty DB" assertion).
- **Live, API layer**: under a churn harness (bury target at z-bottom, immediately POST `/focus-terminal`), the old code failed 2/5 one-shot raises; the fixed endpoint raised **5/5**, each confirmed against window-server ground truth from a fresh osascript process — not the API's own claim.
- **Live, full stack**: **3/3** real Playwright clicks on the dashboard button with the target window deliberately buried first — all returned `focused=true` and ground truth showed the window front at index 1. This is the exact browser-click scenario that failed before the fix.
- Both cross-Space clicks during testing reported truthfully (macOS genuinely switched Spaces in those runs and the window was verifiably visible after).

## Not in this PR (follow-ups)

- **Cross-Space refusal path live repro**: unit-tested but not staged live — the active Space kept legitimately changing under the user during testing, and when the raise lands, `focused=true` is correct. If the "another desktop" tooltip appears in real use, that's this path working as designed.
- **Background-shells test isolation**: the 6 pre-existing `test_background_shells_router.py` failures (real DB leaking into fixtures) need their own fix/ticket — untouched here.
- **Frontend**: no changes needed — `TerminalFocusButton.svelte` already surfaces `detail` as the button tooltip, so the new honest messages reach the user as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVoojXY7ZuQc9LHBg76Ueb

---

## Component

- [x] API (FastAPI backend)

## Type

- [x] Bug fix

## Testing

- [x] API tests pass (`cd api && pytest`) — 53/53 focus suite; full suite 1771 passed, 6 pre-existing unrelated failures (see body)
- [x] Manually tested in browser — 3/3 Playwright churn trials, ground-truth verified

## Related Issues

Relates to #86, #87, #89 (terminal-focus series)
