### PR TITLE
run Karma in a single container — Compose files + GHCR image, also reverse-proxy support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+node_modules
+frontend/node_modules
+frontend/.svelte-kit
+frontend/build
+api/*.egg-info
+**/__pycache__
+*.pyc
+.venv
+.env
+.env.*
+.DS_Store

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,52 @@
+name: Build and Publish image
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm
+FROM node:22-trixie
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,7 @@ USER node
 
 EXPOSE 8020/tcp 5180/tcp
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8020", "--app-dir", "api"]
+# Both processes share one container on purpose: SvelteKit renders server-side and
+# calls the API at http://localhost:8020 (see src/lib/config.ts), so they need the
+# same network namespace. `wait -n` exits as soon as either dies, so restart kicks in.
+CMD ["bash", "-c", "uvicorn main:app --host 0.0.0.0 --port 8020 --app-dir api & npm --prefix frontend run dev -- --host 0.0.0.0 & wait -n"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-trixie
+FROM node:26-trixie
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM node:22-bookworm
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    VIRTUAL_ENV=/opt/venv \
+    PATH=/opt/venv/bin:$PATH
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-venv python3-dev build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && python3 -m venv "$VIRTUAL_ENV"
+
+WORKDIR /usr/src/claude-code-karma
+
+### ------------------ Dependencies ------------------ ###
+COPY ./api/requirements.txt ./api/requirements.txt
+RUN pip install --no-cache-dir -r api/requirements.txt
+
+COPY ./frontend/package.json ./frontend/package-lock.json ./frontend/
+RUN cd frontend && npm ci
+
+### --------------------- Sources -------------------- ###
+COPY . .
+
+RUN pip install --no-cache-dir -e "./api[dev]"
+
+RUN mkdir -p /home/node/.claude /home/node/.claude_karma \
+    && chown -R node:node /usr/src/claude-code-karma /opt/venv /home/node
+
+USER node
+
+EXPOSE 8020/tcp 5180/tcp
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8020", "--app-dir", "api"]

--- a/README.md
+++ b/README.md
@@ -262,18 +262,35 @@ Open **http://localhost:5180** to view the dashboard.
 
 ## Run with Docker Compose
 
-Prefer containers over two terminals? This fork ships a `Dockerfile` and a `docker-compose.yaml`:
+Prefer containers over two terminals? This fork publishes a ready image to GHCR, so nothing has to be built locally:
+
+```bash
+curl -O https://raw.githubusercontent.com/reduxvzr/claude-code-karma-docker-compose/main/docker-compose.yml
+docker compose up -d
+```
+
+Open **http://localhost:5180**; the API stays on **8020**.
+
+The image is `ghcr.io/reduxvzr/claude-code-karma-docker-compose:latest`, rebuilt by [build-docker.yml](.github/workflows/build-docker.yml) on every push to `main`. Update with:
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+Both processes share a single container on purpose: SvelteKit renders pages server-side and calls the API over `localhost`, so they need the same network namespace.
+
+### Build from source instead
+
+To run your own changes rather than the published image:
 
 ```bash
 git clone https://github.com/reduxvzr/claude-code-karma-docker-compose.git
 cd claude-code-karma-docker-compose
 
-docker compose up -d --build
+docker compose -f docker-compose.build.yml up -d --build
 ```
 
-Open **http://localhost:5180**; the API stays on **8020**.
-
-Both processes share a single container on purpose: SvelteKit renders pages server-side and calls the API over `localhost`, so they need the same network namespace.
+Same container layout, same volumes and variables — it just builds from the local `Dockerfile` and tags the result `claude-code-karma:local`.
 
 ### What gets mounted
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,52 @@ Open **http://localhost:5180** to view the dashboard.
 
 **This only gets you the historical dashboard.** Karma's core feature — live session tracking as sessions actually run — needs one more step, [Tier 2 in SETUP.md](./SETUP.md#tier-2-live-monitoring-core-feature). Install through Tier 2 by default; the rest of SETUP.md's tiers are optional polish on top.
 
+## Run with Docker Compose
+
+Prefer containers over two terminals? This fork ships a `Dockerfile` and a `docker-compose.yaml`:
+
+```bash
+git clone https://github.com/reduxvzr/claude-code-karma-docker-compose.git
+cd claude-code-karma-docker-compose
+
+docker compose up -d --build
+```
+
+Open **http://localhost:5180**; the API stays on **8020**.
+
+Both processes share a single container on purpose: SvelteKit renders pages server-side and calls the API over `localhost`, so they need the same network namespace.
+
+### What gets mounted
+
+| Host path | In container | Mode |
+| --- | --- | --- |
+| `~/.claude` | `/home/node/.claude` | read-only — Karma only reads session JSONL |
+| `~/.claude_karma` | `/home/node/.claude_karma` | read-write — SQLite index, title cache, live sessions |
+
+`~/.claude_karma` has to stay writable: mounted read-only the API still starts, but indexing fails with `unable to open database file`.
+
+Live session tracking keeps working — the hooks run on the host and write into `~/.claude_karma/live-sessions`, which the container reads through that same mount. Install them as described in [Tier 2 of SETUP.md](./SETUP.md#tier-2-live-monitoring-core-feature).
+
+### Environment variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `KARMA_ALLOWED_HOSTS` | empty | Comma-separated domains Karma is served under behind a reverse proxy. Vite answers `403` to unknown `Host` headers; `localhost` and bare IPs are always allowed |
+| `CLAUDE_DIR` | `$HOME/.claude` | Claude Code's data directory. Set the real path if `~/.claude` is a symlink |
+| `KARMA_DIR` | `$HOME/.claude_karma` | Karma's own data directory |
+| `KARMA_API_TARGET` | `http://localhost:8020` | Where the browser-facing `/backend` proxy forwards |
+| `TZ` | `Europe/Moscow` | Container timezone |
+
+### Behind a reverse proxy
+
+```bash
+KARMA_ALLOWED_HOSTS=karma.example docker compose up -d
+```
+
+Point the proxy at port `5180` and let it forward the original `Host` header. In the browser Karma calls the API through `/backend` on the same origin, so there is no CORS to configure and no second vhost for port 8020.
+
+Changing the domain only needs a restart — `vite.config.ts` reads the variable at startup, so no rebuild is required.
+
 ## Desktop App (macOS & Windows)
 
 Two terminals every time gets old. Install a desktop icon that starts both servers for you and opens the dashboard:

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,21 @@
+services:
+  claude-code-karma:
+    container_name: claude-code-karma
+    hostname: karma
+    image: claude-code-karma:local
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    restart: unless-stopped
+    environment:
+      TZ: "${TZ:-Europe/Moscow}"
+      # Domains Karma is served under from behind a reverse proxy. Comma-separated.
+      KARMA_ALLOWED_HOSTS: "${KARMA_ALLOWED_HOSTS:-}"
+    ports:
+      - "8020:8020"
+      - "5180:5180"
+    volumes:
+      # Claude Code Files. Karma reads these files.
+      - "${CLAUDE_DIR:-$HOME/.claude}:/home/node/.claude:ro"
+      # Karma files. Must stay writable: metadata.db, cache/titles/, live-sessions/
+      - "${KARMA_DIR:-$HOME/.claude_karma}:/home/node/.claude_karma"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
-  api:
-    container_name: claude-code-karma-api
-    hostname: karma-api
+  claude-code-karma:
+    container_name: claude-code-karma
+    hostname: karma
     image: claude-code-karma:local
     build:
       context: .
@@ -9,25 +9,15 @@ services:
     restart: unless-stopped
     environment:
       TZ: "${TZ:-Europe/Moscow}"
+      # Domains Karma is served under from behind a reverse proxy. Comma-separated.
+      # Without this Vite answers 403 to any Host it doesn't know.
+      # Example: KARMA_ALLOWED_HOSTS=karma.example docker compose up -d
+      KARMA_ALLOWED_HOSTS: "${KARMA_ALLOWED_HOSTS:-}"
     ports:
       - "8020:8020"
+      - "5180:5180"
     volumes:
       # Claude Code Files. Karma reads these files.
       - "${CLAUDE_DIR:-$HOME/.claude}:/home/node/.claude:ro"
-      # Karma files
+      # Karma files. Must stay writable: metadata.db, cache/titles/, live-sessions/
       - "${KARMA_DIR:-$HOME/.claude_karma}:/home/node/.claude_karma"
-  frontend:
-    container_name: claude-code-karma-frontend
-    hostname: karma-frontend
-    image: claude-code-karma:local
-    build:
-      context: .
-      dockerfile: ./Dockerfile
-    restart: unless-stopped
-    environment:
-      TZ: "${TZ:-Europe/Moscow}"
-    command: ["npm", "--prefix", "frontend", "run", "dev", "--", "--host", "0.0.0.0"]
-    ports:
-      - "5180:5180"
-    depends_on:
-      - api

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,33 @@
+services:
+  api:
+    container_name: claude-code-karma-api
+    hostname: karma-api
+    image: claude-code-karma:local
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    restart: unless-stopped
+    environment:
+      TZ: "${TZ:-Europe/Moscow}"
+    ports:
+      - "8020:8020"
+    volumes:
+      # Claude Code Files. Karma reads these files.
+      - "${CLAUDE_DIR:-$HOME/.claude}:/home/node/.claude:ro"
+      # Karma files
+      - "${KARMA_DIR:-$HOME/.claude_karma}:/home/node/.claude_karma"
+  frontend:
+    container_name: claude-code-karma-frontend
+    hostname: karma-frontend
+    image: claude-code-karma:local
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    restart: unless-stopped
+    environment:
+      TZ: "${TZ:-Europe/Moscow}"
+    command: ["npm", "--prefix", "frontend", "run", "dev", "--", "--host", "0.0.0.0"]
+    ports:
+      - "5180:5180"
+    depends_on:
+      - api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,11 @@ services:
   claude-code-karma:
     container_name: claude-code-karma
     hostname: karma
-    image: claude-code-karma:local
-    build:
-      context: .
-      dockerfile: ./Dockerfile
+    image: ghcr.io/reduxvzr/claude-code-karma-docker-compose:latest
     restart: unless-stopped
     environment:
       TZ: "${TZ:-Europe/Moscow}"
       # Domains Karma is served under from behind a reverse proxy. Comma-separated.
-      # Without this Vite answers 403 to any Host it doesn't know.
-      # Example: KARMA_ALLOWED_HOSTS=karma.example docker compose up -d
       KARMA_ALLOWED_HOSTS: "${KARMA_ALLOWED_HOSTS:-}"
     ports:
       - "8020:8020"

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -59,6 +59,10 @@ const browserGlobals = {
 	DOMParser: 'readonly'
 };
 
+const nodeGlobals = {
+	process: 'readonly'
+};
+
 /** Svelte 5 runes — needed in .svelte and .svelte.ts files */
 const svelteRuneGlobals = {
 	$state: 'readonly',
@@ -96,6 +100,13 @@ export default [
 				}
 			],
 			'no-unused-vars': 'off'
+		}
+	},
+	{
+		// Vite config is executed by Node, so it may reach for process.env
+		files: ['vite.config.ts'],
+		languageOptions: {
+			globals: { ...browserGlobals, ...nodeGlobals }
 		}
 	},
 	{

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
 				"@tailwindcss/vite": "^4.1.18",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/svelte": "^5.3.1",
+				"@types/node": "^26.2.0",
 				"@typescript-eslint/eslint-plugin": "^8.52.0",
 				"@typescript-eslint/parser": "^8.52.0",
 				"eslint": "^9.39.2",
@@ -1861,6 +1862,66 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.7.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.1.0",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.7.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+			"version": "1.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1",
+				"@tybys/wasm-util": "^0.10.1"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+			"version": "0.10.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+			"version": "2.8.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "0BSD",
+			"optional": true
+		},
 		"node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
 			"version": "4.1.18",
 			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
@@ -2067,6 +2128,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "*"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "26.2.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+			"integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~8.3.0"
 			}
 		},
 		"node_modules/@types/resolve": {
@@ -5404,7 +5475,8 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD"
+			"license": "0BSD",
+			"peer": true
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -5441,6 +5513,13 @@
 			"engines": {
 				"node": ">=20.18.1"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+			"devOptional": true,
+			"license": "MIT"
 		},
 		"node_modules/unist-util-is": {
 			"version": "6.0.1",
@@ -5827,23 +5906,6 @@
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"license": "MIT"
-		},
-		"node_modules/yaml": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
-			}
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
 		"@tailwindcss/vite": "^4.1.18",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/svelte": "^5.3.1",
+		"@types/node": "^26.2.0",
 		"@typescript-eslint/eslint-plugin": "^8.52.0",
 		"@typescript-eslint/parser": "^8.52.0",
 		"eslint": "^9.39.2",

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -3,7 +3,8 @@
  *
  * API Base URL:
  * - Uses PUBLIC_API_URL environment variable if set
- * - Falls back to http://localhost:8020 for local development
+ * - In the browser, falls back to /backend, which Vite proxies to the API
+ * - During SSR, falls back to http://localhost:8020
  *
  * To configure in production:
  * - Set PUBLIC_API_URL in your .env file
@@ -18,7 +19,14 @@
  * const response = await fetch(`${API_BASE}/projects`);
  * ```
  */
-export const API_BASE = import.meta.env.PUBLIC_API_URL || 'http://localhost:8020';
+export const API_BASE =
+	typeof window === 'undefined'
+		? // SSR runs next to the API inside the container.
+			'http://localhost:8020'
+		: // The browser must not hardcode localhost: served under a domain that
+			// address points at the visitor's own machine, and the API would reject
+			// the cross-origin request anyway. /backend is proxied by Vite.
+			import.meta.env.PUBLIC_API_URL || '/backend';
 
 /**
  * API request timeout in milliseconds (default: 30 seconds)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,17 @@ import { defineConfig } from 'vitest/config';
 import tailwindcss from '@tailwindcss/vite';
 import { svelteTesting } from '@testing-library/svelte/vite';
 
+// Domains Karma is reachable under from behind a reverse proxy, comma-separated:
+//   KARMA_ALLOWED_HOSTS=karma.example,karma.lan
+// Empty leaves Vite's default, which still allows localhost and bare IPs.
+const allowedHosts = (process.env.KARMA_ALLOWED_HOSTS ?? '')
+	.split(',')
+	.map((host) => host.trim())
+	.filter(Boolean);
+
+// Where the browser-facing proxy forwards to. The API runs in the same container.
+const apiTarget = process.env.KARMA_API_TARGET || 'http://localhost:8020';
+
 export default defineConfig({
 	plugins: [sveltekit(), tailwindcss(), svelteTesting()],
 	server: {
@@ -10,7 +21,20 @@ export default defineConfig({
 		// silently moving to 5181+, which would leave the desktop launcher, the
 		// API's CORS allowlist and the installed PWA all pointing at nothing.
 		port: 5180,
-		strictPort: true
+		strictPort: true,
+		// Vite rejects requests whose Host header it doesn't know, so a reverse
+		// proxy forwarding Host: $host would otherwise get a 403.
+		allowedHosts,
+		// Browser-side API calls go through the same origin as the page, so they
+		// keep working over HTTPS and from machines other than the Karma host.
+		// /api is already a SvelteKit route, hence /backend.
+		proxy: {
+			'/backend': {
+				target: apiTarget,
+				changeOrigin: true,
+				rewrite: (path) => path.replace(/^\/backend/, '')
+			}
+		}
 	},
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}'],


### PR DESCRIPTION
## Summary

  Adds a containerized way to run Karma: a single-container image published to GHCR, two compose files (published image / build from source), and the small frontend changes needed to make Karma work behind a reverse proxy.

  Running Karma today means two terminals and a Python + Node toolchain on the host. This PR makes `docker compose up -d` enough, and fixes the two things that break as soon as Karma is served under a domain rather than `localhost`.

  ## Changes

  - **`Dockerfile`** — single container on `node:26-trixie` with Python in a venv. Both processes run together on purpose: SvelteKit renders server-side and calls the API over `localhost:8020`, so they need the same network namespace.
  - **`docker-compose.yml`** — runs the published image, no local build required.
  - **`docker-compose.build.yml`** — same layout, builds from source for development.
  - **`.github/workflows/build-docker.yml`** — builds and pushes to GHCR on every push to `main`, with GHA layer caching. Image name comes from `${{ github.repository }}`, so it follows whichever repo it runs in. PRs build without publishing, since a fork's token cannot write packages.
  - **`.dockerignore`** — keeps `node_modules`, `.svelte-kit`, `__pycache__` and friends out of the build context.
  - **`frontend/vite.config.ts`** — `server.allowedHosts` is read from `KARMA_ALLOWED_HOSTS` (comma-separated), and `/backend` is proxied to the API. Vite answers `403` to any `Host` it doesn't know, so without the first one a reverse proxy gets a blank page.
  - **`frontend/src/lib/config.ts`** — `API_BASE` now differs per environment: `http://localhost:8020` during SSR, `/backend` in the browser. Served under a domain, a hardcoded `localhost:8020` points at the visitor's own machine, and even on the Karma host itself the API rejects the cross-origin request (`CORS
  Missing Allow Origin`). `PUBLIC_API_URL` still overrides both.
  - **`frontend/eslint.config.js`** — Node globals for `vite.config.ts`, which now reads `process.env`.
  - **`frontend/package.json`** — added `@types/node` (dev), needed to type `process` in the Vite config.
  - **`README.md`** — new "Run with Docker Compose" section: quick start, what gets mounted, environment variables, and reverse-proxy notes.

  Volumes are deliberately asymmetric: `~/.claude` is mounted read-only (Karma only reads session JSONL), `~/.claude_karma` read-write. Mounted read-only the API still starts, but indexing fails with `unable to open database file`.

  Live session tracking keeps working — hooks run on the host and write into `~/.claude_karma/live-sessions`, which the container reads through the same mount.

  **One thing to adjust on merge:** `docker-compose.yml` pins `ghcr.io/reduxvzr/claude-code-karma-docker-compose:latest` — the image my fork publishes. In this repo it should read `ghcr.io/jayantdevkar/claude-code-karma:latest`. The workflow itself needs no edit: it derives the name from `${{ github.repository }}` and
  `metadata-action` lowercases it, so the first push to `main` here publishes under the right name. Same for the `curl` URL in the README. Until that first run, `docker-compose.build.yml` builds locally and works regardless.

  ## Component

  - [ ] API (FastAPI backend)
  - [x] Frontend (SvelteKit dashboard)
  - [ ] Captain Hook (hook models)
  - [ ] Hook Scripts
  - [x] Documentation
  - [x] CI / Build

  ## Type

  - [x] Feature (new functionality)
  - [ ] Bug fix
  - [ ] Refactor (no behavior change)
  - [ ] Performance improvement
  - [ ] Documentation
  - [ ] Tests

  ## Testing

  - [x] API tests pass (`cd api && pytest`) — 1804 passed, 8 skipped
  - [x] Frontend type-checks (`cd frontend && npm run check`) — 0 errors
  - [x] Frontend lints clean (`cd frontend && npm run lint`) — 0 errors
  - [x] Captain Hook tests pass (`cd captain-hook && pytest tests/test_models.py`) — 238 passed
  - [x] Manually tested in browser
  - [ ] N/A (docs only)

  All suites were run inside the built container, plus `npm test` (268 passed) and `npm run build`. Verified in a browser both at `http://localhost:5180` and behind an nginx vhost on another host over HTTPS.

  Two notes from running the suites in a container:

  - `tests/api/test_background_shells_router.py::TestListShellsGlobal::test_empty_db_returns_empty_list` fails when `~/.claude_karma` is mounted, because it asserts an empty DB and finds the real `metadata.db`. Environment artifact, not a code change — it passes on a clean filesystem.
  - `pytest` can't even collect without `httpx` (`starlette.testclient` requires it), and it's listed neither in `requirements.txt` nor in the `dev` extra. Unrelated to this PR, but worth adding to `[project.optional-dependencies]`.

  ## Screenshots

  No visual changes — all frontend edits are configuration.

  ## Related Issues

  <!-- -->