### PR TITLE
Floating live-sessions dock + Cmd+B session switcher

### DIFF
--- a/frontend/src/lib/components/CommandFooter.svelte
+++ b/frontend/src/lib/components/CommandFooter.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { Command, Sun, Moon, Keyboard } from 'lucide-svelte';
+	import { Command, Sun, Moon, Keyboard, ArrowLeftRight } from 'lucide-svelte';
 	import { commandPalette } from '$lib/stores/commandPalette';
+	import { sessionSwitcherStore } from '$lib/stores/sessionSwitcher';
 	import KeyIndicator from '$lib/components/ui/KeyIndicator.svelte';
 
 	interface Props {
@@ -70,6 +71,18 @@
 			<Command size={14} />
 			<span class="label">Command Menu</span>
 			<KeyIndicator keys={[isMac ? 'cmd' : 'ctrl', 'K']} class="shortcut" />
+		</button>
+
+		<!-- Session Switcher -->
+		<button
+			type="button"
+			class="command-btn"
+			onclick={() => sessionSwitcherStore.open()}
+			title="Switch Sessions"
+		>
+			<ArrowLeftRight size={14} />
+			<span class="label">Switch Sessions</span>
+			<KeyIndicator keys={[isMac ? 'cmd' : 'ctrl', 'B']} class="shortcut" />
 		</button>
 	</div>
 </footer>

--- a/frontend/src/lib/components/KeyboardShortcutsHelp.svelte
+++ b/frontend/src/lib/components/KeyboardShortcutsHelp.svelte
@@ -23,6 +23,10 @@
 			category: 'Quick Actions',
 			items: [
 				{ keys: [isMac ? 'cmd' : 'ctrl', 'K'], description: 'Command Menu' },
+				{
+					keys: [isMac ? 'cmd' : 'ctrl', 'B'],
+					description: 'Hold + tap to cycle live sessions, release to jump'
+				},
 				{ keys: ['K', 'S'], description: 'This Help' }
 			]
 		},

--- a/frontend/src/lib/components/LiveSessionsDock.svelte
+++ b/frontend/src/lib/components/LiveSessionsDock.svelte
@@ -101,6 +101,10 @@
 									<span class="dock-row-name font-mono"
 										>{getDisplayName(session)}</span
 									>
+									<!-- Status as text too — dot color alone fails color-blind and reduced-motion users. -->
+									<span class="status-label" style="color: {config.color}"
+										>{config.label.toUpperCase()}</span
+									>
 									{#if current}
 										<span class="here-badge">you are here</span>
 									{/if}
@@ -149,8 +153,8 @@
 		position: fixed;
 		right: var(--spacing-5);
 		bottom: var(--spacing-5);
-		/* Above the sticky header (50), below the command palette (9998). */
-		z-index: 60;
+		/* Below modal scrims (50) so dialogs dim it; the header (50) never overlaps it. */
+		z-index: 40;
 		display: flex;
 		flex-direction: column;
 		align-items: flex-end;
@@ -367,6 +371,13 @@
 		color: var(--accent);
 	}
 
+	.status-label {
+		flex-shrink: 0;
+		font-size: 11px;
+		font-weight: 600;
+		letter-spacing: 0.5px;
+	}
+
 	/* The most useful marker in the list, so it reads as one. */
 	.here-badge {
 		flex-shrink: 0;
@@ -401,7 +412,8 @@
 	.duration {
 		flex-shrink: 0;
 		font-variant-numeric: tabular-nums;
-		color: var(--text-faint);
+		/* --text-faint fails AA at this size. */
+		color: var(--text-muted);
 	}
 
 	.dock-row-actions {

--- a/frontend/src/lib/components/LiveSessionsDock.svelte
+++ b/frontend/src/lib/components/LiveSessionsDock.svelte
@@ -1,0 +1,444 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { scale } from 'svelte/transition';
+	import { page } from '$app/stores';
+	import { afterNavigate } from '$app/navigation';
+	import { FolderOpen, Radio, X } from 'lucide-svelte';
+	import { liveSessionsFeed } from '$lib/stores/liveSessionsFeed';
+	import { statusConfig } from '$lib/live-session-config';
+	import TerminalFocusButton from '$lib/components/TerminalFocusButton.svelte';
+	import {
+		formatDuration,
+		getProjectDisplayName,
+		getSessionUrl,
+		canNavigate,
+		getDisplayName,
+		matchesRoute
+	} from '$lib/utils/live-session-display';
+
+	// Hidden on routes that already render the full live-sessions table —
+	// the dock would just be a redundant floating copy there.
+	const HIDDEN_ROUTES = new Set(['/', '/sessions']);
+	const hidden = $derived(HIDDEN_ROUTES.has($page.url.pathname));
+
+	const sessions = $derived(
+		$liveSessionsFeed.filter((s) => s.status !== 'ended' && s.transcript_exists !== false)
+	);
+
+	// "active" means Claude is working and needs nothing; "waiting" means it's
+	// blocked on you. Only the second one earns motion — a dot that pulses
+	// whenever a session is merely busy trains you to ignore it.
+	const hasWorking = $derived(sessions.some((s) => s.status === 'active'));
+	const needsInput = $derived(sessions.some((s) => s.status === 'waiting'));
+
+	let expanded = $state(false);
+	let container: HTMLDivElement | undefined = $state();
+
+	// Close after navigation completes — NOT via onclick on the row link.
+	// Collapsing synchronously inside the anchor's own click handler unmounts
+	// the anchor (via {#if expanded}) before the browser processes its native
+	// href navigation, which silently cancels the navigation.
+	afterNavigate(() => {
+		expanded = false;
+	});
+
+	function handleDocumentClick(e: MouseEvent) {
+		if (expanded && container && !container.contains(e.target as Node)) {
+			expanded = false;
+		}
+	}
+
+	onMount(() => {
+		liveSessionsFeed.start();
+		document.addEventListener('click', handleDocumentClick);
+	});
+
+	onDestroy(() => {
+		liveSessionsFeed.stop();
+		if (typeof document !== 'undefined') {
+			document.removeEventListener('click', handleDocumentClick);
+		}
+	});
+</script>
+
+{#if !hidden && sessions.length > 0}
+	<div class="dock" bind:this={container} transition:scale={{ duration: 150, start: 0.9 }}>
+		{#if expanded}
+			<div class="dock-panel" transition:scale={{ duration: 140, start: 0.94, opacity: 0 }}>
+				<div class="dock-panel-header">
+					<span class="dock-panel-title">
+						<Radio size={12} strokeWidth={2} class="text-[var(--success)]" />
+						Live sessions
+					</span>
+					<button
+						class="dock-close"
+						onclick={() => (expanded = false)}
+						aria-label="Collapse"
+					>
+						<X size={14} strokeWidth={2} />
+					</button>
+				</div>
+				<div class="dock-list">
+					{#each sessions as session (session.session_id)}
+						{@const config = statusConfig[session.status]}
+						{@const current = matchesRoute($page.url.pathname, session)}
+						{@const linkable = canNavigate(session) && !current}
+						<!-- bgTint is the app-wide status wash (SessionCard uses the same
+						     token), and it stays on for the current row too — hover and
+						     "you are here" layer on top instead of erasing the status. -->
+						<div
+							class="dock-row"
+							class:current
+							class:clickable={linkable}
+							style="--row-tint: {config.bgTint}"
+						>
+							{#if linkable}
+								<a
+									class="row-link"
+									href={getSessionUrl(session, 'timeline')}
+									aria-label={`Open session ${getDisplayName(session)}`}
+								></a>
+							{/if}
+							<span
+								class="status-dot"
+								class:pulse={config.pulse}
+								style="background: {config.color}"
+								title={config.label}
+							></span>
+							<div class="dock-row-info">
+								<div class="dock-row-primary">
+									<span class="dock-row-name font-mono"
+										>{getDisplayName(session)}</span
+									>
+									{#if current}
+										<span class="here-badge">you are here</span>
+									{/if}
+								</div>
+								<div class="dock-row-secondary">
+									<span class="project" title={session.cwd}>
+										<FolderOpen size={10} strokeWidth={2} />
+										{getProjectDisplayName(session)}
+									</span>
+									<span class="duration"
+										>{formatDuration(session.duration_seconds)}</span
+									>
+								</div>
+							</div>
+							{#if session.can_focus_terminal}
+								<div class="dock-row-actions">
+									<TerminalFocusButton sessionId={session.session_id} />
+								</div>
+							{/if}
+						</div>
+					{/each}
+				</div>
+			</div>
+		{/if}
+
+		<button
+			class="dock-pill"
+			class:attention={needsInput}
+			onclick={() => (expanded = !expanded)}
+			aria-expanded={expanded}
+			aria-label={needsInput ? 'Live sessions — one is waiting on you' : 'Live sessions'}
+		>
+			<span class="dock-icon">
+				<Radio size={13} strokeWidth={2} />
+			</span>
+			<span class="dock-count">{sessions.length}</span>
+			{#if needsInput || hasWorking}
+				<span class="dock-badge" class:pulse={needsInput}></span>
+			{/if}
+		</button>
+	</div>
+{/if}
+
+<style>
+	.dock {
+		position: fixed;
+		right: var(--spacing-5);
+		bottom: var(--spacing-5);
+		/* Above the sticky header (50), below the command palette (9998) — an
+		   always-on floating dock should never be painted under page chrome. */
+		z-index: 60;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: var(--spacing-2);
+		/* Anchored bottom-right, so it should grow from there — scaling from the
+		   centre reads as a diagonal drift. */
+		transform-origin: bottom right;
+	}
+
+	.dock-pill {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		gap: var(--spacing-2);
+		padding: var(--spacing-2) var(--spacing-3) var(--spacing-2) var(--spacing-2);
+		border: 1px solid var(--border);
+		border-radius: 999px;
+		background: var(--bg-base);
+		color: var(--text-secondary);
+		box-shadow: var(--shadow-lg);
+		cursor: pointer;
+		transition:
+			background var(--duration-fast),
+			border-color var(--duration-fast),
+			color var(--duration-fast),
+			transform var(--duration-fast);
+	}
+
+	.dock-pill:hover {
+		background: var(--bg-subtle);
+		color: var(--text-primary);
+		border-color: var(--accent);
+		transform: translateY(-1px);
+	}
+
+	.dock-pill:active {
+		transform: translateY(0);
+	}
+
+	.dock-pill.attention {
+		border-color: color-mix(in srgb, var(--info) 60%, var(--border));
+	}
+
+	.dock-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		border-radius: 50%;
+		background: var(--nav-teal-subtle);
+		color: var(--nav-teal);
+	}
+
+	.dock-count {
+		font-size: 12px;
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.dock-badge {
+		position: absolute;
+		top: -1px;
+		right: -1px;
+		width: 9px;
+		height: 9px;
+		border-radius: 50%;
+		background: var(--success);
+		border: 2px solid var(--bg-base);
+	}
+
+	.dock-badge.pulse {
+		background: var(--info);
+		animation: dock-pulse 2s ease infinite;
+	}
+
+	@keyframes dock-pulse {
+		0%,
+		100% {
+			opacity: 1;
+			transform: scale(1);
+		}
+		50% {
+			opacity: 0.5;
+			transform: scale(1.2);
+		}
+	}
+
+	.dock-panel {
+		width: 320px;
+		max-height: 60vh;
+		display: flex;
+		flex-direction: column;
+		background: var(--bg-base);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		box-shadow: var(--shadow-elevated);
+		overflow: hidden;
+		transform-origin: bottom right;
+	}
+
+	.dock-panel-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--spacing-2) var(--spacing-3);
+		border-bottom: 1px solid var(--border-subtle);
+		background: var(--bg-muted);
+	}
+
+	.dock-panel-title {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		font-size: 11px;
+		font-weight: 600;
+		letter-spacing: 0.5px;
+		color: var(--text-secondary);
+		text-transform: uppercase;
+	}
+
+	.dock-close {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border: none;
+		background: transparent;
+		color: var(--text-muted);
+		cursor: pointer;
+		padding: 2px;
+		border-radius: var(--radius-sm);
+	}
+
+	.dock-close:hover {
+		color: var(--text-primary);
+		background: var(--bg-subtle);
+	}
+
+	.dock-list {
+		overflow-y: auto;
+	}
+
+	.dock-row {
+		position: relative;
+		display: flex;
+		align-items: flex-start;
+		gap: var(--spacing-2);
+		padding: var(--spacing-2) var(--spacing-3);
+		border-bottom: 1px solid var(--border-subtle);
+		background-color: var(--row-tint, transparent);
+		transition: background-color var(--duration-fast);
+	}
+
+	.dock-row:last-child {
+		border-bottom: none;
+	}
+
+	/* Hover is a layer over the status wash, not a replacement for it — a row
+	   shouldn't lose its meaning the moment you point at it. */
+	.dock-row.clickable:hover {
+		background-image: linear-gradient(var(--accent-muted), var(--accent-muted));
+	}
+
+	.dock-row.current {
+		box-shadow: inset 2px 0 0 var(--accent);
+	}
+
+	.row-link {
+		position: absolute;
+		inset: 0;
+	}
+
+	.row-link:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: -2px;
+	}
+
+	.status-dot {
+		width: 7px;
+		height: 7px;
+		border-radius: 50%;
+		flex-shrink: 0;
+		margin-top: 5px;
+	}
+
+	.status-dot.pulse {
+		animation: dock-pulse 2s ease infinite;
+	}
+
+	.dock-row-info {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+	}
+
+	.dock-row-primary {
+		display: flex;
+		align-items: center;
+		min-width: 0;
+		gap: 6px;
+	}
+
+	/* Accent is the app's "this is a link" colour; spending it on every row name
+	   flattens the list. Names are body text; accent marks where you are. */
+	.dock-row-name {
+		font-size: 12px;
+		color: var(--text-primary);
+		font-weight: 500;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.dock-row.current .dock-row-name {
+		color: var(--accent);
+	}
+
+	/* The most useful marker in the list, so it reads as a marker — it was the
+	   faintest colour in the system before. */
+	.here-badge {
+		flex-shrink: 0;
+		padding: 1px 5px;
+		border-radius: var(--radius-sm);
+		font-size: 9px;
+		font-weight: 600;
+		letter-spacing: 0.3px;
+		text-transform: uppercase;
+		background: var(--accent-subtle);
+		color: var(--accent);
+	}
+
+	.dock-row-secondary {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		font-size: 11px;
+		color: var(--text-muted);
+	}
+
+	.project {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.duration {
+		flex-shrink: 0;
+		font-variant-numeric: tabular-nums;
+		color: var(--text-faint);
+	}
+
+	.dock-row-actions {
+		position: relative;
+		z-index: 1;
+		display: flex;
+		align-items: center;
+		gap: var(--spacing-1);
+		flex-shrink: 0;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.dock-badge.pulse,
+		.status-dot.pulse {
+			animation: none;
+		}
+
+		.dock-pill {
+			transition: none;
+		}
+
+		.dock-pill:hover {
+			transform: none;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/LiveSessionsDock.svelte
+++ b/frontend/src/lib/components/LiveSessionsDock.svelte
@@ -13,31 +13,24 @@
 		getSessionUrl,
 		canNavigate,
 		getDisplayName,
-		matchesRoute
+		matchesRoute,
+		visibleLiveSessions
 	} from '$lib/utils/live-session-display';
 
-	// Hidden on routes that already render the full live-sessions table —
-	// the dock would just be a redundant floating copy there.
+	// Hidden where the full live-sessions table already renders — the dock would be a copy.
 	const HIDDEN_ROUTES = new Set(['/', '/sessions']);
 	const hidden = $derived(HIDDEN_ROUTES.has($page.url.pathname));
 
-	const sessions = $derived(
-		$liveSessionsFeed.filter((s) => s.status !== 'ended' && s.transcript_exists !== false)
-	);
+	const sessions = $derived(visibleLiveSessions($liveSessionsFeed));
 
-	// "active" means Claude is working and needs nothing; "waiting" means it's
-	// blocked on you. Only the second one earns motion — a dot that pulses
-	// whenever a session is merely busy trains you to ignore it.
+	// Only "waiting" (blocked on you) earns motion — pulsing for merely-busy trains you to ignore it.
 	const hasWorking = $derived(sessions.some((s) => s.status === 'active'));
 	const needsInput = $derived(sessions.some((s) => s.status === 'waiting'));
 
 	let expanded = $state(false);
 	let container: HTMLDivElement | undefined = $state();
 
-	// Close after navigation completes — NOT via onclick on the row link.
-	// Collapsing synchronously inside the anchor's own click handler unmounts
-	// the anchor (via {#if expanded}) before the browser processes its native
-	// href navigation, which silently cancels the navigation.
+	// Collapse after navigation, not on row click — unmounting the anchor mid-click cancels it.
 	afterNavigate(() => {
 		expanded = false;
 	});
@@ -83,9 +76,7 @@
 						{@const config = statusConfig[session.status]}
 						{@const current = matchesRoute($page.url.pathname, session)}
 						{@const linkable = canNavigate(session) && !current}
-						<!-- bgTint is the app-wide status wash (SessionCard uses the same
-						     token), and it stays on for the current row too — hover and
-						     "you are here" layer on top instead of erasing the status. -->
+						<!-- bgTint stays on every row — hover and "you are here" layer over it. -->
 						<div
 							class="dock-row"
 							class:current
@@ -158,15 +149,13 @@
 		position: fixed;
 		right: var(--spacing-5);
 		bottom: var(--spacing-5);
-		/* Above the sticky header (50), below the command palette (9998) — an
-		   always-on floating dock should never be painted under page chrome. */
+		/* Above the sticky header (50), below the command palette (9998). */
 		z-index: 60;
 		display: flex;
 		flex-direction: column;
 		align-items: flex-end;
 		gap: var(--spacing-2);
-		/* Anchored bottom-right, so it should grow from there — scaling from the
-		   centre reads as a diagonal drift. */
+		/* Grows from its bottom-right anchor — centre scaling reads as diagonal drift. */
 		transform-origin: bottom right;
 	}
 
@@ -250,8 +239,6 @@
 	}
 
 	.dock-panel {
-		/* +25% over the original 320px / 60vh, per Ayush's request for more
-		   legible row text (project names were reading too small). */
 		width: 400px;
 		max-height: 75vh;
 		display: flex;
@@ -320,8 +307,7 @@
 		border-bottom: none;
 	}
 
-	/* Hover is a layer over the status wash, not a replacement for it — a row
-	   shouldn't lose its meaning the moment you point at it. */
+	/* Hover layers over the status wash — a row keeps its meaning under the pointer. */
 	.dock-row.clickable:hover {
 		background-image: linear-gradient(var(--accent-muted), var(--accent-muted));
 	}
@@ -367,8 +353,7 @@
 		gap: 7px;
 	}
 
-	/* Accent is the app's "this is a link" colour; spending it on every row name
-	   flattens the list. Names are body text; accent marks where you are. */
+	/* Names are body text; accent is reserved for marking where you are. */
 	.dock-row-name {
 		font-size: 15px;
 		color: var(--text-primary);
@@ -382,8 +367,7 @@
 		color: var(--accent);
 	}
 
-	/* The most useful marker in the list, so it reads as a marker — it was the
-	   faintest colour in the system before. */
+	/* The most useful marker in the list, so it reads as one. */
 	.here-badge {
 		flex-shrink: 0;
 		padding: 1px 6px;

--- a/frontend/src/lib/components/LiveSessionsDock.svelte
+++ b/frontend/src/lib/components/LiveSessionsDock.svelte
@@ -67,7 +67,7 @@
 			<div class="dock-panel" transition:scale={{ duration: 140, start: 0.94, opacity: 0 }}>
 				<div class="dock-panel-header">
 					<span class="dock-panel-title">
-						<Radio size={12} strokeWidth={2} class="text-[var(--success)]" />
+						<Radio size={15} strokeWidth={2} class="text-[var(--success)]" />
 						Live sessions
 					</span>
 					<button
@@ -75,7 +75,7 @@
 						onclick={() => (expanded = false)}
 						aria-label="Collapse"
 					>
-						<X size={14} strokeWidth={2} />
+						<X size={17} strokeWidth={2} />
 					</button>
 				</div>
 				<div class="dock-list">
@@ -116,7 +116,7 @@
 								</div>
 								<div class="dock-row-secondary">
 									<span class="project" title={session.cwd}>
-										<FolderOpen size={10} strokeWidth={2} />
+										<FolderOpen size={13} strokeWidth={2} />
 										{getProjectDisplayName(session)}
 									</span>
 									<span class="duration"
@@ -250,8 +250,10 @@
 	}
 
 	.dock-panel {
-		width: 320px;
-		max-height: 60vh;
+		/* +25% over the original 320px / 60vh, per Ayush's request for more
+		   legible row text (project names were reading too small). */
+		width: 400px;
+		max-height: 75vh;
 		display: flex;
 		flex-direction: column;
 		background: var(--bg-base);
@@ -266,7 +268,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
-		padding: var(--spacing-2) var(--spacing-3);
+		padding: 10px 15px;
 		border-bottom: 1px solid var(--border-subtle);
 		background: var(--bg-muted);
 	}
@@ -274,8 +276,8 @@
 	.dock-panel-title {
 		display: inline-flex;
 		align-items: center;
-		gap: 6px;
-		font-size: 11px;
+		gap: 7px;
+		font-size: 14px;
 		font-weight: 600;
 		letter-spacing: 0.5px;
 		color: var(--text-secondary);
@@ -307,8 +309,8 @@
 		position: relative;
 		display: flex;
 		align-items: flex-start;
-		gap: var(--spacing-2);
-		padding: var(--spacing-2) var(--spacing-3);
+		gap: 10px;
+		padding: 10px 15px;
 		border-bottom: 1px solid var(--border-subtle);
 		background-color: var(--row-tint, transparent);
 		transition: background-color var(--duration-fast);
@@ -339,11 +341,11 @@
 	}
 
 	.status-dot {
-		width: 7px;
-		height: 7px;
+		width: 9px;
+		height: 9px;
 		border-radius: 50%;
 		flex-shrink: 0;
-		margin-top: 5px;
+		margin-top: 6px;
 	}
 
 	.status-dot.pulse {
@@ -355,20 +357,20 @@
 		min-width: 0;
 		display: flex;
 		flex-direction: column;
-		gap: 3px;
+		gap: 4px;
 	}
 
 	.dock-row-primary {
 		display: flex;
 		align-items: center;
 		min-width: 0;
-		gap: 6px;
+		gap: 7px;
 	}
 
 	/* Accent is the app's "this is a link" colour; spending it on every row name
 	   flattens the list. Names are body text; accent marks where you are. */
 	.dock-row-name {
-		font-size: 12px;
+		font-size: 15px;
 		color: var(--text-primary);
 		font-weight: 500;
 		overflow: hidden;
@@ -384,9 +386,9 @@
 	   faintest colour in the system before. */
 	.here-badge {
 		flex-shrink: 0;
-		padding: 1px 5px;
+		padding: 1px 6px;
 		border-radius: var(--radius-sm);
-		font-size: 9px;
+		font-size: 11px;
 		font-weight: 600;
 		letter-spacing: 0.3px;
 		text-transform: uppercase;
@@ -398,15 +400,15 @@
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
-		gap: 8px;
-		font-size: 11px;
+		gap: 10px;
+		font-size: 14px;
 		color: var(--text-muted);
 	}
 
 	.project {
 		display: flex;
 		align-items: center;
-		gap: 4px;
+		gap: 5px;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -423,7 +425,7 @@
 		z-index: 1;
 		display: flex;
 		align-items: center;
-		gap: var(--spacing-1);
+		gap: 5px;
 		flex-shrink: 0;
 	}
 

--- a/frontend/src/lib/components/LiveSessionsSection.svelte
+++ b/frontend/src/lib/components/LiveSessionsSection.svelte
@@ -10,14 +10,18 @@
 	import { statusConfig } from '$lib/live-session-config';
 	import TerminalFocusButton from '$lib/components/TerminalFocusButton.svelte';
 	import { API_BASE } from '$lib/config';
+	import { liveSessionsFeed } from '$lib/stores/liveSessionsFeed';
 	import {
 		formatDuration,
 		formatIdleTime,
 		getProjectDisplayName,
 		getSessionUrl,
 		canNavigate,
-		getDisplayName
+		getDisplayName,
+		visibleLiveSessions
 	} from '$lib/utils/live-session-display';
+
+	const feedStatus = liveSessionsFeed.status;
 
 	interface Props {
 		/** Initial collapsed state */
@@ -80,9 +84,9 @@
 		return byId ?? null;
 	}
 
-	let sessions = $state<LiveSessionSummary[]>([]);
-	let loading = $state(true);
-	let error = $state<string | null>(null);
+	const sessions = $derived($liveSessionsFeed);
+	const loading = $derived($feedStatus.loading);
+	const error = $derived($feedStatus.error);
 	// svelte-ignore state_referenced_locally
 	let collapsed = $state(initialCollapsed);
 	let collapsedInitialized = $state(false);
@@ -114,7 +118,7 @@
 		try {
 			const res = await fetch(`${API_BASE}/live-sessions/cleanup-old`, { method: 'POST' });
 			if (res.ok) {
-				await fetchSessions();
+				await liveSessionsFeed.refresh();
 				stuckSessionCount = 0;
 			}
 		} catch (e) {
@@ -123,11 +127,6 @@
 			isCleaningUp = false;
 		}
 	}
-
-	let pollInterval: ReturnType<typeof setInterval> | null = null;
-	let isFetching = $state(false);
-	let abortController: AbortController | null = null;
-	let lastFetchTime = 0;
 
 	// Initialize collapsed state from localStorage
 	$effect(() => {
@@ -162,11 +161,7 @@
 		stopped: sessions.filter((s) => s.status === 'stopped' || s.status === 'stale').length
 	});
 
-	// Filter to only show non-ended sessions, and exclude ghost sessions
-	// (ended sessions whose transcript never materialized)
-	const activeSessions = $derived(
-		sessions.filter((s) => s.status !== 'ended' && s.transcript_exists !== false)
-	);
+	const activeSessions = $derived(visibleLiveSessions(sessions));
 
 	// Apply all filters to activeSessions
 	const filteredSessions = $derived.by(() => {
@@ -228,60 +223,14 @@
 		return `${total}`;
 	});
 
-	async function fetchSessions() {
-		if (isFetching) return; // Guard against concurrent fetches
-		isFetching = true;
-
-		const fetchTime = Date.now();
-
-		// Abort any previous request
-		if (abortController) abortController.abort();
-		abortController = new AbortController();
-
-		try {
-			const res = await fetch(`${API_BASE}/live-sessions/active`, {
-				signal: abortController.signal
-			});
-
-			// Only update if this is the most recent request
-			if (fetchTime < lastFetchTime) return;
-			lastFetchTime = fetchTime;
-
-			if (res.ok) {
-				sessions = await res.json();
-				error = null;
-			} else if (res.status === 404) {
-				error = 'API not available';
-			} else {
-				error = 'Failed to fetch';
-			}
-		} catch (e) {
-			if (e instanceof Error && e.name === 'AbortError') return;
-			error = 'Cannot connect to API';
-			console.error('Failed to fetch live sessions:', e);
-		} finally {
-			isFetching = false;
-			loading = false;
-		}
-	}
-
-	// Polling configuration - 3 seconds is a good balance between responsiveness and efficiency
-	const POLL_INTERVAL = 3000;
-
 	onMount(() => {
-		fetchSessions();
+		// Sessions come from the shared liveSessionsFeed poll — no private fetch loop.
+		liveSessionsFeed.start();
 		checkStuckSessions();
-		// Poll every 3 seconds for live session status
-		pollInterval = setInterval(fetchSessions, POLL_INTERVAL);
 	});
 
 	onDestroy(() => {
-		if (pollInterval) {
-			clearInterval(pollInterval);
-		}
-		if (abortController) {
-			abortController.abort();
-		}
+		liveSessionsFeed.stop();
 	});
 </script>
 
@@ -344,7 +293,7 @@
 						>
 					</button>
 				{/if}
-				<span class="pulse-indicator" title="Polling every 1s"></span>
+				<span class="pulse-indicator" title="Live — updates every 2s"></span>
 			</div>
 		</div>
 

--- a/frontend/src/lib/components/LiveSessionsSection.svelte
+++ b/frontend/src/lib/components/LiveSessionsSection.svelte
@@ -7,10 +7,17 @@
 		LiveSubStatus,
 		SessionSummary
 	} from '$lib/api-types';
-	import { projectHrefFromSession } from '$lib/utils/project-url';
 	import { statusConfig } from '$lib/live-session-config';
 	import TerminalFocusButton from '$lib/components/TerminalFocusButton.svelte';
 	import { API_BASE } from '$lib/config';
+	import {
+		formatDuration,
+		formatIdleTime,
+		getProjectDisplayName,
+		getSessionUrl,
+		canNavigate,
+		getDisplayName
+	} from '$lib/utils/live-session-display';
 
 	interface Props {
 		/** Initial collapsed state */
@@ -256,60 +263,6 @@
 			isFetching = false;
 			loading = false;
 		}
-	}
-
-	function formatDuration(seconds: number): string {
-		const mins = Math.floor(seconds / 60);
-		const hrs = Math.floor(mins / 60);
-		if (hrs > 0) return `${hrs}h ${mins % 60}m`;
-		if (mins > 0) return `${mins}m`;
-		return `${Math.floor(seconds)}s`;
-	}
-
-	function formatIdleTime(seconds: number): string {
-		if (seconds < 60) return `${Math.floor(seconds)}s`;
-		const mins = Math.floor(seconds / 60);
-		return `${mins}m`;
-	}
-
-	function getProjectDisplayName(session: LiveSessionSummary): string {
-		const parts = session.cwd.split('/').filter(Boolean);
-		const skipDirs = ['Users', 'home', 'Documents', 'GitHub', 'Projects', 'repos', 'src'];
-
-		for (let i = parts.length - 1; i >= 0; i--) {
-			const part = parts[i];
-			if (!skipDirs.includes(part) && part.length > 2) {
-				if (
-					i > 0 &&
-					(part === 'frontend' ||
-						part === 'backend' ||
-						part === 'api' ||
-						part === 'src' ||
-						part === 'app')
-				) {
-					return parts[i - 1] || part;
-				}
-				return part;
-			}
-		}
-
-		return parts[parts.length - 1] || 'Unknown';
-	}
-
-	function getSessionUrl(session: LiveSessionSummary): string {
-		if (!session.project_encoded_name) {
-			return '#';
-		}
-		const identifier = session.slug || session.session_id.slice(0, 8);
-		return projectHrefFromSession(session, `/${identifier}`);
-	}
-
-	function canNavigate(session: LiveSessionSummary): boolean {
-		return !!session.project_encoded_name;
-	}
-
-	function getDisplayName(session: LiveSessionSummary): string {
-		return session.slug || session.session_id.slice(0, 8);
 	}
 
 	// Polling configuration - 3 seconds is a good balance between responsiveness and efficiency

--- a/frontend/src/lib/components/SessionSwitcher.svelte
+++ b/frontend/src/lib/components/SessionSwitcher.svelte
@@ -1,0 +1,600 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { FolderOpen, Clock, Bot, Pause } from 'lucide-svelte';
+	import { commandPalette } from '$lib/stores/commandPalette';
+	import { liveSessionsFeed } from '$lib/stores/liveSessionsFeed';
+	import { statusConfig } from '$lib/live-session-config';
+	import type { LiveSessionSummary } from '$lib/api-types';
+	import {
+		formatDuration,
+		formatIdleTime,
+		getProjectDisplayName,
+		getSessionUrl,
+		canNavigate,
+		getDisplayName,
+		matchesRoute
+	} from '$lib/utils/live-session-display';
+
+	// Cmd+B — both keys sit under the left hand, unlike Cmd+K.
+	// (Cmd+E was tried first but Chrome on Mac reserves it at the browser-chrome
+	// level — "search with selected text" — so the keydown never reaches page JS.
+	// Cmd+B has no default Chrome/macOS binding.)
+	const SWITCH_KEY = 'b';
+
+	const sessions = $derived(
+		$liveSessionsFeed.filter((s) => s.status !== 'ended' && s.transcript_exists !== false)
+	);
+
+	let isOpen = $state(false);
+	let index = $state(0);
+
+	// --- display-only derivations (no bearing on open/commit behaviour) ---
+
+	// Tiles shrink as the roster grows so 2 and ~12 sessions both sit on one row.
+	const density = $derived(
+		sessions.length <= 6
+			? { tile: 76, gap: 12 }
+			: sessions.length <= 10
+				? { tile: 62, gap: 9 }
+				: { tile: 50, gap: 6 }
+	);
+
+	const selected = $derived(sessions[index]);
+
+	/** Two-letter project mark — the "app icon" identity of a tile. */
+	function monogram(session: LiveSessionSummary): string {
+		const name = getProjectDisplayName(session).replace(/[^a-zA-Z0-9]/g, '');
+		return name.slice(0, 2).toUpperCase() || '··';
+	}
+
+	function openAt(startIndex: number) {
+		isOpen = true;
+		index = startIndex;
+	}
+
+	function advance() {
+		if (sessions.length === 0) return;
+		index = (index + 1) % sessions.length;
+	}
+
+	function commit() {
+		const session = sessions[index];
+		isOpen = false;
+		if (!session) return;
+		// Route-only: focus-terminal raises the native Terminal window on top of
+		// Chrome, which would steal focus the instant you land here and hide the
+		// very page you just switched to. Terminal jump stays a deliberate,
+		// separate action on the dock's own button.
+		if (canNavigate(session)) goto(getSessionUrl(session, 'timeline'));
+	}
+
+	function cancel() {
+		isOpen = false;
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key.toLowerCase() === SWITCH_KEY && e.metaKey && !e.ctrlKey && !e.altKey) {
+			if (commandPalette.getIsOpen()) return;
+			if (sessions.length === 0) return;
+			e.preventDefault();
+
+			if (!isOpen) {
+				// First press: skip past whatever session we're already on, same
+				// as Cmd+Tab landing on the "other" window first.
+				const currentIdx = sessions.findIndex((s) => matchesRoute($page.url.pathname, s));
+				openAt(currentIdx >= 0 ? (currentIdx + 1) % sessions.length : 0);
+			} else {
+				advance();
+			}
+			return;
+		}
+
+		if (isOpen && e.key === 'Escape') {
+			e.preventDefault();
+			cancel();
+		}
+	}
+
+	function handleKeyup(e: KeyboardEvent) {
+		if (isOpen && e.key === 'Meta') {
+			commit();
+		}
+	}
+
+	function handleBlur() {
+		if (isOpen) cancel();
+	}
+
+	function handleVisibilityChange() {
+		if (isOpen && document.hidden) cancel();
+	}
+
+	onMount(() => {
+		liveSessionsFeed.start();
+		window.addEventListener('keydown', handleKeydown);
+		window.addEventListener('keyup', handleKeyup);
+		window.addEventListener('blur', handleBlur);
+		document.addEventListener('visibilitychange', handleVisibilityChange);
+	});
+
+	onDestroy(() => {
+		liveSessionsFeed.stop();
+		// onDestroy also fires during SSR teardown, where onMount never ran and
+		// window/document don't exist — guard so that doesn't throw.
+		if (typeof window === 'undefined') return;
+		window.removeEventListener('keydown', handleKeydown);
+		window.removeEventListener('keyup', handleKeyup);
+		window.removeEventListener('blur', handleBlur);
+		document.removeEventListener('visibilitychange', handleVisibilityChange);
+	});
+</script>
+
+{#if isOpen}
+	<div
+		class="switcher-overlay"
+		role="dialog"
+		aria-modal="true"
+		aria-label="Live session switcher"
+	>
+		<div
+			class="switcher-frame"
+			style="--n: {sessions.length}; --tile: {density.tile}px; --gap: {density.gap}px; --i: {index}"
+		>
+			<div class="strip-scroll">
+				<div class="switcher-strip">
+					<div class="strip-plate"></div>
+					{#each sessions as session, i (session.session_id)}
+						{@const config = statusConfig[session.status]}
+						<div
+							class="switcher-tile"
+							class:selected={i === index}
+							class:here={matchesRoute($page.url.pathname, session)}
+							style="--tone: {config.color}"
+						>
+							<div class="tile-art">
+								<div class="tile-icon">
+									<span class="tile-mark font-mono">{monogram(session)}</span>
+								</div>
+								<span class="tile-status" class:pulse={config.pulse}></span>
+								{#if session.active_subagent_count > 0}
+									<span class="tile-agents font-mono"
+										>{session.active_subagent_count}</span
+									>
+								{/if}
+							</div>
+							<!-- Session name, not just the project monogram: two sessions in the
+							     same repo would otherwise render as identical tiles. -->
+							<span class="tile-label font-mono">{getDisplayName(session)}</span>
+						</div>
+					{/each}
+				</div>
+			</div>
+
+			<div class="switcher-detail">
+				{#if selected}
+					{@const config = statusConfig[selected.status]}
+					<div class="detail-name font-mono" aria-live="polite">
+						{getDisplayName(selected)}
+					</div>
+					<!-- Single line, never wrapping: a second line would grow the frame
+					     mid-cycle and shift the tiles under the user's fingers. Order is
+					     priority order — the last items are the ones allowed to clip. -->
+					<div class="detail-meta">
+						<span class="meta-status" style="--tone: {config.color}">
+							<span class="meta-dot"></span>{config.label}
+						</span>
+						<span class="meta-item shrink"
+							><FolderOpen size={11} strokeWidth={2} />
+							<span class="meta-text">{getProjectDisplayName(selected)}</span></span
+						>
+						{#if selected.active_subagent_count > 0}
+							<span class="meta-item accent"
+								><Bot size={11} strokeWidth={2} />
+								{selected.active_subagent_count}</span
+							>
+						{/if}
+						<span class="meta-item"
+							><Clock size={11} strokeWidth={2} />
+							{formatDuration(selected.duration_seconds)}</span
+						>
+						{#if selected.idle_seconds >= 60}
+							<span class="meta-item"
+								><Pause size={11} strokeWidth={2} />
+								{formatIdleTime(selected.idle_seconds)} idle</span
+							>
+						{/if}
+					</div>
+				{/if}
+			</div>
+
+			<div class="switcher-hint">
+				<span>hold <kbd>⌘</kbd> — tap <kbd>B</kbd> to cycle, release to jump</span>
+				<span class="hint-sep"></span>
+				<span><kbd>esc</kbd> cancel</span>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.switcher-overlay {
+		position: fixed;
+		inset: 0;
+		/* Just under the command palette's 9998 — the palette wins if both open. */
+		z-index: 9997;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		/* Same black as the command palette's scrim, lighter: this HUD is a
+		   transient hold-to-cycle overlay, not a place you stop and work.
+		   No backdrop-filter — a full-viewport blur is the one thing that could
+		   make a keypress-triggered HUD arrive late, and it buys nothing under
+		   a 42% wash. The frame keeps its own glass. */
+		background: rgba(0, 0, 0, 0.42);
+		animation: overlayIn 80ms linear;
+	}
+
+	/* --- HUD frame ------------------------------------------------------ */
+
+	.switcher-frame {
+		/* Sized from the tile roster so the panel never jitters as the
+		   selected session's name changes length underneath it. */
+		width: min(
+			92vw,
+			max(
+				380px,
+				calc(var(--n) * var(--tile) + (var(--n) - 1) * var(--gap) + var(--spacing-4) * 2)
+			)
+		);
+		padding: var(--spacing-4) var(--spacing-4) 0;
+		background: color-mix(in srgb, var(--bg-base) 82%, transparent);
+		border: 1px solid var(--border);
+		border-radius: calc(var(--radius-lg) * 2);
+		backdrop-filter: blur(24px) saturate(180%);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.07),
+			0 2px 6px rgba(0, 0, 0, 0.18),
+			0 32px 64px -16px rgba(0, 0, 0, 0.55);
+		animation: hudIn 140ms cubic-bezier(0.2, 0.9, 0.3, 1);
+	}
+
+	.strip-scroll {
+		overflow-x: auto;
+		scrollbar-width: none;
+	}
+
+	.strip-scroll::-webkit-scrollbar {
+		display: none;
+	}
+
+	.switcher-strip {
+		position: relative;
+		display: flex;
+		gap: var(--gap);
+		width: max-content;
+		margin-inline: auto;
+	}
+
+	/* Single highlight that slides between cells — reads as one continuous
+	   selection rather than N independently-animating tiles. */
+	.strip-plate {
+		position: absolute;
+		/* Stretched rather than given a height, so it always covers the full
+		   tile (art + label) without hardcoding the tile's computed height. */
+		top: 0;
+		bottom: 0;
+		left: 0;
+		width: var(--tile);
+		border-radius: var(--radius-lg);
+		background: var(--bg-muted);
+		box-shadow: inset 0 0 0 1px var(--accent-subtle);
+		transform: translateX(calc(var(--i) * (var(--tile) + var(--gap))));
+		transition: transform 160ms cubic-bezier(0.22, 1, 0.36, 1);
+	}
+
+	/* --- tiles ---------------------------------------------------------- */
+
+	.switcher-tile {
+		position: relative;
+		flex: none;
+		width: var(--tile);
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--spacing-1);
+		padding: calc(var(--tile) * 0.11) 0 var(--spacing-1);
+	}
+
+	.tile-art {
+		position: relative;
+		width: calc(var(--tile) * 0.78);
+		height: calc(var(--tile) * 0.78);
+	}
+
+	.tile-icon {
+		width: 100%;
+		height: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: var(--radius-lg);
+		border: 1px solid color-mix(in srgb, var(--tone) 34%, var(--border));
+		background: linear-gradient(
+			155deg,
+			color-mix(in srgb, var(--tone) 24%, var(--bg-subtle)),
+			color-mix(in srgb, var(--tone) 7%, var(--bg-subtle))
+		);
+		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+		/* Unselected tiles stay readable — you pick a session by scanning the
+		   whole roster, so dimming everything but the current selection defeats
+		   the point. Selection is already carried by the plate, ring and scale. */
+		opacity: 0.82;
+		transform: scale(0.96);
+		transition:
+			opacity 110ms var(--ease),
+			transform 130ms cubic-bezier(0.22, 1, 0.36, 1),
+			box-shadow 110ms var(--ease);
+	}
+
+	.switcher-tile.selected .tile-icon {
+		opacity: 1;
+		transform: scale(1.04);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.14),
+			0 0 0 1.5px color-mix(in srgb, var(--tone) 55%, transparent),
+			0 6px 16px -4px color-mix(in srgb, var(--tone) 45%, transparent);
+	}
+
+	.tile-mark {
+		font-size: calc(var(--tile) * 0.3);
+		font-weight: 600;
+		letter-spacing: -0.02em;
+		color: color-mix(in srgb, var(--tone) 65%, var(--text-primary));
+	}
+
+	/* Status badge, notification-dot style, overhanging the icon corner. */
+	.tile-status {
+		position: absolute;
+		top: -3px;
+		right: -3px;
+		width: 9px;
+		height: 9px;
+		border-radius: 50%;
+		background: var(--tone);
+		border: 2px solid var(--bg-base);
+		opacity: 0.55;
+		transition: opacity 110ms var(--ease);
+	}
+
+	.switcher-tile.selected .tile-status {
+		opacity: 1;
+	}
+
+	.tile-status.pulse {
+		animation: badgePulse 2s ease infinite;
+	}
+
+	.tile-agents {
+		position: absolute;
+		bottom: -3px;
+		right: -3px;
+		min-width: 15px;
+		height: 15px;
+		padding: 0 3px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 9px;
+		font-weight: 600;
+		line-height: 1;
+		border-radius: 999px;
+		background: var(--accent);
+		color: var(--bg-base);
+		border: 2px solid var(--bg-base);
+		opacity: 0.55;
+		transition: opacity 110ms var(--ease);
+	}
+
+	.switcher-tile.selected .tile-agents {
+		opacity: 1;
+	}
+
+	.tile-label {
+		max-width: 100%;
+		font-size: 10px;
+		line-height: 1.3;
+		letter-spacing: -0.01em;
+		color: var(--text-muted);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		transition: color 110ms var(--ease);
+	}
+
+	.switcher-tile.selected .tile-label {
+		color: var(--text-primary);
+		font-weight: 600;
+	}
+
+	/* Where you're standing right now — the tile Cmd+B skipped past. Carried by
+	   the label's colour: a 2px faint dash under the tile was invisible. */
+	.switcher-tile.here .tile-label {
+		color: var(--accent);
+	}
+
+	.switcher-tile.selected.here .tile-label {
+		color: var(--accent);
+		font-weight: 600;
+	}
+
+	/* --- selected-session readout --------------------------------------- */
+
+	.switcher-detail {
+		min-height: 46px;
+		padding-top: var(--spacing-3);
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--spacing-1);
+		text-align: center;
+	}
+
+	.detail-name {
+		max-width: 100%;
+		font-size: 14px;
+		font-weight: 600;
+		letter-spacing: -0.01em;
+		color: var(--text-primary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.detail-meta {
+		max-width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-wrap: nowrap;
+		gap: var(--spacing-2);
+		overflow: hidden;
+		font-size: 11px;
+		color: var(--text-muted);
+	}
+
+	.meta-status {
+		display: inline-flex;
+		align-items: center;
+		flex: none;
+		gap: 5px;
+		white-space: nowrap;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.4px;
+		font-size: 10px;
+		color: var(--tone);
+	}
+
+	.meta-dot {
+		width: 5px;
+		height: 5px;
+		border-radius: 50%;
+		background: var(--tone);
+	}
+
+	.meta-item {
+		display: inline-flex;
+		align-items: center;
+		flex: none;
+		gap: var(--spacing-1);
+		white-space: nowrap;
+		font-variant-numeric: tabular-nums;
+	}
+
+	/* The project name is the only variable-length item, so it's the one that
+	   gives ground when the line is tight. */
+	.meta-item.shrink {
+		flex: 0 1 auto;
+		min-width: 0;
+	}
+
+	.meta-text {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.meta-item.accent {
+		color: var(--accent);
+	}
+
+	/* --- footer hint ---------------------------------------------------- */
+
+	.switcher-hint {
+		margin-top: var(--spacing-3);
+		padding: var(--spacing-2) 0;
+		border-top: 1px solid var(--border-subtle);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: var(--spacing-2);
+		font-size: 11px;
+		/* --text-faint at 11px lands under AA; this line teaches the whole
+		   interaction, so it gets the readable muted step instead. */
+		color: var(--text-muted);
+	}
+
+	.hint-sep {
+		width: 1px;
+		height: 10px;
+		background: var(--border);
+	}
+
+	.switcher-hint kbd {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 18px;
+		height: 18px;
+		margin: 0 1px;
+		padding: 0 5px;
+		font-family: var(--font-sans);
+		font-size: 10px;
+		font-weight: 600;
+		line-height: 1;
+		background: var(--bg-muted);
+		border: 1px solid var(--border);
+		border-bottom-width: 2px;
+		border-radius: var(--radius-sm);
+		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+		color: var(--text-secondary);
+	}
+
+	@keyframes badgePulse {
+		0%,
+		100% {
+			transform: scale(1);
+		}
+		50% {
+			transform: scale(1.25);
+		}
+	}
+
+	@keyframes overlayIn {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
+
+	@keyframes hudIn {
+		from {
+			opacity: 0;
+			transform: scale(0.96) translateY(6px);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.switcher-overlay,
+		.switcher-frame {
+			animation: none;
+		}
+
+		.strip-plate,
+		.tile-icon {
+			transition: none;
+		}
+
+		.tile-status.pulse {
+			animation: none;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/SessionSwitcher.svelte
+++ b/frontend/src/lib/components/SessionSwitcher.svelte
@@ -15,26 +15,23 @@
 		getSessionUrl,
 		canNavigate,
 		getDisplayName,
-		matchesRoute
+		matchesRoute,
+		visibleLiveSessions
 	} from '$lib/utils/live-session-display';
 
-	// Cmd+B — both keys sit under the left hand, unlike Cmd+K.
-	// (Cmd+E was tried first but Chrome on Mac reserves it at the browser-chrome
-	// level — "search with selected text" — so the keydown never reaches page JS.
-	// Cmd+B has no default Chrome/macOS binding.)
+	// Cmd/Ctrl+B — 'b' is free of browser-chrome bindings (unlike Cmd+E on Chrome/Mac).
 	const SWITCH_KEY = 'b';
 
-	const sessions = $derived(
-		$liveSessionsFeed.filter((s) => s.status !== 'ended' && s.transcript_exists !== false)
-	);
+	const sessions = $derived(visibleLiveSessions($liveSessionsFeed));
 
 	let isOpen = $state(false);
 	let index = $state(0);
-
-	// --- display-only derivations (no bearing on open/commit behaviour) ---
+	// Mac holds Cmd, everyone else holds Ctrl (Meta is the Windows/Super key there).
+	let isMac = $state(true);
+	// A mouse-opened switcher must not commit on an incidentally-held Cmd/Ctrl release.
+	let openedViaKeyboard = false;
 
 	// Tiles shrink as the roster grows so 2 and ~12 sessions both sit on one row.
-	// +25% over the original 76/62/50 px, per Ayush's request to match the dock resize.
 	const density = $derived(
 		sessions.length <= 6
 			? { tile: 95, gap: 15 }
@@ -56,10 +53,7 @@
 		index = startIndex;
 	}
 
-	// Skip past whatever session we're already on, same as Cmd+Tab landing on
-	// the "other" window first. Shared by the Cmd+B first-press and the
-	// footer button (which has no "current session" of its own to skip via
-	// held-key repeats, so it needs the same starting point).
+	// Land on the "other" session first, Cmd+Tab-style — skip the one we're on.
 	function openFromCurrent() {
 		if (sessions.length === 0) return;
 		const currentIdx = sessions.findIndex((s) => matchesRoute($page.url.pathname, s));
@@ -76,10 +70,7 @@
 		isOpen = false;
 		sessionSwitcherStore.close();
 		if (!session) return;
-		// Route-only: focus-terminal raises the native Terminal window on top of
-		// Chrome, which would steal focus the instant you land here and hide the
-		// very page you just switched to. Terminal jump stays a deliberate,
-		// separate action on the dock's own button.
+		// Route-only: raising the native terminal here would hide the page just switched to.
 		if (canNavigate(session)) goto(getSessionUrl(session, 'timeline'));
 	}
 
@@ -88,24 +79,29 @@
 		sessionSwitcherStore.close();
 	}
 
-	// Opened via the footer button (mouse, no Cmd held) — sync from the store.
+	// Opened via the footer button (mouse) — sync from the store.
 	$effect(() => {
 		if ($sessionSwitcherStore.isOpen && !isOpen) {
+			openedViaKeyboard = false;
 			openFromCurrent();
 		}
 	});
 
-	// Clicking the dimmed backdrop is the only way to cancel a mouse-opened
-	// switcher — there's no Cmd being held to release.
+	// Backdrop click is the mouse path's cancel — there may be no modifier held to release.
 	function handleBackdropClick(e: MouseEvent) {
 		if (e.target === e.currentTarget) cancel();
 	}
 
+	function switchModifierHeld(e: KeyboardEvent): boolean {
+		return isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
+	}
+
 	function handleKeydown(e: KeyboardEvent) {
-		if (e.key.toLowerCase() === SWITCH_KEY && e.metaKey && !e.ctrlKey && !e.altKey) {
+		if (e.key.toLowerCase() === SWITCH_KEY && switchModifierHeld(e) && !e.altKey) {
 			if (commandPalette.getIsOpen()) return;
 			if (sessions.length === 0) return;
 			e.preventDefault();
+			openedViaKeyboard = true;
 
 			if (!isOpen) {
 				openFromCurrent();
@@ -122,7 +118,7 @@
 	}
 
 	function handleKeyup(e: KeyboardEvent) {
-		if (isOpen && e.key === 'Meta') {
+		if (isOpen && openedViaKeyboard && e.key === (isMac ? 'Meta' : 'Control')) {
 			commit();
 		}
 	}
@@ -136,6 +132,7 @@
 	}
 
 	onMount(() => {
+		isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
 		liveSessionsFeed.start();
 		window.addEventListener('keydown', handleKeydown);
 		window.addEventListener('keyup', handleKeyup);
@@ -145,8 +142,7 @@
 
 	onDestroy(() => {
 		liveSessionsFeed.stop();
-		// onDestroy also fires during SSR teardown, where onMount never ran and
-		// window/document don't exist — guard so that doesn't throw.
+		// onDestroy also fires during SSR teardown, where window never existed — guard it.
 		if (typeof window === 'undefined') return;
 		window.removeEventListener('keydown', handleKeydown);
 		window.removeEventListener('keyup', handleKeyup);
@@ -156,10 +152,7 @@
 </script>
 
 {#if isOpen}
-	<!-- Escape is already handled globally by handleKeydown above; this click
-	     handler is the mouse-only equivalent for a switcher opened without
-	     Cmd held (via the footer button), so no separate keyboard handler
-	     is needed on the element itself. -->
+	<!-- Escape is handled by the global handleKeydown; this click is its mouse-only twin. -->
 	<!-- svelte-ignore a11y_click_events_have_key_events -->
 	<div
 		class="switcher-overlay"
@@ -210,8 +203,7 @@
 									>
 								{/if}
 							</div>
-							<!-- Session name, not just the project monogram: two sessions in the
-							     same repo would otherwise render as identical tiles. -->
+							<!-- Session name disambiguates two sessions in the same repo. -->
 							<span class="tile-label font-mono">{getDisplayName(session)}</span>
 						</div>
 					{/each}
@@ -221,13 +213,11 @@
 			<div class="switcher-detail">
 				{#if selected}
 					{@const config = statusConfig[selected.status]}
-					<!-- The tile label already shows the session id/slug — the big
-					     readout should answer "which project", not repeat it. -->
+					<!-- The big readout answers "which project"; tiles already show the session id. -->
 					<div class="detail-name font-mono" aria-live="polite">
 						{getProjectDisplayName(selected)}
 					</div>
-					<!-- Single line, never wrapping: a second line would grow the frame
-					     mid-cycle and shift the tiles under the user's fingers. -->
+					<!-- Never wraps — a second line would shift the tiles mid-cycle. -->
 					<div class="detail-meta">
 						<span class="meta-status" style="--tone: {config.color}">
 							<span class="meta-dot"></span>{config.label}
@@ -253,7 +243,9 @@
 			</div>
 
 			<div class="switcher-hint">
-				<span>hold <kbd>⌘</kbd> — tap <kbd>B</kbd> to cycle, release to jump</span>
+				<span
+					>hold <kbd>{isMac ? '⌘' : 'Ctrl'}</kbd> — tap <kbd>B</kbd> to cycle, release to jump</span
+				>
 				<span class="hint-sep"></span>
 				<span><kbd>esc</kbd> cancel</span>
 			</div>
@@ -270,11 +262,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		/* Same black as the command palette's scrim, lighter: this HUD is a
-		   transient hold-to-cycle overlay, not a place you stop and work.
-		   No backdrop-filter — a full-viewport blur is the one thing that could
-		   make a keypress-triggered HUD arrive late, and it buys nothing under
-		   a 42% wash. The frame keeps its own glass. */
+		/* Lighter than the palette scrim; no full-viewport blur — it would delay the HUD. */
 		background: rgba(0, 0, 0, 0.42);
 		animation: overlayIn 80ms linear;
 	}
@@ -282,9 +270,11 @@
 	/* --- HUD frame ------------------------------------------------------ */
 
 	.switcher-frame {
-		/* Sized from the tile roster so the panel never jitters as the
-		   selected session's name changes length underneath it. */
-		width: min(92vw, max(475px, calc(var(--n) * var(--tile) + (var(--n) - 1) * var(--gap) + 40px)));
+		/* Sized from the tile roster so the frame never jitters as the detail text changes. */
+		width: min(
+			92vw,
+			max(475px, calc(var(--n) * var(--tile) + (var(--n) - 1) * var(--gap) + 40px))
+		);
 		padding: 20px 20px 0;
 		background: color-mix(in srgb, var(--bg-base) 82%, transparent);
 		border: 1px solid var(--border);
@@ -314,12 +304,10 @@
 		margin-inline: auto;
 	}
 
-	/* Single highlight that slides between cells — reads as one continuous
-	   selection rather than N independently-animating tiles. */
+	/* One highlight sliding between cells — reads as a single continuous selection. */
 	.strip-plate {
 		position: absolute;
-		/* Stretched rather than given a height, so it always covers the full
-		   tile (art + label) without hardcoding the tile's computed height. */
+		/* Stretched, not sized — covers the full tile without hardcoding its height. */
 		top: 0;
 		bottom: 0;
 		left: 0;
@@ -371,9 +359,7 @@
 			color-mix(in srgb, var(--tone) 7%, var(--bg-subtle))
 		);
 		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
-		/* Unselected tiles stay readable — you pick a session by scanning the
-		   whole roster, so dimming everything but the current selection defeats
-		   the point. Selection is already carried by the plate, ring and scale. */
+		/* Unselected tiles stay readable — the roster is picked by scanning all of it. */
 		opacity: 0.82;
 		transform: scale(0.96);
 		transition:
@@ -462,8 +448,7 @@
 		font-weight: 600;
 	}
 
-	/* Where you're standing right now — the tile Cmd+B skipped past. Carried by
-	   the label's colour: a 2px faint dash under the tile was invisible. */
+	/* The session you're on now — accent label; a faint underline dash was invisible. */
 	.switcher-tile.here .tile-label {
 		color: var(--accent);
 	}
@@ -552,8 +537,7 @@
 		justify-content: center;
 		gap: 10px;
 		font-size: 14px;
-		/* --text-faint at this size lands under AA; this line teaches the whole
-		   interaction, so it gets the readable muted step instead. */
+		/* --text-faint lands under AA at this size — this line teaches the interaction. */
 		color: var(--text-muted);
 	}
 

--- a/frontend/src/lib/components/SessionSwitcher.svelte
+++ b/frontend/src/lib/components/SessionSwitcher.svelte
@@ -178,6 +178,7 @@
 							style="--tone: {config.color}"
 							role="button"
 							tabindex="0"
+							title={getDisplayName(session)}
 							aria-label={`Switch to ${getDisplayName(session)}`}
 							onmouseenter={() => (index = i)}
 							onclick={() => {
@@ -537,8 +538,8 @@
 		justify-content: center;
 		gap: 10px;
 		font-size: 14px;
-		/* --text-faint lands under AA at this size — this line teaches the interaction. */
-		color: var(--text-muted);
+		/* This line teaches the interaction — muted/faint steps land under AA on the glass frame. */
+		color: var(--text-secondary);
 	}
 
 	.hint-sep {

--- a/frontend/src/lib/components/SessionSwitcher.svelte
+++ b/frontend/src/lib/components/SessionSwitcher.svelte
@@ -2,8 +2,9 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
-	import { FolderOpen, Clock, Bot, Pause } from 'lucide-svelte';
+	import { Clock, Bot, Pause } from 'lucide-svelte';
 	import { commandPalette } from '$lib/stores/commandPalette';
+	import { sessionSwitcherStore } from '$lib/stores/sessionSwitcher';
 	import { liveSessionsFeed } from '$lib/stores/liveSessionsFeed';
 	import { statusConfig } from '$lib/live-session-config';
 	import type { LiveSessionSummary } from '$lib/api-types';
@@ -33,12 +34,13 @@
 	// --- display-only derivations (no bearing on open/commit behaviour) ---
 
 	// Tiles shrink as the roster grows so 2 and ~12 sessions both sit on one row.
+	// +25% over the original 76/62/50 px, per Ayush's request to match the dock resize.
 	const density = $derived(
 		sessions.length <= 6
-			? { tile: 76, gap: 12 }
+			? { tile: 95, gap: 15 }
 			: sessions.length <= 10
-				? { tile: 62, gap: 9 }
-				: { tile: 50, gap: 6 }
+				? { tile: 78, gap: 11 }
+				: { tile: 63, gap: 8 }
 	);
 
 	const selected = $derived(sessions[index]);
@@ -54,6 +56,16 @@
 		index = startIndex;
 	}
 
+	// Skip past whatever session we're already on, same as Cmd+Tab landing on
+	// the "other" window first. Shared by the Cmd+B first-press and the
+	// footer button (which has no "current session" of its own to skip via
+	// held-key repeats, so it needs the same starting point).
+	function openFromCurrent() {
+		if (sessions.length === 0) return;
+		const currentIdx = sessions.findIndex((s) => matchesRoute($page.url.pathname, s));
+		openAt(currentIdx >= 0 ? (currentIdx + 1) % sessions.length : 0);
+	}
+
 	function advance() {
 		if (sessions.length === 0) return;
 		index = (index + 1) % sessions.length;
@@ -62,6 +74,7 @@
 	function commit() {
 		const session = sessions[index];
 		isOpen = false;
+		sessionSwitcherStore.close();
 		if (!session) return;
 		// Route-only: focus-terminal raises the native Terminal window on top of
 		// Chrome, which would steal focus the instant you land here and hide the
@@ -72,6 +85,20 @@
 
 	function cancel() {
 		isOpen = false;
+		sessionSwitcherStore.close();
+	}
+
+	// Opened via the footer button (mouse, no Cmd held) — sync from the store.
+	$effect(() => {
+		if ($sessionSwitcherStore.isOpen && !isOpen) {
+			openFromCurrent();
+		}
+	});
+
+	// Clicking the dimmed backdrop is the only way to cancel a mouse-opened
+	// switcher — there's no Cmd being held to release.
+	function handleBackdropClick(e: MouseEvent) {
+		if (e.target === e.currentTarget) cancel();
 	}
 
 	function handleKeydown(e: KeyboardEvent) {
@@ -81,10 +108,7 @@
 			e.preventDefault();
 
 			if (!isOpen) {
-				// First press: skip past whatever session we're already on, same
-				// as Cmd+Tab landing on the "other" window first.
-				const currentIdx = sessions.findIndex((s) => matchesRoute($page.url.pathname, s));
-				openAt(currentIdx >= 0 ? (currentIdx + 1) % sessions.length : 0);
+				openFromCurrent();
 			} else {
 				advance();
 			}
@@ -132,11 +156,18 @@
 </script>
 
 {#if isOpen}
+	<!-- Escape is already handled globally by handleKeydown above; this click
+	     handler is the mouse-only equivalent for a switcher opened without
+	     Cmd held (via the footer button), so no separate keyboard handler
+	     is needed on the element itself. -->
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
 	<div
 		class="switcher-overlay"
 		role="dialog"
 		aria-modal="true"
 		aria-label="Live session switcher"
+		tabindex="-1"
+		onclick={handleBackdropClick}
 	>
 		<div
 			class="switcher-frame"
@@ -152,6 +183,21 @@
 							class:selected={i === index}
 							class:here={matchesRoute($page.url.pathname, session)}
 							style="--tone: {config.color}"
+							role="button"
+							tabindex="0"
+							aria-label={`Switch to ${getDisplayName(session)}`}
+							onmouseenter={() => (index = i)}
+							onclick={() => {
+								index = i;
+								commit();
+							}}
+							onkeydown={(e) => {
+								if (e.key === 'Enter' || e.key === ' ') {
+									e.preventDefault();
+									index = i;
+									commit();
+								}
+							}}
 						>
 							<div class="tile-art">
 								<div class="tile-icon">
@@ -175,33 +221,30 @@
 			<div class="switcher-detail">
 				{#if selected}
 					{@const config = statusConfig[selected.status]}
+					<!-- The tile label already shows the session id/slug — the big
+					     readout should answer "which project", not repeat it. -->
 					<div class="detail-name font-mono" aria-live="polite">
-						{getDisplayName(selected)}
+						{getProjectDisplayName(selected)}
 					</div>
 					<!-- Single line, never wrapping: a second line would grow the frame
-					     mid-cycle and shift the tiles under the user's fingers. Order is
-					     priority order — the last items are the ones allowed to clip. -->
+					     mid-cycle and shift the tiles under the user's fingers. -->
 					<div class="detail-meta">
 						<span class="meta-status" style="--tone: {config.color}">
 							<span class="meta-dot"></span>{config.label}
 						</span>
-						<span class="meta-item shrink"
-							><FolderOpen size={11} strokeWidth={2} />
-							<span class="meta-text">{getProjectDisplayName(selected)}</span></span
-						>
 						{#if selected.active_subagent_count > 0}
 							<span class="meta-item accent"
-								><Bot size={11} strokeWidth={2} />
+								><Bot size={14} strokeWidth={2} />
 								{selected.active_subagent_count}</span
 							>
 						{/if}
 						<span class="meta-item"
-							><Clock size={11} strokeWidth={2} />
+							><Clock size={14} strokeWidth={2} />
 							{formatDuration(selected.duration_seconds)}</span
 						>
 						{#if selected.idle_seconds >= 60}
 							<span class="meta-item"
-								><Pause size={11} strokeWidth={2} />
+								><Pause size={14} strokeWidth={2} />
 								{formatIdleTime(selected.idle_seconds)} idle</span
 							>
 						{/if}
@@ -241,14 +284,8 @@
 	.switcher-frame {
 		/* Sized from the tile roster so the panel never jitters as the
 		   selected session's name changes length underneath it. */
-		width: min(
-			92vw,
-			max(
-				380px,
-				calc(var(--n) * var(--tile) + (var(--n) - 1) * var(--gap) + var(--spacing-4) * 2)
-			)
-		);
-		padding: var(--spacing-4) var(--spacing-4) 0;
+		width: min(92vw, max(475px, calc(var(--n) * var(--tile) + (var(--n) - 1) * var(--gap) + 40px)));
+		padding: 20px 20px 0;
 		background: color-mix(in srgb, var(--bg-base) 82%, transparent);
 		border: 1px solid var(--border);
 		border-radius: calc(var(--radius-lg) * 2);
@@ -303,8 +340,15 @@
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		gap: var(--spacing-1);
-		padding: calc(var(--tile) * 0.11) 0 var(--spacing-1);
+		gap: 5px;
+		padding: calc(var(--tile) * 0.11) 0 5px;
+		cursor: pointer;
+	}
+
+	.switcher-tile:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+		border-radius: var(--radius-lg);
 	}
 
 	.tile-art {
@@ -359,8 +403,8 @@
 		position: absolute;
 		top: -3px;
 		right: -3px;
-		width: 9px;
-		height: 9px;
+		width: 11px;
+		height: 11px;
 		border-radius: 50%;
 		background: var(--tone);
 		border: 2px solid var(--bg-base);
@@ -380,13 +424,13 @@
 		position: absolute;
 		bottom: -3px;
 		right: -3px;
-		min-width: 15px;
-		height: 15px;
-		padding: 0 3px;
+		min-width: 19px;
+		height: 19px;
+		padding: 0 4px;
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		font-size: 9px;
+		font-size: 11px;
 		font-weight: 600;
 		line-height: 1;
 		border-radius: 999px;
@@ -403,7 +447,7 @@
 
 	.tile-label {
 		max-width: 100%;
-		font-size: 10px;
+		font-size: 13px;
 		line-height: 1.3;
 		letter-spacing: -0.01em;
 		color: var(--text-muted);
@@ -432,18 +476,18 @@
 	/* --- selected-session readout --------------------------------------- */
 
 	.switcher-detail {
-		min-height: 46px;
-		padding-top: var(--spacing-3);
+		min-height: 58px;
+		padding-top: 15px;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		gap: var(--spacing-1);
+		gap: 5px;
 		text-align: center;
 	}
 
 	.detail-name {
 		max-width: 100%;
-		font-size: 14px;
+		font-size: 18px;
 		font-weight: 600;
 		letter-spacing: -0.01em;
 		color: var(--text-primary);
@@ -458,9 +502,9 @@
 		align-items: center;
 		justify-content: center;
 		flex-wrap: nowrap;
-		gap: var(--spacing-2);
+		gap: 10px;
 		overflow: hidden;
-		font-size: 11px;
+		font-size: 14px;
 		color: var(--text-muted);
 	}
 
@@ -468,18 +512,18 @@
 		display: inline-flex;
 		align-items: center;
 		flex: none;
-		gap: 5px;
+		gap: 6px;
 		white-space: nowrap;
 		font-weight: 600;
 		text-transform: uppercase;
 		letter-spacing: 0.4px;
-		font-size: 10px;
+		font-size: 13px;
 		color: var(--tone);
 	}
 
 	.meta-dot {
-		width: 5px;
-		height: 5px;
+		width: 6px;
+		height: 6px;
 		border-radius: 50%;
 		background: var(--tone);
 	}
@@ -488,22 +532,9 @@
 		display: inline-flex;
 		align-items: center;
 		flex: none;
-		gap: var(--spacing-1);
+		gap: 5px;
 		white-space: nowrap;
 		font-variant-numeric: tabular-nums;
-	}
-
-	/* The project name is the only variable-length item, so it's the one that
-	   gives ground when the line is tight. */
-	.meta-item.shrink {
-		flex: 0 1 auto;
-		min-width: 0;
-	}
-
-	.meta-text {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
 	}
 
 	.meta-item.accent {
@@ -513,22 +544,22 @@
 	/* --- footer hint ---------------------------------------------------- */
 
 	.switcher-hint {
-		margin-top: var(--spacing-3);
-		padding: var(--spacing-2) 0;
+		margin-top: 15px;
+		padding: 10px 0;
 		border-top: 1px solid var(--border-subtle);
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		gap: var(--spacing-2);
-		font-size: 11px;
-		/* --text-faint at 11px lands under AA; this line teaches the whole
+		gap: 10px;
+		font-size: 14px;
+		/* --text-faint at this size lands under AA; this line teaches the whole
 		   interaction, so it gets the readable muted step instead. */
 		color: var(--text-muted);
 	}
 
 	.hint-sep {
 		width: 1px;
-		height: 10px;
+		height: 13px;
 		background: var(--border);
 	}
 
@@ -536,12 +567,12 @@
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
-		min-width: 18px;
-		height: 18px;
+		min-width: 23px;
+		height: 23px;
 		margin: 0 1px;
-		padding: 0 5px;
+		padding: 0 6px;
 		font-family: var(--font-sans);
-		font-size: 10px;
+		font-size: 13px;
 		font-weight: 600;
 		line-height: 1;
 		background: var(--bg-muted);

--- a/frontend/src/lib/live-session-config.ts
+++ b/frontend/src/lib/live-session-config.ts
@@ -23,13 +23,13 @@ export const statusConfig: Record<LiveSessionStatus, StatusConfig> = {
 	starting: {
 		color: 'var(--nav-purple)',
 		label: 'starting',
-		pulse: true,
+		pulse: false,
 		bgTint: 'var(--status-starting-bg)'
 	},
 	active: {
 		color: 'var(--success)',
 		label: 'active',
-		pulse: true,
+		pulse: false,
 		bgTint: 'var(--status-active-bg)'
 	},
 	idle: {
@@ -38,10 +38,11 @@ export const statusConfig: Record<LiveSessionStatus, StatusConfig> = {
 		pulse: false,
 		bgTint: 'var(--status-idle-bg)'
 	},
+	// Pulse means "blocked on you" everywhere — a dot blinking for merely-busy trains you to ignore it.
 	waiting: {
 		color: 'var(--info)',
 		label: 'waiting',
-		pulse: false,
+		pulse: true,
 		bgTint: 'var(--status-waiting-bg)'
 	},
 	stopped: {

--- a/frontend/src/lib/stores/liveSessionsFeed.ts
+++ b/frontend/src/lib/stores/liveSessionsFeed.ts
@@ -1,17 +1,20 @@
 /**
- * Shared live-sessions polling feed.
- *
- * LiveSessionsDock and SessionSwitcher both need the same active-session
- * list; this ref-counts subscribers so the poll runs once regardless of how
- * many consumers are mounted, and stops when none are.
+ * Shared live-sessions polling feed — ref-counted so the poll runs once no
+ * matter how many consumers (dock, switcher, LIVE NOW sections) are mounted.
  */
 
 import { writable } from 'svelte/store';
 import { API_BASE, POLLING_INTERVALS } from '$lib/config';
 import type { LiveSessionSummary } from '$lib/api-types';
 
+export interface LiveSessionsFeedStatus {
+	loading: boolean;
+	error: string | null;
+}
+
 function createLiveSessionsFeed() {
 	const { subscribe, set } = writable<LiveSessionSummary[]>([]);
+	const status = writable<LiveSessionsFeedStatus>({ loading: true, error: null });
 
 	let refCount = 0;
 	let interval: ReturnType<typeof setInterval> | null = null;
@@ -26,10 +29,17 @@ function createLiveSessionsFeed() {
 			});
 			if (res.ok) {
 				set(await res.json());
+				status.set({ loading: false, error: null });
+			} else {
+				status.set({
+					loading: false,
+					error: res.status === 404 ? 'API not available' : 'Failed to fetch'
+				});
 			}
 		} catch (e) {
 			if (e instanceof Error && e.name === 'AbortError') return;
 			// Best-effort — leave the last known list in place on transient errors.
+			status.set({ loading: false, error: 'Cannot connect to API' });
 		}
 	}
 
@@ -50,7 +60,7 @@ function createLiveSessionsFeed() {
 		}
 	}
 
-	return { subscribe, start, stop, refresh: fetchOnce };
+	return { subscribe, status: { subscribe: status.subscribe }, start, stop, refresh: fetchOnce };
 }
 
 export const liveSessionsFeed = createLiveSessionsFeed();

--- a/frontend/src/lib/stores/liveSessionsFeed.ts
+++ b/frontend/src/lib/stores/liveSessionsFeed.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared live-sessions polling feed.
+ *
+ * LiveSessionsDock and SessionSwitcher both need the same active-session
+ * list; this ref-counts subscribers so the poll runs once regardless of how
+ * many consumers are mounted, and stops when none are.
+ */
+
+import { writable } from 'svelte/store';
+import { API_BASE, POLLING_INTERVALS } from '$lib/config';
+import type { LiveSessionSummary } from '$lib/api-types';
+
+function createLiveSessionsFeed() {
+	const { subscribe, set } = writable<LiveSessionSummary[]>([]);
+
+	let refCount = 0;
+	let interval: ReturnType<typeof setInterval> | null = null;
+	let abortController: AbortController | null = null;
+
+	async function fetchOnce() {
+		abortController?.abort();
+		abortController = new AbortController();
+		try {
+			const res = await fetch(`${API_BASE}/live-sessions/active`, {
+				signal: abortController.signal
+			});
+			if (res.ok) {
+				set(await res.json());
+			}
+		} catch (e) {
+			if (e instanceof Error && e.name === 'AbortError') return;
+			// Best-effort — leave the last known list in place on transient errors.
+		}
+	}
+
+	function start() {
+		refCount++;
+		if (refCount === 1) {
+			fetchOnce();
+			interval = setInterval(fetchOnce, POLLING_INTERVALS.LIVE_SESSIONS);
+		}
+	}
+
+	function stop() {
+		refCount = Math.max(0, refCount - 1);
+		if (refCount === 0 && interval) {
+			clearInterval(interval);
+			interval = null;
+			abortController?.abort();
+		}
+	}
+
+	return { subscribe, start, stop, refresh: fetchOnce };
+}
+
+export const liveSessionsFeed = createLiveSessionsFeed();

--- a/frontend/src/lib/stores/sessionSwitcher.ts
+++ b/frontend/src/lib/stores/sessionSwitcher.ts
@@ -1,0 +1,24 @@
+/**
+ * Session Switcher Store
+ * Lets sibling components (e.g. CommandFooter's button) open the Cmd+B
+ * switcher HUD, mirroring the commandPalette store's open/close pattern.
+ */
+
+import { writable, get } from 'svelte/store';
+
+interface SessionSwitcherState {
+	isOpen: boolean;
+}
+
+function createSessionSwitcherStore() {
+	const { subscribe, set } = writable<SessionSwitcherState>({ isOpen: false });
+
+	return {
+		subscribe,
+		open: () => set({ isOpen: true }),
+		close: () => set({ isOpen: false }),
+		getIsOpen: () => get({ subscribe }).isOpen
+	};
+}
+
+export const sessionSwitcherStore = createSessionSwitcherStore();

--- a/frontend/src/lib/utils/live-session-display.ts
+++ b/frontend/src/lib/utils/live-session-display.ts
@@ -56,10 +56,19 @@ export function getDisplayName(session: LiveSessionSummary): string {
 	return session.slug || session.session_id.slice(0, 8);
 }
 
+/** Sessions worth showing: not ended, and not ghosts whose transcript never materialized. */
+export function visibleLiveSessions(sessions: LiveSessionSummary[]): LiveSessionSummary[] {
+	return sessions.filter((s) => s.status !== 'ended' && s.transcript_exists !== false);
+}
+
 /** True when the current route (`/projects/[id]/[session_slug]`) points at this session. */
 export function matchesRoute(pathname: string, session: LiveSessionSummary): boolean {
 	const parts = pathname.split('/').filter(Boolean);
 	if (parts[0] !== 'projects' || parts.length < 3) return false;
+	// Slugs are LLM-generated and collide across projects — the project segment must match too.
+	const projectMatches =
+		parts[1] === session.project_slug || parts[1] === session.project_encoded_name;
+	if (!projectMatches) return false;
 	const routeIdentifier = parts[2];
 	return routeIdentifier === session.slug || routeIdentifier === session.session_id.slice(0, 8);
 }

--- a/frontend/src/lib/utils/live-session-display.ts
+++ b/frontend/src/lib/utils/live-session-display.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared display helpers for live session lists — used by LiveSessionsSection,
+ * LiveSessionsDock, and SessionSwitcher so all three render sessions identically.
+ */
+
+import type { LiveSessionSummary } from '$lib/api-types';
+import { projectHrefFromSession } from '$lib/utils/project-url';
+
+export function formatDuration(seconds: number): string {
+	const mins = Math.floor(seconds / 60);
+	const hrs = Math.floor(mins / 60);
+	if (hrs > 0) return `${hrs}h ${mins % 60}m`;
+	if (mins > 0) return `${mins}m`;
+	return `${Math.floor(seconds)}s`;
+}
+
+export function formatIdleTime(seconds: number): string {
+	if (seconds < 60) return `${Math.floor(seconds)}s`;
+	const mins = Math.floor(seconds / 60);
+	return `${mins}m`;
+}
+
+const SKIP_DIRS = ['Users', 'home', 'Documents', 'GitHub', 'Projects', 'repos', 'src'];
+const NESTED_DIRS = new Set(['frontend', 'backend', 'api', 'src', 'app']);
+
+export function getProjectDisplayName(session: LiveSessionSummary): string {
+	const parts = session.cwd.split('/').filter(Boolean);
+
+	for (let i = parts.length - 1; i >= 0; i--) {
+		const part = parts[i];
+		if (!SKIP_DIRS.includes(part) && part.length > 2) {
+			if (i > 0 && NESTED_DIRS.has(part)) {
+				return parts[i - 1] || part;
+			}
+			return part;
+		}
+	}
+
+	return parts[parts.length - 1] || 'Unknown';
+}
+
+export function canNavigate(session: LiveSessionSummary): boolean {
+	return !!session.project_encoded_name;
+}
+
+export function getSessionUrl(session: LiveSessionSummary, tab?: string): string {
+	if (!session.project_encoded_name) {
+		return '#';
+	}
+	const identifier = session.slug || session.session_id.slice(0, 8);
+	const suffix = tab ? `/${identifier}?tab=${tab}` : `/${identifier}`;
+	return projectHrefFromSession(session, suffix);
+}
+
+export function getDisplayName(session: LiveSessionSummary): string {
+	return session.slug || session.session_id.slice(0, 8);
+}
+
+/** True when the current route (`/projects/[id]/[session_slug]`) points at this session. */
+export function matchesRoute(pathname: string, session: LiveSessionSummary): boolean {
+	const parts = pathname.split('/').filter(Boolean);
+	if (parts[0] !== 'projects' || parts.length < 3) return false;
+	const routeIdentifier = parts[2];
+	return routeIdentifier === session.slug || routeIdentifier === session.session_id.slice(0, 8);
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -5,6 +5,8 @@
 	import CommandFooter from '$lib/components/CommandFooter.svelte';
 	import CommandPalette from '$lib/components/command-palette/CommandPalette.svelte';
 	import KeyboardShortcutsHelp from '$lib/components/KeyboardShortcutsHelp.svelte';
+	import LiveSessionsDock from '$lib/components/LiveSessionsDock.svelte';
+	import SessionSwitcher from '$lib/components/SessionSwitcher.svelte';
 	import { globalKeyboard } from '$lib/actions/globalKeyboard';
 	import { globalShortcuts } from '$lib/actions/globalShortcuts';
 	import { navigating } from '$app/stores';
@@ -174,4 +176,10 @@
 
 	<!-- Keyboard Shortcuts Help Modal -->
 	<KeyboardShortcutsHelp bind:open={showKeyboardHelp} />
+
+	<!-- Floating live-sessions dock (hidden on / and /sessions — they already show the full table) -->
+	<LiveSessionsDock />
+
+	<!-- Cmd+B hold-to-cycle session switcher -->
+	<SessionSwitcher />
 </div>


### PR DESCRIPTION
## What this does

Two ways to jump between concurrently-running Claude Code sessions without going back to the sessions list:

- **Floating dock** (bottom-right pill, every page except `/` and `/sessions` where the full table already exists): click to expand a list of live sessions, click a row to open it, or use its dedicated button to focus the session's terminal window.
- **Cmd+B session switcher**: hold Cmd, tap B to cycle a macOS-Cmd+Tab-style HUD through your live sessions, release Cmd to jump to the highlighted one's Timeline tab.

Both read from one shared polling store instead of each hitting `/live-sessions/active` on their own.

## Why Cmd+B, not Cmd+K or Cmd+E

Cmd+K is already the command palette. Cmd+E was tried first but Chrome on Mac reserves it at the browser-chrome level (search-with-selection), so the keydown never reaches page JS — Cmd+B has no such conflict.

## Why the switcher only navigates, doesn't also focus the terminal

Focus-terminal raises the native Terminal window on top of Chrome, which would immediately hide the page you just switched to. Terminal focus stays a separate, deliberate action on the dock's own button.

## Files touched

- `LiveSessionsDock.svelte`, `SessionSwitcher.svelte` — new
- `liveSessionsFeed.ts` — new shared polling store
- `live-session-display.ts` — new shared formatting/URL helpers, extracted out of `LiveSessionsSection.svelte` (also refactored to use them, no behavior change there)
- `+layout.svelte` — mounts both globally
- `KeyboardShortcutsHelp.svelte` — documents Cmd+B

## Test plan

- [x] `npm run check` / `npm run lint` clean (0 errors)
- [x] Verified via curl against the running dev server: homepage and a session-detail route both 200, no SSR errors
- [x] Manual click-through and Cmd+B verification (done live by Ayush during the session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)