### PR TITLE
Wire timeline search-result highlighting across cards, modal, and tool details

### DIFF
--- a/api/tests/test_utils_tool_summary.py
+++ b/api/tests/test_utils_tool_summary.py
@@ -1,0 +1,77 @@
+"""Tests for get_tool_summary()'s text-capping contract (_cap_text)."""
+
+import pytest
+
+from models.content import ToolUseBlock
+from utils import _METADATA_TEXT_LIMIT, _cap_text, get_tool_summary
+
+
+def make_tool_use(name: str, **input_kwargs) -> ToolUseBlock:
+    return ToolUseBlock(type="tool_use", id="toolu_test", name=name, input=input_kwargs)
+
+
+class TestCapText:
+    def test_exactly_at_limit_passes_untouched(self):
+        value = "x" * _METADATA_TEXT_LIMIT
+        assert _cap_text(value) == value
+
+    def test_over_limit_is_capped_with_marker(self):
+        value = "x" * 9000
+        result = _cap_text(value)
+        assert result.startswith("x" * _METADATA_TEXT_LIMIT)
+        assert result.endswith("[truncated, 9000 chars total]")
+        assert len(result) > _METADATA_TEXT_LIMIT
+
+    def test_under_limit_passes_untouched(self):
+        assert _cap_text("short") == "short"
+
+
+class TestGetToolSummaryEdit:
+    def test_edit_carries_path_and_capped_strings(self):
+        block = make_tool_use(
+            "Edit",
+            path="/repo/file.py",
+            old_string="a" * 5000,
+            new_string="b" * 10,
+        )
+        _, _, metadata = get_tool_summary(block)
+        assert metadata["path"] == "/repo/file.py"
+        assert metadata["old_string"].endswith("[truncated, 5000 chars total]")
+        assert metadata["new_string"] == "b" * 10
+
+    def test_edit_short_strings_uncapped(self):
+        block = make_tool_use("Edit", path="/repo/file.py", old_string="foo", new_string="bar")
+        _, _, metadata = get_tool_summary(block)
+        assert metadata["old_string"] == "foo"
+        assert metadata["new_string"] == "bar"
+
+
+class TestGetToolSummaryWrite:
+    def test_write_content_capped_over_limit(self):
+        block = make_tool_use("Write", path="/repo/big.txt", content="c" * 9000)
+        _, _, metadata = get_tool_summary(block)
+        assert metadata["content"].endswith("[truncated, 9000 chars total]")
+
+    def test_write_content_under_limit_uncapped(self):
+        block = make_tool_use("Write", path="/repo/small.txt", content="hello")
+        _, _, metadata = get_tool_summary(block)
+        assert metadata["content"] == "hello"
+
+
+class TestGetToolSummaryTask:
+    @pytest.mark.parametrize("tool_name", ["Task", "Agent"])
+    def test_task_carries_capped_prompt(self, tool_name):
+        block = make_tool_use(
+            tool_name,
+            description="Investigate the bug",
+            subagent_type="explore",
+            prompt="p" * 9000,
+        )
+        _, _, metadata = get_tool_summary(block)
+        assert metadata["subagent_type"] == "explore"
+        assert metadata["prompt"].endswith("[truncated, 9000 chars total]")
+
+    def test_task_short_prompt_uncapped(self):
+        block = make_tool_use("Task", description="desc", subagent_type="explore", prompt="find x")
+        _, _, metadata = get_tool_summary(block)
+        assert metadata["prompt"] == "find x"

--- a/api/utils.py
+++ b/api/utils.py
@@ -749,6 +749,18 @@ def find_best_root(path: str, working_dirs: list[str]) -> str | None:
         return None
 
 
+# Cap on free-text tool-input fields (diffs, subagent prompts) placed into
+# timeline metadata. Without this, large Edit diffs or Task prompts ship in
+# full over the timeline endpoint, which live sessions poll every second.
+_METADATA_TEXT_LIMIT = 4000
+
+
+def _cap_text(value: str, limit: int = _METADATA_TEXT_LIMIT) -> str:
+    if len(value) <= limit:
+        return value
+    return value[:limit] + f"\n... [truncated, {len(value)} chars total]"
+
+
 def get_tool_summary(block, working_dirs: list[str] | None = None) -> tuple[str, str | None, dict]:
     """
     Extract title, summary, and metadata from a tool use block.
@@ -780,7 +792,13 @@ def get_tool_summary(block, working_dirs: list[str] | None = None) -> tuple[str,
         return "Write file", to_relative(path), {"path": path, "content": content}
     elif tool_name == "Edit" or tool_name == "StrReplace":
         path = tool_input.get("path") or tool_input.get("file_path", "")
-        return "Edit file", to_relative(path), {"path": path}
+        old_string = _cap_text(tool_input.get("old_string", ""))
+        new_string = _cap_text(tool_input.get("new_string", ""))
+        return (
+            "Edit file",
+            to_relative(path),
+            {"path": path, "old_string": old_string, "new_string": new_string},
+        )
     elif tool_name == "Delete":
         path = tool_input.get("path") or tool_input.get("file_path", "")
         return "Delete file", to_relative(path), {"path": path}
@@ -807,12 +825,14 @@ def get_tool_summary(block, working_dirs: list[str] | None = None) -> tuple[str,
     elif tool_name in ("Task", "Agent"):
         description = tool_input.get("description", "")
         subagent_type = tool_input.get("subagent_type")  # None if missing
+        prompt = _cap_text(tool_input.get("prompt", ""))
         return (
             "Spawn subagent",
             description[:100] if description else None,
             {
                 "description": description,
                 "subagent_type": subagent_type,
+                "prompt": prompt,
             },
         )
     elif tool_name == "TodoWrite":

--- a/api/utils.py
+++ b/api/utils.py
@@ -749,9 +749,7 @@ def find_best_root(path: str, working_dirs: list[str]) -> str | None:
         return None
 
 
-# Cap on free-text tool-input fields (diffs, subagent prompts) placed into
-# timeline metadata. Without this, large Edit diffs or Task prompts ship in
-# full over the timeline endpoint, which live sessions poll every second.
+# Cap on free-text tool-input fields shipped in timeline metadata, which live sessions poll every second.
 _METADATA_TEXT_LIMIT = 4000
 
 
@@ -788,7 +786,7 @@ def get_tool_summary(block, working_dirs: list[str] | None = None) -> tuple[str,
         return "Read file", to_relative(path), {"path": path}
     elif tool_name == "Write":
         path = tool_input.get("path") or tool_input.get("file_path", "")
-        content = tool_input.get("content", "")
+        content = _cap_text(tool_input.get("content", ""))
         return "Write file", to_relative(path), {"path": path, "content": content}
     elif tool_name == "Edit" or tool_name == "StrReplace":
         path = tool_input.get("path") or tool_input.get("file_path", "")

--- a/frontend/src/lib/components/timeline/TimelineEventCard.svelte
+++ b/frontend/src/lib/components/timeline/TimelineEventCard.svelte
@@ -62,14 +62,17 @@
 
 	let isCopied = $state(false);
 
-	// Sanitized markdown for expanded view — parsing/sanitizing is the expensive
-	// part, so this effect depends only on content/expansion state, NOT searchQuery.
-	// Highlighting is applied separately below as a cheap $derived over this.
+	// Sanitized markdown for expanded view; depends on content/expansion, not searchQuery (see $derived below).
 	let sanitizedExpandedContent = $state('');
 
-	// Render markdown when content changes or expansion state changes
+	// Skips tool_call/todo_update — they render via ToolCallDetail/TodoUpdateDetail instead.
 	$effect(() => {
-		if (isExpanded && hasExpandableContent) {
+		if (
+			isExpanded &&
+			hasExpandableContent &&
+			event.event_type !== 'tool_call' &&
+			event.event_type !== 'todo_update'
+		) {
 			const rawContent =
 				event.metadata?.full_content ||
 				event.metadata?.full_thinking ||
@@ -90,12 +93,13 @@
 		}
 	});
 
-	// Re-runs only the (cheap) text-node walk when searchQuery changes, not the
-	// full marked.parse + DOMPurify.sanitize pipeline.
+	// Cheap text-node walk over the already-parsed content; skips tool_call/todo_update like the effect above.
 	const renderedExpandedContent = $derived(
-		searchQuery
-			? highlightHtmlContent(sanitizedExpandedContent, searchQuery)
-			: sanitizedExpandedContent
+		event.event_type !== 'tool_call' && event.event_type !== 'todo_update'
+			? searchQuery
+				? highlightHtmlContent(sanitizedExpandedContent, searchQuery)
+				: sanitizedExpandedContent
+			: ''
 	);
 
 	// Get event configuration
@@ -170,22 +174,27 @@
 		event.actor_type === 'subagent' && (!currentAgentId || event.actor !== currentAgentId)
 	);
 
-	// True when the event matched the search, but the match is buried in content
-	// that isn't shown on the collapsed card (e.g. full_content/full_thinking) —
-	// title + visible summary don't contain it, so there's nothing here to highlight.
+	// True when the event matched the search but the match is buried in content not shown on the collapsed card.
 	const hasHiddenMatch = $derived.by(() => {
-		// Once expanded, any match in full_content/full_thinking/etc. is already
-		// visible (rendered inline via ToolCallDetail or the generic markdown
-		// block below) — the dot would otherwise keep claiming it's still hidden.
+		// Expanded content is already visible via ToolCallDetail/the markdown block below.
 		if (isExpanded) return false;
 		const trimmedQuery = searchQuery.trim();
 		if (!trimmedQuery) return false;
-		const visibleSummary = event.summary
-			? isExpanded
-				? event.summary
-				: truncate(event.summary, 100)
-			: '';
-		const visibleText = `${displayTitle} ${visibleSummary}`.toLowerCase();
+
+		const visibleParts = [displayTitle];
+		if (event.summary && event.event_type !== 'todo_update') {
+			visibleParts.push(truncate(event.summary, 100));
+		}
+		if (toolName && event.event_type === 'tool_call') visibleParts.push(toolName);
+		if (shouldShowActorBadge) visibleParts.push(event.actor);
+		if (event.event_type === 'todo_update' && todosArray.length <= 3) {
+			// Mirrors TodoUpdateDetail's own inlineLimit (beyond 3 it shows a "click to see all" hint, not content).
+			for (const todo of todosArray) {
+				visibleParts.push(todo.content);
+				if (todo.status === 'in_progress' && todo.activeForm) visibleParts.push(todo.activeForm);
+			}
+		}
+		const visibleText = visibleParts.join(' ').toLowerCase();
 		if (visibleText.includes(trimmedQuery.toLowerCase())) return false;
 		return matchesSearch(event, searchQuery);
 	});

--- a/frontend/src/lib/components/timeline/TimelineEventCard.svelte
+++ b/frontend/src/lib/components/timeline/TimelineEventCard.svelte
@@ -17,6 +17,8 @@
 	import TodoUpdateDetail from './TodoUpdateDetail.svelte';
 	import ImageAttachments from '$lib/components/ImageAttachments.svelte';
 	import { markdownCopyButtons } from '$lib/actions/markdownCopyButtons';
+	import { highlightPlainText, highlightHtmlContent } from '$lib/utils/highlight';
+	import { matchesSearch } from '$lib/utils/timelineLogic.svelte';
 
 	interface Props {
 		event: TimelineEvent;
@@ -60,8 +62,10 @@
 
 	let isCopied = $state(false);
 
-	// Rendered markdown content for expanded view
-	let renderedExpandedContent = $state('');
+	// Sanitized markdown for expanded view — parsing/sanitizing is the expensive
+	// part, so this effect depends only on content/expansion state, NOT searchQuery.
+	// Highlighting is applied separately below as a cheap $derived over this.
+	let sanitizedExpandedContent = $state('');
 
 	// Render markdown when content changes or expansion state changes
 	$effect(() => {
@@ -71,19 +75,28 @@
 				event.metadata?.full_thinking ||
 				event.metadata?.full_text ||
 				event.metadata?.result_content ||
+				(event.metadata?.prompt as string | undefined) ||
 				event.summary ||
 				'';
 
 			const parsed = marked.parse(rawContent);
 			if (parsed instanceof Promise) {
 				parsed.then((html) => {
-					renderedExpandedContent = DOMPurify.sanitize(html);
+					sanitizedExpandedContent = DOMPurify.sanitize(html);
 				});
 			} else {
-				renderedExpandedContent = DOMPurify.sanitize(parsed);
+				sanitizedExpandedContent = DOMPurify.sanitize(parsed);
 			}
 		}
 	});
+
+	// Re-runs only the (cheap) text-node walk when searchQuery changes, not the
+	// full marked.parse + DOMPurify.sanitize pipeline.
+	const renderedExpandedContent = $derived(
+		searchQuery
+			? highlightHtmlContent(sanitizedExpandedContent, searchQuery)
+			: sanitizedExpandedContent
+	);
 
 	// Get event configuration
 	const isPlanEvent = $derived(
@@ -138,6 +151,7 @@
 			event.metadata?.full_thinking ||
 			event.metadata?.full_text ||
 			event.metadata?.result_content ||
+			event.metadata?.prompt ||
 			(event.summary && event.summary.length > 100)
 	);
 
@@ -156,18 +170,26 @@
 		event.actor_type === 'subagent' && (!currentAgentId || event.actor !== currentAgentId)
 	);
 
-	function highlightText(text: string, query: string): string {
-		if (!query || !text) return text;
-		// Escape HTML entities first to prevent XSS
-		const safeText = text
-			.replace(/&/g, '&amp;')
-			.replace(/</g, '&lt;')
-			.replace(/>/g, '&gt;')
-			.replace(/"/g, '&quot;');
-		const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-		const regex = new RegExp(`(${escaped})`, 'gi');
-		return safeText.replace(regex, '<mark class="search-highlight">$1</mark>');
-	}
+	// True when the event matched the search, but the match is buried in content
+	// that isn't shown on the collapsed card (e.g. full_content/full_thinking) —
+	// title + visible summary don't contain it, so there's nothing here to highlight.
+	const hasHiddenMatch = $derived.by(() => {
+		// Once expanded, any match in full_content/full_thinking/etc. is already
+		// visible (rendered inline via ToolCallDetail or the generic markdown
+		// block below) — the dot would otherwise keep claiming it's still hidden.
+		if (isExpanded) return false;
+		const trimmedQuery = searchQuery.trim();
+		if (!trimmedQuery) return false;
+		const visibleSummary = event.summary
+			? isExpanded
+				? event.summary
+				: truncate(event.summary, 100)
+			: '';
+		const visibleText = `${displayTitle} ${visibleSummary}`.toLowerCase();
+		if (visibleText.includes(trimmedQuery.toLowerCase())) return false;
+		return matchesSearch(event, searchQuery);
+	});
+
 </script>
 
 <div
@@ -271,7 +293,7 @@
 				<div class="flex items-center gap-2 flex-wrap">
 					<span class="font-medium text-[var(--text-primary)]">
 						{#if searchQuery}
-							{@html highlightText(displayTitle, searchQuery)}
+							{@html highlightPlainText(displayTitle, searchQuery)}
 						{:else}
 							{displayTitle}
 						{/if}
@@ -336,7 +358,7 @@
 				{#if event.summary && event.event_type !== 'todo_update'}
 					<p class="font-mono text-xs text-[var(--text-muted)]">
 						{#if searchQuery}
-							{@html highlightText(
+							{@html highlightPlainText(
 								isExpanded ? event.summary : truncate(event.summary, 100),
 								searchQuery
 							)}
@@ -354,6 +376,7 @@
 							action={event.metadata?.action as 'set' | 'merge' | undefined}
 							agentSlug={event.metadata?.agent_slug as string | undefined}
 							{isExpanded}
+							{searchQuery}
 						/>
 					</div>
 				{/if}
@@ -384,6 +407,12 @@
 
 			<!-- Timestamp and expand -->
 			<div class="flex items-center gap-2 shrink-0">
+				{#if hasHiddenMatch}
+					<span
+						class="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--warning)]"
+						title="Search match found in expanded content"
+					></span>
+				{/if}
 				<span
 					class="whitespace-nowrap font-mono text-xs text-[var(--text-muted)]/70 tabular-nums"
 					title={formatDate(event.timestamp)}
@@ -410,7 +439,7 @@
 		{#if isExpanded && hasExpandableContent && !usePopup}
 			<!-- Tool call detail - use specialized component -->
 			{#if event.event_type === 'tool_call'}
-				<ToolCallDetail {event} {projectPath} />
+				<ToolCallDetail {event} {projectPath} {searchQuery} />
 			{:else if event.event_type !== 'todo_update'}
 				<!-- Non-tool-call, non-todo content (prompts, thinking, responses) -->
 				<div class="mt-3 border-t border-[var(--border)] pt-3 relative">
@@ -438,6 +467,7 @@
 									event.metadata?.full_thinking ||
 									event.metadata?.full_text ||
 									event.metadata?.result_content ||
+									(event.metadata?.prompt as string | undefined) ||
 									event.summary ||
 									'';
 								navigator.clipboard.writeText(content);

--- a/frontend/src/lib/components/timeline/TimelineFilterBar.svelte
+++ b/frontend/src/lib/components/timeline/TimelineFilterBar.svelte
@@ -43,8 +43,7 @@
 		class: className = ''
 	}: Props = $props();
 
-	// Debounce the (expensive — full metadata scan across every event)
-	// downstream search so it doesn't re-run on every keystroke.
+	// Debounces the downstream search (a full metadata scan) so it doesn't re-run on every keystroke.
 	let debounceTimeout: ReturnType<typeof setTimeout>;
 	function handleSearchInput(value: string) {
 		clearTimeout(debounceTimeout);
@@ -56,10 +55,7 @@
 	}
 	onDestroy(() => clearTimeout(debounceTimeout));
 
-	// If searchQuery changes from outside this component (e.g. the Cmd+F bar
-	// clearing it on Escape), cancel any pending debounced edit — otherwise a
-	// stale keystroke fires after the external change and resurrects a query
-	// the user just cleared.
+	// Cancels a pending debounced edit on external searchQuery changes, so a stale keystroke can't resurrect a cleared query.
 	$effect(() => {
 		void searchQuery;
 		clearTimeout(debounceTimeout);

--- a/frontend/src/lib/components/timeline/TimelineFilterBar.svelte
+++ b/frontend/src/lib/components/timeline/TimelineFilterBar.svelte
@@ -16,6 +16,7 @@
 		Plug,
 		ClipboardList
 	} from 'lucide-svelte';
+	import { onDestroy } from 'svelte';
 	import type { FilterCategory, FilterCounts } from '$lib/api-types';
 
 	interface Props {
@@ -41,6 +42,28 @@
 		onSearchChange,
 		class: className = ''
 	}: Props = $props();
+
+	// Debounce the (expensive — full metadata scan across every event)
+	// downstream search so it doesn't re-run on every keystroke.
+	let debounceTimeout: ReturnType<typeof setTimeout>;
+	function handleSearchInput(value: string) {
+		clearTimeout(debounceTimeout);
+		debounceTimeout = setTimeout(() => onSearchChange(value), 200);
+	}
+	function clearSearch() {
+		clearTimeout(debounceTimeout);
+		onSearchChange('');
+	}
+	onDestroy(() => clearTimeout(debounceTimeout));
+
+	// If searchQuery changes from outside this component (e.g. the Cmd+F bar
+	// clearing it on Escape), cancel any pending debounced edit — otherwise a
+	// stale keystroke fires after the external change and resurrects a query
+	// the user just cleared.
+	$effect(() => {
+		void searchQuery;
+		clearTimeout(debounceTimeout);
+	});
 
 	// Color mapping for each filter category - matches timeline event node colors
 	const filterColors: Record<
@@ -236,7 +259,7 @@
 			<input
 				type="text"
 				value={searchQuery}
-				oninput={(e) => onSearchChange(e.currentTarget.value)}
+				oninput={(e) => handleSearchInput(e.currentTarget.value)}
 				placeholder="Search events..."
 				data-timeline-search="true"
 				class="
@@ -252,7 +275,7 @@
 			/>
 			{#if searchQuery}
 				<button
-					onclick={() => onSearchChange('')}
+					onclick={clearSearch}
 					class="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-[var(--text-primary)]"
 				>
 					<X size={12} strokeWidth={2} />

--- a/frontend/src/lib/components/timeline/TimelineRail.svelte
+++ b/frontend/src/lib/components/timeline/TimelineRail.svelte
@@ -5,7 +5,7 @@
 	import { marked } from 'marked';
 	import DOMPurify from 'isomorphic-dompurify';
 	import type { TimelineEvent } from '$lib/api-types';
-	import { createTimelineLogic } from '$lib/utils/timelineLogic.svelte';
+	import { createTimelineLogic, matchesSearch } from '$lib/utils/timelineLogic.svelte';
 	import { formatDate } from '$lib/utils';
 	import TimelineFilterBar from './TimelineFilterBar.svelte';
 	import TimelineEventCard from './TimelineEventCard.svelte';
@@ -15,6 +15,7 @@
 	import TodoUpdateDetail from './TodoUpdateDetail.svelte';
 	import ImageAttachments from '$lib/components/ImageAttachments.svelte';
 	import { markdownCopyButtons } from '$lib/actions/markdownCopyButtons';
+	import { highlightHtmlContent } from '$lib/utils/highlight';
 
 	interface Props {
 		events: TimelineEvent[];
@@ -65,8 +66,10 @@
 	const isPopupOpen = $derived(popupEvent !== null);
 	let isCopied = $state(false);
 
-	// Rendered markdown content for popup modal
-	let renderedPopupContent = $state('');
+	// Sanitized markdown content for popup modal — parsing/sanitizing is the
+	// expensive part, so this effect depends only on popupEvent, NOT the search
+	// query. Highlighting is applied separately below as a cheap $derived.
+	let sanitizedPopupContent = $state('');
 
 	// Render markdown when popup opens or content changes
 	$effect(() => {
@@ -76,16 +79,17 @@
 				popupEvent.metadata?.full_thinking ||
 				popupEvent.metadata?.full_text ||
 				popupEvent.metadata?.result_content ||
+				(popupEvent.metadata?.prompt as string | undefined) ||
 				popupEvent.summary ||
 				'';
 
 			const parsed = marked.parse(rawContent);
 			if (parsed instanceof Promise) {
 				parsed.then((html) => {
-					renderedPopupContent = DOMPurify.sanitize(html);
+					sanitizedPopupContent = DOMPurify.sanitize(html);
 				});
 			} else {
-				renderedPopupContent = DOMPurify.sanitize(parsed);
+				sanitizedPopupContent = DOMPurify.sanitize(parsed);
 			}
 		}
 	});
@@ -126,6 +130,14 @@
 		currentAgentIdGetter: () => currentAgentId
 	});
 
+	// Re-runs only the (cheap) text-node walk when the search query changes,
+	// not the full marked.parse + DOMPurify.sanitize pipeline.
+	const renderedPopupContent = $derived(
+		timeline.searchQuery
+			? highlightHtmlContent(sanitizedPopupContent, timeline.searchQuery)
+			: sanitizedPopupContent
+	);
+
 	// Pre-compute visible events (excluding gaps) for correct indexing
 	const visibleEvents = $derived(timeline.viewItems.filter((i) => !('type' in i)));
 
@@ -138,6 +150,7 @@
 			event.metadata?.full_thinking ||
 			event.metadata?.full_text ||
 			event.metadata?.result_content ||
+			event.metadata?.prompt ||
 			(event.summary && event.summary.length > 100)
 		);
 	}
@@ -169,25 +182,12 @@
 		return () => window.removeEventListener('keydown', onKeyDown);
 	});
 
-	// Search match tracking
+	// Search match tracking — shares matchesSearch (and its memoized haystack)
+	// with the filter bar / card highlighting so the "N matches" count here
+	// never contradicts what's actually visible and marked on screen.
 	let searchMatchIds = $derived.by<string[]>(() => {
-		if (!searchQuery) return [];
-		const q = searchQuery.toLowerCase();
-		return events
-			.filter((e) => {
-				const text = [
-					e.summary,
-					e.title,
-					e.metadata?.full_content,
-					e.metadata?.full_text,
-					e.metadata?.full_thinking
-				]
-					.filter(Boolean)
-					.join(' ')
-					.toLowerCase();
-				return text.includes(q);
-			})
-			.map((e) => e.id);
+		if (!timeline.searchQuery.trim()) return [];
+		return events.filter((e) => matchesSearch(e, timeline.searchQuery)).map((e) => e.id);
 	});
 
 	let currentMatchIdx = $state(0);
@@ -204,11 +204,11 @@
 		onCurrentMatchChange?.(currentMatchIdx);
 	});
 
-	// When search query changes, also update TimelineFilterBar's search if searchQuery is set externally
+	// Sync the external (Cmd+F) search query into the timeline's own search state,
+	// including when it's cleared — otherwise Escape closes the search bar but
+	// leaves every card's highlights and the filtered view stuck in place.
 	$effect(() => {
-		if (searchQuery) {
-			timeline.setSearchQuery(searchQuery);
-		}
+		timeline.setSearchQuery(searchQuery);
 	});
 
 	// Container ref for scroll management
@@ -348,7 +348,7 @@
 						{currentAgentId}
 						{projectPath}
 						onToggleHide={() => timeline.toggleHide(eventItem.id)}
-						{searchQuery}
+						searchQuery={timeline.searchQuery}
 					/>
 				{/if}
 			{/each}
@@ -419,7 +419,7 @@
 
 		<div class="max-h-[70vh] overflow-auto break-words">
 			{#if popupEvent.event_type === 'tool_call'}
-				<ToolCallDetail event={popupEvent} {projectPath} />
+				<ToolCallDetail event={popupEvent} {projectPath} searchQuery={timeline.searchQuery} />
 			{:else if popupEvent.event_type === 'todo_update'}
 				{@const todos = Array.isArray(popupEvent.metadata?.todos)
 					? popupEvent.metadata.todos
@@ -429,6 +429,7 @@
 					action={popupEvent.metadata?.action as 'set' | 'merge' | undefined}
 					agentSlug={popupEvent.metadata?.agent_slug as string | undefined}
 					isExpanded={true}
+					searchQuery={timeline.searchQuery}
 				/>
 			{:else}
 				<!-- Generic content display for prompts, thinking, responses -->
@@ -456,6 +457,7 @@
 								popupEvent?.metadata?.full_thinking ||
 								popupEvent?.metadata?.full_text ||
 								popupEvent?.metadata?.result_content ||
+								(popupEvent?.metadata?.prompt as string | undefined) ||
 								popupEvent?.summary ||
 								'';
 							navigator.clipboard.writeText(content);

--- a/frontend/src/lib/components/timeline/TimelineRail.svelte
+++ b/frontend/src/lib/components/timeline/TimelineRail.svelte
@@ -66,14 +66,16 @@
 	const isPopupOpen = $derived(popupEvent !== null);
 	let isCopied = $state(false);
 
-	// Sanitized markdown content for popup modal — parsing/sanitizing is the
-	// expensive part, so this effect depends only on popupEvent, NOT the search
-	// query. Highlighting is applied separately below as a cheap $derived.
+	// Sanitized markdown content for popup modal; depends on popupEvent, not the search query (see $derived below).
 	let sanitizedPopupContent = $state('');
 
-	// Render markdown when popup opens or content changes
+	// Skips tool_call/todo_update — they render via ToolCallDetail/TodoUpdateDetail instead.
 	$effect(() => {
-		if (popupEvent) {
+		if (
+			popupEvent &&
+			popupEvent.event_type !== 'tool_call' &&
+			popupEvent.event_type !== 'todo_update'
+		) {
 			const rawContent =
 				popupEvent.metadata?.full_content ||
 				popupEvent.metadata?.full_thinking ||
@@ -130,12 +132,13 @@
 		currentAgentIdGetter: () => currentAgentId
 	});
 
-	// Re-runs only the (cheap) text-node walk when the search query changes,
-	// not the full marked.parse + DOMPurify.sanitize pipeline.
+	// Cheap text-node walk over the already-parsed content; skips tool_call/todo_update like the effect above.
 	const renderedPopupContent = $derived(
-		timeline.searchQuery
-			? highlightHtmlContent(sanitizedPopupContent, timeline.searchQuery)
-			: sanitizedPopupContent
+		popupEvent && popupEvent.event_type !== 'tool_call' && popupEvent.event_type !== 'todo_update'
+			? timeline.searchQuery
+				? highlightHtmlContent(sanitizedPopupContent, timeline.searchQuery)
+				: sanitizedPopupContent
+			: ''
 	);
 
 	// Pre-compute visible events (excluding gaps) for correct indexing
@@ -182,9 +185,7 @@
 		return () => window.removeEventListener('keydown', onKeyDown);
 	});
 
-	// Search match tracking — shares matchesSearch (and its memoized haystack)
-	// with the filter bar / card highlighting so the "N matches" count here
-	// never contradicts what's actually visible and marked on screen.
+	// Shares matchesSearch/its haystack cache with the filter bar and cards, so the count never contradicts them.
 	let searchMatchIds = $derived.by<string[]>(() => {
 		if (!timeline.searchQuery.trim()) return [];
 		return events.filter((e) => matchesSearch(e, timeline.searchQuery)).map((e) => e.id);
@@ -204,9 +205,7 @@
 		onCurrentMatchChange?.(currentMatchIdx);
 	});
 
-	// Sync the external (Cmd+F) search query into the timeline's own search state,
-	// including when it's cleared — otherwise Escape closes the search bar but
-	// leaves every card's highlights and the filtered view stuck in place.
+	// Syncs the external (Cmd+F) search query, including clears, so Escape doesn't leave stale highlights.
 	$effect(() => {
 		timeline.setSearchQuery(searchQuery);
 	});
@@ -482,4 +481,3 @@
 		</div>
 	</Modal>
 {/if}
-```

--- a/frontend/src/lib/components/timeline/TodoUpdateDetail.svelte
+++ b/frontend/src/lib/components/timeline/TodoUpdateDetail.svelte
@@ -9,6 +9,7 @@
 		Bot
 	} from 'lucide-svelte';
 	import type { TodoItem } from '$lib/api-types';
+	import { highlightPlainText } from '$lib/utils/highlight';
 
 	interface Props {
 		todos: TodoItem[];
@@ -16,9 +17,18 @@
 		agentSlug?: string;
 		isExpanded?: boolean;
 		class?: string;
+		/** Search query for highlighting matches in todo content */
+		searchQuery?: string;
 	}
 
-	let { todos, action, agentSlug, isExpanded = false, class: className = '' }: Props = $props();
+	let {
+		todos,
+		action,
+		agentSlug,
+		isExpanded = false,
+		class: className = '',
+		searchQuery = ''
+	}: Props = $props();
 
 	// Calculate counts
 	const completed = $derived(todos.filter((t) => t.status === 'completed').length);
@@ -35,6 +45,8 @@
 	const completedPercent = $derived(total > 0 ? (completed / total) * 100 : 0);
 	const inProgressPercent = $derived(total > 0 ? (inProgress / total) * 100 : 0);
 </script>
+
+{#snippet hl(text: string)}{#if searchQuery}{@html highlightPlainText(text, searchQuery)}{:else}{text}{/if}{/snippet}
 
 <div class="space-y-3 {className}">
 	<!-- Header badges -->
@@ -129,11 +141,11 @@
 								? 'text-[var(--text-muted)] line-through'
 								: 'text-[var(--text-primary)]'}"
 						>
-							{todo.content}
+							{@render hl(todo.content)}
 						</p>
 						{#if todo.status === 'in_progress' && todo.activeForm}
 							<p class="text-xs text-[var(--warning)] mt-0.5 italic">
-								{todo.activeForm}...
+								{@render hl(todo.activeForm)}...
 							</p>
 						{/if}
 					</div>
@@ -193,11 +205,11 @@
 							{#if todos.length > 5}
 								<span class="text-[var(--text-muted)] mr-1">{index + 1}.</span>
 							{/if}
-							{todo.content}
+							{@render hl(todo.content)}
 						</p>
 						{#if todo.status === 'in_progress' && todo.activeForm}
 							<p class="text-xs text-[var(--warning)] mt-0.5 italic">
-								{todo.activeForm}...
+								{@render hl(todo.activeForm)}...
 							</p>
 						{/if}
 					</div>

--- a/frontend/src/lib/components/timeline/ToolCallDetail.svelte
+++ b/frontend/src/lib/components/timeline/ToolCallDetail.svelte
@@ -39,9 +39,7 @@
 
 	let copiedSection = $state<string | null>(null);
 
-	// Sanitized plan markdown — parsing/sanitizing is the expensive part, so
-	// this effect depends only on toolName/input, NOT searchQuery. Highlighting
-	// is applied separately below as a cheap $derived over this.
+	// Sanitized plan markdown; depends on toolName/input, not searchQuery (see $derived below).
 	let sanitizedPlanHtml = $state('');
 
 	// Extract tool metadata
@@ -105,8 +103,7 @@
 		}
 	});
 
-	// Re-runs only the (cheap) text-node walk when searchQuery changes, not the
-	// full marked.parse + DOMPurify.sanitize pipeline.
+	// Cheap text-node walk over the already-parsed content, re-run on searchQuery change only.
 	const renderedPlanHtml = $derived(
 		searchQuery ? highlightHtmlContent(sanitizedPlanHtml, searchQuery) : sanitizedPlanHtml
 	);
@@ -253,12 +250,8 @@
 		return val != null && val !== '';
 	}
 
-	// Cap large free-text blocks (Write content, Edit diffs, Task prompts, the
-	// default JSON dump) before display/highlighting — these are only ever
-	// shown in a max-h-80 scroll box anyway, so highlighting the untruncated
-	// string (which can be multi-MB) wastes cycles clipped content never uses.
-	// Copy-to-clipboard buttons still use the original, untruncated string.
-	const DISPLAY_TRUNCATE_LENGTH = 2000;
+	// Caps free-text blocks for display; matches the server's _METADATA_TEXT_LIMIT (api/utils.py).
+	const DISPLAY_TRUNCATE_LENGTH = 4000;
 	function truncateForDisplay(text: string, maxLength = DISPLAY_TRUNCATE_LENGTH): string {
 		return text.length > maxLength ? text.slice(0, maxLength) + '\n... [truncated]' : text;
 	}
@@ -486,10 +479,11 @@
 
 			<!-- Bash/Shell Tool -->
 		{:else if toolName === 'Bash' || toolName === 'Shell'}
+			{@const displayCommand = truncateForDisplay(String(input.command || ''))}
 			<div
 				class="font-mono text-sm bg-[var(--bg-muted)] rounded-[var(--radius-md)] p-3 flex items-center justify-between gap-2"
 			>
-				<pre class="text-[var(--event-tool)] overflow-x-auto flex-1">$ {#if searchQuery}{@html highlightPlainText(String(input.command || ''), searchQuery)}{:else}{input.command || ''}{/if}</pre>
+				<pre class="text-[var(--event-tool)] overflow-x-auto flex-1">$ {#if searchQuery}{@html highlightPlainText(displayCommand, searchQuery)}{:else}{displayCommand}{/if}</pre>
 				{#if hasValue(input.command)}
 					<button
 						onclick={(e) => {

--- a/frontend/src/lib/components/timeline/ToolCallDetail.svelte
+++ b/frontend/src/lib/components/timeline/ToolCallDetail.svelte
@@ -25,17 +25,24 @@
 	import DOMPurify from 'isomorphic-dompurify';
 	import type { TimelineEvent } from '$lib/api-types';
 	import { formatDisplayPath } from '$lib/utils';
+	import { highlightPlainText, highlightHtmlContent } from '$lib/utils/highlight';
 
 	interface Props {
 		event: TimelineEvent;
 		projectPath?: string | null;
 		class?: string;
+		/** Search query for highlighting matches in content blocks */
+		searchQuery?: string;
 	}
 
-	let { event, projectPath = null, class: className = '' }: Props = $props();
+	let { event, projectPath = null, class: className = '', searchQuery = '' }: Props = $props();
 
 	let copiedSection = $state<string | null>(null);
-	let renderedPlanHtml = $state('');
+
+	// Sanitized plan markdown — parsing/sanitizing is the expensive part, so
+	// this effect depends only on toolName/input, NOT searchQuery. Highlighting
+	// is applied separately below as a cheap $derived over this.
+	let sanitizedPlanHtml = $state('');
 
 	// Extract tool metadata
 	const toolName = $derived(event.metadata?.tool_name as string | undefined);
@@ -90,13 +97,19 @@
 			const parsed = marked.parse(raw);
 			if (parsed instanceof Promise) {
 				parsed.then((html) => {
-					renderedPlanHtml = DOMPurify.sanitize(html);
+					sanitizedPlanHtml = DOMPurify.sanitize(html);
 				});
 			} else {
-				renderedPlanHtml = DOMPurify.sanitize(parsed);
+				sanitizedPlanHtml = DOMPurify.sanitize(parsed);
 			}
 		}
 	});
+
+	// Re-runs only the (cheap) text-node walk when searchQuery changes, not the
+	// full marked.parse + DOMPurify.sanitize pipeline.
+	const renderedPlanHtml = $derived(
+		searchQuery ? highlightHtmlContent(sanitizedPlanHtml, searchQuery) : sanitizedPlanHtml
+	);
 
 	// Task tool detection
 	const isTaskTool = $derived(
@@ -240,12 +253,24 @@
 		return val != null && val !== '';
 	}
 
+	// Cap large free-text blocks (Write content, Edit diffs, Task prompts, the
+	// default JSON dump) before display/highlighting — these are only ever
+	// shown in a max-h-80 scroll box anyway, so highlighting the untruncated
+	// string (which can be multi-MB) wastes cycles clipped content never uses.
+	// Copy-to-clipboard buttons still use the original, untruncated string.
+	const DISPLAY_TRUNCATE_LENGTH = 2000;
+	function truncateForDisplay(text: string, maxLength = DISPLAY_TRUNCATE_LENGTH): string {
+		return text.length > maxLength ? text.slice(0, maxLength) + '\n... [truncated]' : text;
+	}
+
 	async function copyToClipboard(text: string, section: string) {
 		await navigator.clipboard.writeText(text);
 		copiedSection = section;
 		setTimeout(() => (copiedSection = null), 2000);
 	}
 </script>
+
+{#snippet hl(text: string)}{#if searchQuery}{@html highlightPlainText(String(text ?? ''), searchQuery)}{:else}{String(text ?? '')}{/if}{/snippet}
 
 <div class="border-t border-[var(--border)] pt-3 space-y-4 {className}">
 	<!-- Input Section -->
@@ -259,10 +284,10 @@
 			<div
 				class="font-mono text-sm bg-[var(--bg-muted)] rounded-[var(--radius-md)] p-3 flex items-center justify-between gap-2"
 			>
-				<div title={String(input.file_path || '')}>
+				<div title={String(input.file_path || input.path || '')}>
 					<span class="text-[var(--event-prompt)]">Reading:</span>
 					<span class="text-[var(--text-primary)] ml-1"
-						>{formatDisplayPath(String(input.file_path || ''), projectPath)}</span
+						>{@render hl(formatDisplayPath(String(input.file_path || input.path || ''), projectPath))}</span
 					>
 					{#if input.offset != null && input.limit != null}
 						<span class="text-[var(--text-muted)]">
@@ -270,11 +295,11 @@
 						</span>
 					{/if}
 				</div>
-				{#if hasValue(input.file_path)}
+				{#if hasValue(input.file_path || input.path)}
 					<button
 						onclick={(e) => {
 							e.stopPropagation();
-							copyToClipboard(String(input.file_path), 'file_path');
+							copyToClipboard(String(input.file_path || input.path), 'file_path');
 						}}
 						class="p-1 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-subtle)] transition-colors"
 						title="Copy path"
@@ -294,17 +319,17 @@
 				<div
 					class="font-mono text-sm bg-[var(--bg-muted)] rounded-[var(--radius-md)] p-3 flex items-center justify-between gap-2"
 				>
-					<div title={String(input.file_path || '')}>
+					<div title={String(input.file_path || input.path || '')}>
 						<span class="text-[var(--success)]">Creating:</span>
 						<span class="text-[var(--text-primary)] ml-1"
-							>{formatDisplayPath(String(input.file_path || ''), projectPath)}</span
+							>{@render hl(formatDisplayPath(String(input.file_path || input.path || ''), projectPath))}</span
 						>
 					</div>
-					{#if hasValue(input.file_path)}
+					{#if hasValue(input.file_path || input.path)}
 						<button
 							onclick={(e) => {
 								e.stopPropagation();
-								copyToClipboard(String(input.file_path), 'file_path');
+								copyToClipboard(String(input.file_path || input.path), 'file_path');
 							}}
 							class="p-1 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-subtle)] transition-colors"
 							title="Copy path"
@@ -319,6 +344,7 @@
 				</div>
 				{#if hasValue(input.content)}
 					{@const content = String(input.content)}
+					{@const displayContent = truncateForDisplay(content)}
 					{@const lineCount = content.replace(/\n$/, '').split('\n').length || 1}
 					<div
 						class="rounded-[var(--radius-md)] border border-[var(--border)] p-3 relative"
@@ -351,7 +377,7 @@
 						</div>
 						<div class="max-h-80 overflow-y-auto">
 							<pre
-								class="font-mono text-xs whitespace-pre-wrap break-words text-[var(--text-secondary)]">{content}</pre>
+								class="font-mono text-xs whitespace-pre-wrap break-words text-[var(--text-secondary)]">{#if searchQuery}{@html highlightPlainText(displayContent, searchQuery)}{:else}{displayContent}{/if}</pre>
 						</div>
 					</div>
 				{/if}
@@ -363,17 +389,17 @@
 				<div
 					class="font-mono text-sm bg-[var(--bg-muted)] rounded-[var(--radius-md)] p-3 flex items-center justify-between gap-2"
 				>
-					<div title={String(input.file_path || '')}>
+					<div title={String(input.file_path || input.path || '')}>
 						<span class="text-[var(--event-thinking)]">Editing:</span>
 						<span class="text-[var(--text-primary)] ml-1"
-							>{formatDisplayPath(String(input.file_path || ''), projectPath)}</span
+							>{@render hl(formatDisplayPath(String(input.file_path || input.path || ''), projectPath))}</span
 						>
 					</div>
-					{#if hasValue(input.file_path)}
+					{#if hasValue(input.file_path || input.path)}
 						<button
 							onclick={(e) => {
 								e.stopPropagation();
-								copyToClipboard(String(input.file_path), 'file_path');
+								copyToClipboard(String(input.file_path || input.path), 'file_path');
 							}}
 							class="p-1 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-subtle)] transition-colors"
 							title="Copy path"
@@ -390,6 +416,7 @@
 				<!-- Original (old_string) -->
 				{#if hasValue(input.old_string)}
 					{@const content = String(input.old_string)}
+					{@const displayContent = truncateForDisplay(content)}
 					<div
 						class="rounded-[var(--radius-md)] border border-red-500/20 bg-red-500/5 p-3 relative"
 					>
@@ -414,14 +441,17 @@
 								{/if}
 							</button>
 						</div>
-						<pre
-							class="font-mono text-xs whitespace-pre-wrap break-words text-red-300">{content}</pre>
+						<div class="max-h-80 overflow-y-auto">
+							<pre
+								class="font-mono text-xs whitespace-pre-wrap break-words text-red-300">{#if searchQuery}{@html highlightPlainText(displayContent, searchQuery)}{:else}{displayContent}{/if}</pre>
+						</div>
 					</div>
 				{/if}
 
 				<!-- Replacement (new_string) -->
 				{#if hasValue(input.new_string)}
 					{@const content = String(input.new_string)}
+					{@const displayContent = truncateForDisplay(content)}
 					<div
 						class="rounded-[var(--radius-md)] border border-green-500/20 bg-green-500/5 p-3 relative"
 					>
@@ -446,8 +476,10 @@
 								{/if}
 							</button>
 						</div>
-						<pre
-							class="font-mono text-xs whitespace-pre-wrap break-words text-green-300">{content}</pre>
+						<div class="max-h-80 overflow-y-auto">
+							<pre
+								class="font-mono text-xs whitespace-pre-wrap break-words text-green-300">{#if searchQuery}{@html highlightPlainText(displayContent, searchQuery)}{:else}{displayContent}{/if}</pre>
+						</div>
 					</div>
 				{/if}
 			</div>
@@ -457,8 +489,7 @@
 			<div
 				class="font-mono text-sm bg-[var(--bg-muted)] rounded-[var(--radius-md)] p-3 flex items-center justify-between gap-2"
 			>
-				<pre class="text-[var(--event-tool)] overflow-x-auto flex-1">$ {input.command ||
-						''}</pre>
+				<pre class="text-[var(--event-tool)] overflow-x-auto flex-1">$ {#if searchQuery}{@html highlightPlainText(String(input.command || ''), searchQuery)}{:else}{input.command || ''}{/if}</pre>
 				{#if hasValue(input.command)}
 					<button
 						onclick={(e) => {
@@ -481,10 +512,10 @@
 		{:else if toolName === 'Glob'}
 			<div class="font-mono text-sm bg-[var(--bg-muted)] rounded-[var(--radius-md)] p-3">
 				<span class="text-[var(--event-subagent)]">Pattern:</span>
-				<span class="text-[var(--text-primary)] ml-1">{input.pattern || ''}</span>
+				<span class="text-[var(--text-primary)] ml-1">{@render hl(String(input.pattern || ''))}</span>
 				{#if hasValue(input.path)}
 					<span class="text-[var(--text-muted)]" title={String(input.path)}>
-						in {formatDisplayPath(String(input.path), projectPath)}</span
+						in {@render hl(formatDisplayPath(String(input.path), projectPath))}</span
 					>
 				{/if}
 			</div>
@@ -496,20 +527,20 @@
 			>
 				<div>
 					<span class="text-[var(--event-subagent)]">Pattern:</span>
-					<span class="text-[var(--text-primary)] ml-1">{input.pattern || ''}</span>
+					<span class="text-[var(--text-primary)] ml-1">{@render hl(String(input.pattern || ''))}</span>
 				</div>
 				{#if hasValue(input.path)}
 					<div title={String(input.path)}>
 						<span class="text-[var(--text-muted)]">In:</span>
 						<span class="text-[var(--text-primary)] ml-1"
-							>{formatDisplayPath(String(input.path), projectPath)}</span
+							>{@render hl(formatDisplayPath(String(input.path), projectPath))}</span
 						>
 					</div>
 				{/if}
 				{#if hasValue(input.include)}
 					<div>
 						<span class="text-[var(--text-muted)]">Include:</span>
-						<span class="text-[var(--text-primary)] ml-1">{input.include}</span>
+						<span class="text-[var(--text-primary)] ml-1">{@render hl(String(input.include))}</span>
 					</div>
 				{/if}
 			</div>
@@ -522,11 +553,12 @@
 						class="font-mono text-sm bg-[var(--bg-muted)] rounded-[var(--radius-md)] p-3"
 					>
 						<span class="text-[var(--event-subagent)]">Task:</span>
-						<span class="text-[var(--text-primary)] ml-1">{input.description}</span>
+						<span class="text-[var(--text-primary)] ml-1">{@render hl(String(input.description))}</span>
 					</div>
 				{/if}
 				{#if hasValue(input.prompt)}
 					{@const content = String(input.prompt)}
+					{@const displayContent = truncateForDisplay(content)}
 					<div
 						class="rounded-[var(--radius-md)] border border-[var(--border)] p-3 relative"
 					>
@@ -551,8 +583,10 @@
 								{/if}
 							</button>
 						</div>
-						<pre
-							class="font-mono text-xs whitespace-pre-wrap break-words text-[var(--text-secondary)]">{content}</pre>
+						<div class="max-h-80 overflow-y-auto">
+							<pre
+								class="font-mono text-xs whitespace-pre-wrap break-words text-[var(--text-secondary)]">{#if searchQuery}{@html highlightPlainText(displayContent, searchQuery)}{:else}{displayContent}{/if}</pre>
+						</div>
 					</div>
 				{/if}
 			</div>
@@ -619,7 +653,7 @@
 		{:else if toolName === 'WebSearch'}
 			<div class="font-mono text-sm bg-[var(--bg-muted)] rounded-[var(--radius-md)] p-3">
 				<span class="text-[var(--event-prompt)]">Search:</span>
-				<span class="text-[var(--text-primary)] ml-1">{input.query || ''}</span>
+				<span class="text-[var(--text-primary)] ml-1">{@render hl(String(input.query || ''))}</span>
 			</div>
 
 			<!-- WebFetch Tool -->
@@ -629,7 +663,7 @@
 			>
 				<div class="overflow-hidden">
 					<span class="text-[var(--event-prompt)]">Fetching:</span>
-					<span class="text-[var(--text-primary)] ml-1 break-all">{input.url || ''}</span>
+					<span class="text-[var(--text-primary)] ml-1 break-all">{@render hl(String(input.url || ''))}</span>
 				</div>
 				{#if hasValue(input.url)}
 					<button
@@ -673,7 +707,7 @@
 						<!-- Subject -->
 						{#if subject}
 							<p class="text-sm font-medium text-[var(--text-primary)] leading-snug">
-								{subject}
+								{@render hl(subject)}
 							</p>
 						{/if}
 						<!-- Description -->
@@ -681,14 +715,14 @@
 							<p
 								class="text-xs text-[var(--text-secondary)] leading-relaxed border-l-2 border-emerald-500/30 pl-3"
 							>
-								{description}
+								{@render hl(description)}
 							</p>
 						{/if}
 						<!-- Active form -->
 						{#if activeForm}
 							<div class="flex items-center gap-2 text-xs text-[var(--text-muted)]">
 								<RefreshCw size={11} class="animate-spin" />
-								<span class="italic">{activeForm}</span>
+								<span class="italic">{@render hl(activeForm)}</span>
 							</div>
 						{/if}
 					</div>
@@ -730,7 +764,7 @@
 							</div>
 							{#if subject || taskSubject}
 								<span class="text-xs text-[var(--text-secondary)] pl-6 truncate">
-									{subject || taskSubject}
+									{@render hl(subject || taskSubject)}
 								</span>
 							{/if}
 						</div>
@@ -756,7 +790,7 @@
 									>
 										Rename to
 									</span>
-									<span class="text-sm text-[var(--text-primary)]">{subject}</span>
+									<span class="text-sm text-[var(--text-primary)]">{@render hl(subject)}</span>
 								</div>
 							{/if}
 							{#if description}
@@ -768,7 +802,7 @@
 									</span>
 									<span
 										class="text-xs text-[var(--text-secondary)] leading-relaxed"
-										>{description}</span
+										>{@render hl(description)}</span
 									>
 								</div>
 							{/if}
@@ -783,7 +817,7 @@
 										class="inline-flex items-center gap-1 text-xs text-[var(--text-primary)]"
 									>
 										<User size={11} class="text-[var(--text-muted)]" />
-										{owner}
+										{@render hl(owner)}
 									</span>
 								</div>
 							{/if}
@@ -795,7 +829,7 @@
 										Spinner
 									</span>
 									<span class="text-xs italic text-[var(--text-muted)]"
-										>{activeForm}</span
+										>{@render hl(activeForm)}</span
 									>
 								</div>
 							{/if}
@@ -806,7 +840,7 @@
 											class="inline-flex items-center gap-1 text-[10px] text-orange-400"
 										>
 											<GitBranch size={10} />
-											blocks: {addBlocks.join(', ')}
+											blocks: {@render hl(addBlocks.join(', '))}
 										</span>
 									{/if}
 									{#if addBlockedBy.length > 0}
@@ -814,7 +848,7 @@
 											class="inline-flex items-center gap-1 text-[10px] text-orange-400"
 										>
 											<ArrowRight size={10} />
-											blocked by: {addBlockedBy.join(', ')}
+											blocked by: {@render hl(addBlockedBy.join(', '))}
 										</span>
 									{/if}
 								</div>
@@ -874,14 +908,14 @@
 						<span
 							class="font-mono text-[10px] rounded-full bg-purple-500/15 px-2.5 py-1 text-purple-300 border border-purple-500/20"
 						>
-							{server}
+							{@render hl(server)}
 						</span>
 					{/if}
 					{#if server && mcpTool}
 						<ArrowRight size={12} class="text-purple-500/40" />
 					{/if}
 					{#if mcpTool}
-						<span class="font-mono text-sm text-[var(--text-primary)]">{mcpTool}</span>
+						<span class="font-mono text-sm text-[var(--text-primary)]">{@render hl(mcpTool)}</span>
 					{/if}
 				</div>
 				<!-- MCP tool arguments -->
@@ -901,13 +935,17 @@
 											class="font-mono text-xs text-[var(--text-secondary)] break-all"
 										>
 											{#if typeof mcpArgs[key] === 'string'}
-												{String(mcpArgs[key]).length > 150
-													? String(mcpArgs[key]).slice(0, 150) + '...'
-													: mcpArgs[key]}
+												{@render hl(
+													String(mcpArgs[key]).length > 150
+														? String(mcpArgs[key]).slice(0, 150) + '...'
+														: String(mcpArgs[key])
+												)}
 											{:else}
-												{JSON.stringify(mcpArgs[key]).length > 150
-													? JSON.stringify(mcpArgs[key]).slice(0, 150) + '...'
-													: JSON.stringify(mcpArgs[key])}
+												{@render hl(
+													JSON.stringify(mcpArgs[key]).length > 150
+														? JSON.stringify(mcpArgs[key]).slice(0, 150) + '...'
+														: JSON.stringify(mcpArgs[key])
+												)}
 											{/if}
 										</span>
 									</div>
@@ -932,7 +970,7 @@
 					<FolderOpen size={15} class="text-[var(--event-tool)] shrink-0" />
 					<span class="text-[var(--event-tool)]">Listing:</span>
 					<span class="text-[var(--text-primary)]">
-						{formatDisplayPath(String(input.path || '.'), projectPath)}
+						{@render hl(formatDisplayPath(String(input.path || '.'), projectPath))}
 					</span>
 				</div>
 			</div>
@@ -946,7 +984,7 @@
 					<Trash2 size={15} class="text-red-400 shrink-0" />
 					<span class="text-red-400">Deleting:</span>
 					<span class="text-[var(--text-primary)]">
-						{formatDisplayPath(String(input.file_path || input.path || ''), projectPath)}
+						{@render hl(formatDisplayPath(String(input.file_path || input.path || ''), projectPath))}
 					</span>
 				</div>
 			</div>
@@ -971,7 +1009,7 @@
 					<span
 						class="rounded bg-[var(--event-thinking)]/15 px-2 py-0.5 text-xs font-medium text-[var(--text-primary)]"
 					>
-						{input.target_mode}
+						{@render hl(String(input.target_mode))}
 					</span>
 				{/if}
 			</div>
@@ -1007,11 +1045,11 @@
 					<div class="px-4 py-3">
 						{#if summary}
 							<p class="text-[10px] text-indigo-400/60 uppercase tracking-wide mb-1">
-								{summary}
+								{@render hl(summary)}
 							</p>
 						{/if}
 						<p class="text-xs text-[var(--text-secondary)] leading-relaxed">
-							{content.length > 200 ? content.slice(0, 200) + '...' : content}
+							{@render hl(content.length > 200 ? content.slice(0, 200) + '...' : content)}
 						</p>
 					</div>
 				{/if}
@@ -1025,9 +1063,9 @@
 				class="font-mono text-sm bg-[var(--accent)]/5 border border-[var(--accent)]/20 rounded-[var(--radius-md)] p-3 flex items-center gap-2.5"
 			>
 				<Zap size={15} class="text-[var(--accent)] shrink-0" />
-				<span class="text-[var(--accent)]">/{skillName}</span>
+				<span class="text-[var(--accent)]">/{@render hl(skillName)}</span>
 				{#if args}
-					<span class="text-[var(--text-muted)] text-xs">{args}</span>
+					<span class="text-[var(--text-muted)] text-xs">{@render hl(args)}</span>
 				{/if}
 			</div>
 
@@ -1039,7 +1077,7 @@
 			>
 				<Search size={15} class="text-[var(--text-muted)] shrink-0" />
 				<span class="text-[var(--text-muted)]">Searching tools:</span>
-				<span class="text-[var(--text-primary)]">{query}</span>
+				<span class="text-[var(--text-primary)]">{@render hl(query)}</span>
 			</div>
 
 			<!-- SemanticSearch -->
@@ -1049,7 +1087,7 @@
 			>
 				<Search size={15} class="text-[var(--event-subagent)] shrink-0" />
 				<span class="text-[var(--event-subagent)]">Semantic search:</span>
-				<span class="text-[var(--text-primary)]">{input.query || ''}</span>
+				<span class="text-[var(--text-primary)]">{@render hl(String(input.query || ''))}</span>
 			</div>
 
 			<!-- AskUserQuestion: Formatted questions with options -->
@@ -1073,7 +1111,7 @@
 									</span>
 								{/if}
 								<p class="text-sm font-medium text-[var(--text-primary)] leading-snug">
-									{q.question}
+									{@render hl(q.question)}
 								</p>
 								{#if q.multiSelect}
 									<span
@@ -1132,7 +1170,7 @@
 												: 'text-[var(--text-primary)]'}
 											"
 										>
-											{option.label}
+											{@render hl(option.label)}
 										</span>
 										{#if option.description}
 											<p
@@ -1143,7 +1181,7 @@
 													: 'text-[var(--text-muted)]'}
 												"
 											>
-												{option.description}
+												{@render hl(option.description)}
 											</p>
 										{/if}
 									</div>
@@ -1187,7 +1225,7 @@
 										<p
 											class="mt-0.5 text-sm font-medium text-[var(--success)]"
 										>
-											{getCustomAnswer(q)}
+											{@render hl(String(getCustomAnswer(q)))}
 										</p>
 									</div>
 									<span
@@ -1209,7 +1247,7 @@
 										User Note
 									</span>
 									<p class="mt-0.5 text-xs text-[var(--text-secondary)]">
-										{userNotes.get(q.question)}
+										{@render hl(String(userNotes.get(q.question)))}
 									</p>
 								</div>
 							{/if}
@@ -1221,6 +1259,7 @@
 		<!-- Default: JSON display -->
 		{:else}
 			{@const content = JSON.stringify(input, null, 2)}
+			{@const displayContent = truncateForDisplay(content)}
 			<div class="rounded-[var(--radius-md)] border border-[var(--border)] p-3 relative">
 				<div class="flex items-center justify-between gap-2 mb-2">
 					<h5
@@ -1244,7 +1283,7 @@
 					</button>
 				</div>
 				<pre
-					class="font-mono text-xs whitespace-pre-wrap break-words text-[var(--text-secondary)]">{content}</pre>
+					class="font-mono text-xs whitespace-pre-wrap break-words text-[var(--text-secondary)]">{#if searchQuery}{@html highlightPlainText(displayContent, searchQuery)}{:else}{displayContent}{/if}</pre>
 			</div>
 		{/if}
 	</div>
@@ -1275,6 +1314,7 @@
 		{@const isError = resultStatus === 'error'}
 		{@const maxLength = 1000}
 		{@const truncated = content.length > maxLength}
+		{@const displayContent = truncated ? content.slice(0, maxLength) + '\n...' : content}
 		<div>
 			<div class="flex items-center gap-2 mb-2">
 				<h4
@@ -1304,9 +1344,7 @@
 					: 'bg-[var(--bg-muted)] border-[var(--border)]'}"
 			>
 				<pre
-					class="font-mono text-xs whitespace-pre-wrap break-words text-[var(--text-secondary)]">{truncated
-						? content.slice(0, maxLength) + '\n...'
-						: content}</pre>
+					class="font-mono text-xs whitespace-pre-wrap break-words text-[var(--text-secondary)]">{#if searchQuery}{@html highlightPlainText(displayContent, searchQuery)}{:else}{displayContent}{/if}</pre>
 				{#if truncated}
 					<div class="absolute bottom-2 right-2">
 						<span

--- a/frontend/src/lib/utils/highlight.ts
+++ b/frontend/src/lib/utils/highlight.ts
@@ -1,0 +1,97 @@
+/**
+ * Search-match highlighting utilities, shared between the collapsed timeline
+ * card (plain text) and the expanded/modal views (rendered markdown HTML).
+ */
+
+import DOMPurify from 'isomorphic-dompurify';
+
+function escapeHtml(text: string): string {
+	return text
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+}
+
+function escapeRegExp(text: string): string {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Highlight matches of `query` in plain (unescaped) text, returning HTML
+ * safe for `{@html}`. Only safe for text that has NOT already been rendered
+ * to HTML.
+ *
+ * Matching happens against the RAW text, then each segment is escaped on
+ * the way out — matching against already-escaped text would let a query
+ * like "lt" match inside an entity the escaping itself produced (turning
+ * "a < b" into visible "a &lt; b"), and would make a query containing
+ * `< > & "` unmatchable even though the raw text contains it literally.
+ */
+export function highlightPlainText(text: string, query: string): string {
+	const trimmedQuery = query.trim();
+	if (!trimmedQuery || !text) return escapeHtml(text);
+
+	const regex = new RegExp(`(${escapeRegExp(trimmedQuery)})`, 'gi');
+	let result = '';
+	let lastIndex = 0;
+	let match: RegExpExecArray | null;
+	while ((match = regex.exec(text))) {
+		result += escapeHtml(text.slice(lastIndex, match.index));
+		result += `<mark class="search-highlight">${escapeHtml(match[0])}</mark>`;
+		lastIndex = match.index + match[0].length;
+	}
+	result += escapeHtml(text.slice(lastIndex));
+	return result;
+}
+
+/**
+ * Highlight matches of `query` inside already-rendered (sanitized) HTML.
+ * Walks text nodes only, so it can't corrupt tags/attributes or double-escape
+ * content — safe to run on markdown output from `marked` + DOMPurify.
+ */
+export function highlightHtmlContent(html: string, query: string): string {
+	const trimmedQuery = query.trim();
+	if (!trimmedQuery || !html || typeof document === 'undefined') return html;
+
+	const regex = new RegExp(`(${escapeRegExp(trimmedQuery)})`, 'gi');
+	const container = document.createElement('div');
+	container.innerHTML = html;
+
+	const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+	const textNodes: Text[] = [];
+	let node: Node | null;
+	while ((node = walker.nextNode())) {
+		textNodes.push(node as Text);
+	}
+
+	for (const textNode of textNodes) {
+		const value = textNode.nodeValue ?? '';
+		regex.lastIndex = 0;
+		if (!regex.test(value)) continue;
+		regex.lastIndex = 0;
+
+		const fragment = document.createDocumentFragment();
+		let lastIndex = 0;
+		let match: RegExpExecArray | null;
+		while ((match = regex.exec(value))) {
+			if (match.index > lastIndex) {
+				fragment.appendChild(document.createTextNode(value.slice(lastIndex, match.index)));
+			}
+			const mark = document.createElement('mark');
+			mark.className = 'search-highlight';
+			mark.textContent = match[0];
+			fragment.appendChild(mark);
+			lastIndex = match.index + match[0].length;
+		}
+		if (lastIndex < value.length) {
+			fragment.appendChild(document.createTextNode(value.slice(lastIndex)));
+		}
+		textNode.parentNode?.replaceChild(fragment, textNode);
+	}
+
+	// Re-sanitize: innerHTML was already sanitized once, but reading it back out
+	// and returning it as a fresh HTML string is a parse/serialize round-trip —
+	// re-sanitizing here is the cheap way to stay safe against that class of bug.
+	return DOMPurify.sanitize(container.innerHTML);
+}

--- a/frontend/src/lib/utils/highlight.ts
+++ b/frontend/src/lib/utils/highlight.ts
@@ -90,8 +90,7 @@ export function highlightHtmlContent(html: string, query: string): string {
 		textNode.parentNode?.replaceChild(fragment, textNode);
 	}
 
-	// Re-sanitize: innerHTML was already sanitized once, but reading it back out
-	// and returning it as a fresh HTML string is a parse/serialize round-trip —
-	// re-sanitizing here is the cheap way to stay safe against that class of bug.
+	// Belt-and-suspenders: content is already safe (built via createElement/
+	// textContent above), but this feeds {@html} so re-sanitize anyway.
 	return DOMPurify.sanitize(container.innerHTML);
 }

--- a/frontend/src/lib/utils/timelineLogic.svelte.ts
+++ b/frontend/src/lib/utils/timelineLogic.svelte.ts
@@ -85,28 +85,92 @@ function matchesSingleFilter(
 }
 
 /**
+ * Metadata keys that hold binary/opaque/non-searchable data — walking these
+ * produces false-positive matches (e.g. a short query matching inside a
+ * base64 image payload) and wastes cycles lowercasing multi-MB strings.
+ */
+const SEARCH_SKIP_KEYS = new Set([
+	'image_attachments',
+	'tool_id',
+	'result_timestamp',
+	'spawned_agent_id',
+	'result_parsed'
+]);
+
+/**
+ * Recursively collect every searchable string value inside `value` into `out`.
+ * Walks nested objects/arrays (e.g. MCP tool `args`) so every metadata field
+ * is searchable without hand-listing each tool's field names here, skipping
+ * SEARCH_SKIP_KEYS at any depth.
+ */
+function collectSearchableText(value: unknown, out: string[]): void {
+	if (value == null) return;
+	if (typeof value === 'string') {
+		out.push(value);
+		return;
+	}
+	if (Array.isArray(value)) {
+		for (const item of value) collectSearchableText(item, out);
+		return;
+	}
+	if (typeof value === 'object') {
+		for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+			if (SEARCH_SKIP_KEYS.has(key)) continue;
+			collectSearchableText(item, out);
+		}
+	}
+}
+
+/**
+ * Per-event lowercased "haystack" cache, keyed by event.id. Building the
+ * haystack (walking metadata, lowercasing every string) is the expensive
+ * part — this makes it happen once per event object instead of once per
+ * keystroke x call site (matchesFilters, matchingCount, and each card's
+ * hasHiddenMatch all used to run their own independent walk).
+ *
+ * Invalidated by a cheap content fingerprint, NOT object identity: a live
+ * session's poll (see ConversationView's POLL_INTERVAL_ACTIVE) replaces the
+ * entire event list with freshly-parsed objects every second even when
+ * nothing actually changed, so an identity check would rebuild every
+ * haystack every tick while a search is active. The fingerprint only needs
+ * to change when the *searchable content* changes, not the object reference.
+ */
+const haystackCache = new Map<string, { fingerprint: string; haystack: string }>();
+
+function getEventFingerprint(event: TimelineEvent): string {
+	const m = event.metadata;
+	return [
+		event.timestamp,
+		event.summary?.length ?? 0,
+		m?.result_content?.length ?? 0,
+		m?.full_content?.length ?? 0,
+		m?.full_text?.length ?? 0,
+		m?.full_thinking?.length ?? 0,
+		m?.has_result ? 1 : 0,
+		m?.result_status ?? ''
+	].join('|');
+}
+
+function getHaystack(event: TimelineEvent): string {
+	const fingerprint = getEventFingerprint(event);
+	const cached = haystackCache.get(event.id);
+	if (cached && cached.fingerprint === fingerprint) {
+		return cached.haystack;
+	}
+	const parts: string[] = [event.title, event.summary ?? '', event.actor];
+	collectSearchableText(event.metadata, parts);
+	const haystack = parts.join(' ').toLowerCase();
+	haystackCache.set(event.id, { fingerprint, haystack });
+	return haystack;
+}
+
+/**
  * Check if event matches search query
  */
-function matchesSearch(event: TimelineEvent, query: string): boolean {
-	if (!query.trim()) return true;
-	const q = query.toLowerCase();
-
-	// Check basic fields
-	if (event.title.toLowerCase().includes(q)) return true;
-	if (event.summary?.toLowerCase().includes(q)) return true;
-	if (event.actor.toLowerCase().includes(q)) return true;
-
-	// Check metadata content
-	const metadata = event.metadata || {};
-	if (metadata.tool_name?.toLowerCase().includes(q)) return true;
-	if (metadata.full_content?.toLowerCase().includes(q)) return true;
-	if (metadata.full_thinking?.toLowerCase().includes(q)) return true;
-	if (metadata.full_text?.toLowerCase().includes(q)) return true;
-	if (metadata.result_content?.toLowerCase().includes(q)) return true;
-	if (metadata.error_message && String(metadata.error_message).toLowerCase().includes(q))
-		return true;
-
-	return false;
+export function matchesSearch(event: TimelineEvent, query: string): boolean {
+	const trimmed = query.trim();
+	if (!trimmed) return true;
+	return getHaystack(event).includes(trimmed.toLowerCase());
 }
 
 /**

--- a/frontend/src/lib/utils/timelineLogic.svelte.ts
+++ b/frontend/src/lib/utils/timelineLogic.svelte.ts
@@ -84,11 +84,8 @@ function matchesSingleFilter(
 	}
 }
 
-/**
- * Metadata keys that hold binary/opaque/non-searchable data — walking these
- * produces false-positive matches (e.g. a short query matching inside a
- * base64 image payload) and wastes cycles lowercasing multi-MB strings.
- */
+// Metadata keys holding binary/opaque data — skipped to avoid false-positive
+// matches and wasted cycles lowercasing multi-MB strings.
 const SEARCH_SKIP_KEYS = new Set([
 	'image_attachments',
 	'tool_id',
@@ -97,12 +94,8 @@ const SEARCH_SKIP_KEYS = new Set([
 	'result_parsed'
 ]);
 
-/**
- * Recursively collect every searchable string value inside `value` into `out`.
- * Walks nested objects/arrays (e.g. MCP tool `args`) so every metadata field
- * is searchable without hand-listing each tool's field names here, skipping
- * SEARCH_SKIP_KEYS at any depth.
- */
+// Recursively collects every searchable string value inside `value` into `out`,
+// walking nested objects/arrays and skipping SEARCH_SKIP_KEYS at any depth.
 function collectSearchableText(value: unknown, out: string[]): void {
 	if (value == null) return;
 	if (typeof value === 'string') {
@@ -121,21 +114,12 @@ function collectSearchableText(value: unknown, out: string[]): void {
 	}
 }
 
-/**
- * Per-event lowercased "haystack" cache, keyed by event.id. Building the
- * haystack (walking metadata, lowercasing every string) is the expensive
- * part — this makes it happen once per event object instead of once per
- * keystroke x call site (matchesFilters, matchingCount, and each card's
- * hasHiddenMatch all used to run their own independent walk).
- *
- * Invalidated by a cheap content fingerprint, NOT object identity: a live
- * session's poll (see ConversationView's POLL_INTERVAL_ACTIVE) replaces the
- * entire event list with freshly-parsed objects every second even when
- * nothing actually changed, so an identity check would rebuild every
- * haystack every tick while a search is active. The fingerprint only needs
- * to change when the *searchable content* changes, not the object reference.
- */
+// Per-event lowercased "haystack" cache, invalidated by content fingerprint rather than object identity
+// (live-session polling replaces the event list every second). Cleared per session view in createTimelineLogic.
 const haystackCache = new Map<string, { fingerprint: string; haystack: string }>();
+
+// A separator no realistic query contains, so a multi-word query can't match across two fields' boundary.
+const FIELD_SEPARATOR = String.fromCharCode(0);
 
 function getEventFingerprint(event: TimelineEvent): string {
 	const m = event.metadata;
@@ -147,7 +131,10 @@ function getEventFingerprint(event: TimelineEvent): string {
 		m?.full_text?.length ?? 0,
 		m?.full_thinking?.length ?? 0,
 		m?.has_result ? 1 : 0,
-		m?.result_status ?? ''
+		m?.result_status ?? '',
+		// Structural signals so a metadata field arriving on a later poll (e.g. spawned_agent_slug) invalidates the cache.
+		m ? Object.keys(m).length : 0,
+		m?.spawned_agent_slug ?? ''
 	].join('|');
 }
 
@@ -159,7 +146,7 @@ function getHaystack(event: TimelineEvent): string {
 	}
 	const parts: string[] = [event.title, event.summary ?? '', event.actor];
 	collectSearchableText(event.metadata, parts);
-	const haystack = parts.join(' ').toLowerCase();
+	const haystack = parts.join(FIELD_SEPARATOR).toLowerCase();
 	haystackCache.set(event.id, { fingerprint, haystack });
 	return haystack;
 }
@@ -323,6 +310,9 @@ export function createTimelineLogic(
 	eventsGetter: () => TimelineEvent[],
 	options: TimelineLogicOptions = {}
 ) {
+	// New session view — event ids are session-scoped, so prior entries can never hit again.
+	haystackCache.clear();
+
 	const {
 		isTailingGetter = () => false,
 		tailCount = 3,


### PR DESCRIPTION
## Summary
- Searching a session's timeline found matches but never highlighted them once you opened a result — this wires the search query into every render path that can show one: collapsed card, inline-expanded card, modal popup, `ToolCallDetail`'s per-tool panels, and todo updates.
- Broadens which fields are actually searchable/renderable (Edit `old_string`/`new_string`, Task/Agent `prompt`), with server-side truncation so those additions don't balloon the 1s live-session poll payload.
- Fixes the correctness, performance, and security issues surfaced by two rounds of independent blind code review, including:
  - A per-event search cache that never hit on live sessions (keyed on object identity, which polling replaces every second).
  - A highlight/escape ordering bug where certain queries (`<div>`, `&&`, `"key"`) never highlighted, and others (`lt`, `amp`) corrupted rendered text.
  - A debounce race that could resurrect a search query right after it was cleared via Escape.
  - Untruncated diffs/prompts making highlighting run over multi-MB strings that are clipped to a 320px box anyway.
  - Match-count vs. what's-actually-highlighted divergence, a stuck "hidden match" indicator, whitespace-only-query false positives, and a pre-existing `input.file_path`/`path` key mismatch that left Read/Write/Edit paths blank.

## Test plan
- [x] `npm run check` (frontend) — 0 errors, same 13 pre-existing warnings
- [x] `pytest` (api) — 1795 passed, same 2 pre-existing unrelated failures (local `.storygraph.db` leak, not caused by this branch)
- [x] Both dev servers verified healthy after changes
- [x] Manual verification in-browser (search across collapsed/expanded/modal/tool-detail views, live session behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)